### PR TITLE
Use R1 as return register

### DIFF
--- a/llvm/lib/Target/SyncVM/SyncVMCallingConv.td
+++ b/llvm/lib/Target/SyncVM/SyncVMCallingConv.td
@@ -9,7 +9,23 @@
 //===----------------------------------------------------------------------===//
 // SyncVM Return Value Calling Convention
 //===----------------------------------------------------------------------===//
+def RetCC_SYNCVM : CallingConv<[
+  CCIfType<[i1, i8, i16, i32, i64, i128], CCPromoteToType<i256>>,
+
+  // return values are stored inside R1
+  CCAssignToReg<[R1]>,
+
+  // if, there are any other returned value (in the future), store on stack
+  CCAssignToStack<32, 1>,
+]>;
+
+//===----------------------------------------------------------------------===//
+// SyncVM Argument Calling Conventions
+//===----------------------------------------------------------------------===//
 def CC_SYNCVM : CallingConv<[
+  // promote all integer types to i256
+  CCIfType<[i8, i16, i32, i64, i128], CCPromoteToType<i256>>,
+
   CCAssignToReg<[R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15]>,
-  CCAssignToStack<32, 32>
+  CCAssignToStack<32, 1>,
 ]>;

--- a/llvm/lib/Target/SyncVM/SyncVMISelLowering.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMISelLowering.cpp
@@ -105,9 +105,17 @@ static bool CallingConvSupported(CallingConv::ID CallConv) {
 }
 
 bool SyncVMTargetLowering::CanLowerReturn(
-    CallingConv::ID /*CallConv*/, MachineFunction & /*MF*/, bool /*IsVarArg*/,
+    CallingConv::ID CallConv, MachineFunction & MF, bool IsVarArg,
     const SmallVectorImpl<ISD::OutputArg> &Outs,
-    LLVMContext & /*Context*/) const {
+    LLVMContext & Context) const {
+
+  SmallVector<CCValAssign, 1> RVLocs;
+  CCState CCInfo(CallConv, IsVarArg, MF, RVLocs, Context);
+
+  // cannot support return convention or is variadic?
+  if (!CCInfo.CheckReturn(Outs, RetCC_SYNCVM) || IsVarArg)
+    return false;
+  
   // SyncVM can't currently handle returning tuples.
   return Outs.size() <= 1;
 }

--- a/llvm/lib/Target/SyncVM/SyncVMInstrInfo.td
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrInfo.td
@@ -614,6 +614,12 @@ let isReturn = 1, isTerminator = 1, isBarrier = 1  in
 def RET   : IRet<7, RFNone, "ret", [(SyncVMret)]>;
 let isTerminator = 1, isBarrier = 1, isTrap = 1 in
 def THROW : IRet<7, RFErr, "ret.err", [(int_syncvm_throw)]>;
+
+let Defs = [R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15],
+    Uses = [SP], isCall = 1 in {
+  def CALL : Pseudo<(outs), (ins i16imm:$callee),
+                  "call\t$callee", [(SyncVMcall tglobaladdr:$callee)]>;
+}
               /*
 def JCC: IJump<10, (outs), (ins jmptarget:$addrtrue, jmptarget:$addrfalse, GR256:$cond),
                "j$cond\t$dst_true, $dst_false",

--- a/llvm/lib/Target/SyncVM/SyncVMRegisterInfo.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMRegisterInfo.cpp
@@ -37,9 +37,6 @@ BitVector SyncVMRegisterInfo::getReservedRegs(const MachineFunction &MF) const {
   Reserved.set(SyncVM::SP);
   Reserved.set(SyncVM::Flags);
   Reserved.set(SyncVM::R0);
-  // FIXME: When a call result is move to a successor, CodeGen needs to count R1
-  // as live.
-  Reserved.set(SyncVM::R1);
   return Reserved;
 }
 

--- a/llvm/test/CodeGen/SyncVM/arithmetic.ll
+++ b/llvm/test/CodeGen/SyncVM/arithmetic.ll
@@ -48,8 +48,8 @@ define i256 @uremi256(i256 %par, i256 %p2) nounwind {
 ; CHECK-LABEL: udivremi256
 ; TODO: optimize to use a single div instruction
 define i256 @udivremi256(i256 %par, i256 %p2) nounwind {
-; CHECK: div r1, r2, r2, r3
-; CHECK: add r2, r3, r1
+; CHECK: div r1, r2, r1, r2
+; CHECK: add r1, r2, r1
   %1 = udiv i256 %par, %p2
   %2 = urem i256 %par, %p2
   %3 = add i256 %1, %2

--- a/llvm/test/CodeGen/SyncVM/bitwise.ll
+++ b/llvm/test/CodeGen/SyncVM/bitwise.ll
@@ -51,7 +51,7 @@ define i256 @or2(i256 %a, i256 %b) {
 define i256 @select_and(i1 %x, i1 %y, i256 %v) nounwind {
 ; TODO: For some reason `and` unrolls in additional control flow,
 ; which probably needs to be fixed
-; CHECK: sub r2, r0, r0
+; CHECK: sub r1, r0, r0
   %1 = and i1 %x, %y
   %2 = select i1 %1, i256 %v, i256 42
   ret i256 %2
@@ -61,7 +61,7 @@ define i256 @select_and(i1 %x, i1 %y, i256 %v) nounwind {
 define i256 @select_or(i1 %x, i1 %y, i256 %v) nounwind {
 ; TODO: For some reason `or` unrolls in additional control flow,
 ; which probably needs to be fixed
-; CHECK: sub r2, r0, r0
+; CHECK: sub r1, r0, r0
   %1 = or i1 %x, %y
   %2 = select i1 %1, i256 %v, i256 42
   ret i256 %2
@@ -69,8 +69,8 @@ define i256 @select_or(i1 %x, i1 %y, i256 %v) nounwind {
 
 ; CHECK-LABEL: select_xor
 define i256 @select_xor(i1 %x, i1 %y, i256 %v) nounwind {
-; CHECK: xor r1, r2, r2
-; CHECK: sub r2, r0, r0
+; CHECK: xor r1, r2, r1
+; CHECK: sub r1, r0, r0
   %1 = xor i1 %x, %y
   %2 = select i1 %1, i256 %v, i256 42
   ret i256 %2

--- a/llvm/test/CodeGen/SyncVM/brcc.ll
+++ b/llvm/test/CodeGen/SyncVM/brcc.ll
@@ -98,7 +98,7 @@ loop.exit:
 define i256 @cmpir(i256 %p1, i256 %p2) nounwind {
 ; TODO: CPR-447 should be subx 42, r1, r{{[0-9]}}
 ; CHECK: add 42, 0, r2
-; CHECK: sub r1, r2, r2
+; CHECK: sub r1, r2, r1
   %1 = icmp ugt i256 %p1, 42
   br i1 %1, label %l1, label %l2
 l1:
@@ -111,7 +111,7 @@ l2:
 define i256 @cmpcr(i256 %p1, i256 %p2) nounwind {
 ; TODO: CPR-447 should be subx code[val], r1, r{{[0-9]}}
 ; CHECK: add code[val], 0, r2
-; CHECK: sub r1, r2, r2
+; CHECK: sub r1, r2, r1
   %const = load i256, i256 addrspace(4)* @val
   %1 = icmp ugt i256 %p1, %const
   br i1 %1, label %l1, label %l2
@@ -126,7 +126,7 @@ define i256 @cmpsr(i256 %p1, i256 %p2) nounwind {
   %ptr = alloca i256
 ; TODO: CPR-447 should be subx stack-[1], r1, r{{[0-9]}}
 ; CHECK: add stack-[1], 0, r2
-; CHECK: sub r1, r2, r2
+; CHECK: sub r1, r2, r1
   %data = load i256, i256* %ptr
   %1 = icmp ugt i256 %p1, %data
   br i1 %1, label %l1, label %l2
@@ -140,7 +140,7 @@ l2:
 define i256 @cmpri(i256 %p1, i256 %p2) nounwind {
 ; TODO: CPR-447 should be sub 42, r1, r{{[0-9]}}
 ; CHECK: add 42, 0, r2
-; CHECK: sub r2, r1, r2
+; CHECK: sub r2, r1, r1
   %1 = icmp ugt i256 42, %p1
   br i1 %1, label %l1, label %l2
 l1:
@@ -153,7 +153,7 @@ l2:
 define i256 @cmprc(i256 %p1, i256 %p2) nounwind {
 ; TODO: CPR-447 should be sub code[val], r1, r{{[0-9]}}
 ; CHECK: add code[val], 0, r2
-; CHECK: sub r2, r1, r2
+; CHECK: sub r2, r1, r1
   %const = load i256, i256 addrspace(4)* @val
   %1 = icmp ugt i256 %const, %p1
   br i1 %1, label %l1, label %l2
@@ -168,7 +168,7 @@ define i256 @cmprs(i256 %p1, i256 %p2) nounwind {
   %ptr = alloca i256
 ; TODO: CPR-447 should be sub stack-[1], r1, r{{[0-9]}}
 ; CHECK: add stack-[1], 0, r2
-; CHECK: sub r2, r1, r2
+; CHECK: sub r2, r1, r1
   %data = load i256, i256* %ptr
   %1 = icmp ugt i256 %data, %p1
   br i1 %1, label %l1, label %l2

--- a/llvm/test/CodeGen/SyncVM/brcond.ll
+++ b/llvm/test/CodeGen/SyncVM/brcond.ll
@@ -7,9 +7,9 @@ target triple = "syncvm"
 
 ; CHECK-LABEL: brcond:
 define i256 @brcond(i256 %p1) nounwind {
-; CHECK: and 1, r1, r2
-; CHECK: add 1, 0, r3
-; CHECK: sub r2, r3, r2
+; CHECK: and 1, r1, r1
+; CHECK: add 1, 0, r2
+; CHECK: sub r1, r2, r1
 ; CHECK: jump.eq r0, .LBB0_1, .LBB0_2
   %1 = trunc i256 %p1 to i1
   br i1 %1, label %l1, label %l2

--- a/llvm/test/CodeGen/SyncVM/calling-convensions.ll
+++ b/llvm/test/CodeGen/SyncVM/calling-convensions.ll
@@ -50,7 +50,7 @@ define i256 @caller_argtypes(i1 %a1, i8 %a2, i16 %a3, i32 %a4, i64 %a5, i128 %a6
 define i256 @caller_i1.ret(i256 %a1) nounwind {
 ; CHECK: call	i1.ret
   %1 = call i1 @i1.ret(i256 %a1)
-; CHECK: and #1, r1, r1
+; CHECK: and 1, r1, r1
   %2 = zext i1 %1 to i256
   ret i256 %2
 }
@@ -59,7 +59,7 @@ define i256 @caller_i1.ret(i256 %a1) nounwind {
 define i256 @caller_i8.ret(i256 %a1) nounwind {
 ; CHECK: call	i8.ret
   %1 = call i8 @i8.ret(i256 %a1)
-; CHECK: and #255, r1, r1
+; CHECK: and 255, r1, r1
   %2 = zext i8 %1 to i256
   ret i256 %2
 }
@@ -68,7 +68,7 @@ define i256 @caller_i8.ret(i256 %a1) nounwind {
 define i256 @caller_i16.ret(i256 %a1) nounwind {
 ; CHECK: call	i16.ret
   %1 = call i16 @i16.ret(i256 %a1)
-; CHECK: and #65535, r1, r1
+; CHECK: and 65535, r1, r1
   %2 = zext i16 %1 to i256
   ret i256 %2
 }
@@ -77,7 +77,7 @@ define i256 @caller_i16.ret(i256 %a1) nounwind {
 define i256 @caller_i32.ret(i256 %a1) nounwind {
 ; CHECK: call	i32.ret
   %1 = call i32 @i32.ret(i256 %a1)
-; CHECK: and #4294967295, r1, r1
+; CHECK: and code[CPI{{[0-9]+}}_{{[0-9]+}}], r1, r1
   %2 = zext i32 %1 to i256
   ret i256 %2
 }
@@ -86,7 +86,7 @@ define i256 @caller_i32.ret(i256 %a1) nounwind {
 define i256 @caller_i64.ret(i256 %a1) nounwind {
 ; CHECK: call	i64.ret
   %1 = call i64 @i64.ret(i256 %a1)
-; CHECK: and #18446744073709551615, r1, r1
+; CHECK: and code[CPI{{[0-9]+}}_{{[0-9]+}}], r1, r1
   %2 = zext i64 %1 to i256
   ret i256 %2
 }
@@ -95,30 +95,29 @@ define i256 @caller_i64.ret(i256 %a1) nounwind {
 define i256 @caller_i128.ret(i256 %a1) nounwind {
 ; CHECK: call	i128.ret
   %1 = call i128 @i128.ret(i256 %a1)
-; CHECK: and #340282366920938463463374607431768211455, r1, r1
+; CHECK: and code[CPI{{[0-9]+}}_{{[0-9]+}}], r1, r1
   %2 = zext i128 %1 to i256
   ret i256 %2
 }
 
 ; CHECK-LABEL: call.onestack
 define i256 @call.onestack() nounwind {
-; CHECK: sfll #0, r2, r2
-; CHECK: sflh #0, r2, r2
-; CHECK: push #0, r2
-; CHECK: add r2, r0, r1
-; CHECK: add r2, r0, r3
-; CHECK: add r2, r0, r4
-; CHECK: add r2, r0, r5
-; CHECK: add r2, r0, r6
-; CHECK: add r2, r0, r7
-; CHECK: add r2, r0, r8
-; CHECK: add r2, r0, r9
-; CHECK: add r2, r0, r10
-; CHECK: add r2, r0, r11
-; CHECK: add r2, r0, r12
-; CHECK: add r2, r0, r13
-; CHECK: add r2, r0, r14
-; CHECK: add r2, r0, r15
+; CHECK: add 0, 0, r1
+; CHECK: push #0, r1
+; CHECK: add r1, r0, r2
+; CHECK: add r1, r0, r3
+; CHECK: add r1, r0, r4
+; CHECK: add r1, r0, r5
+; CHECK: add r1, r0, r6
+; CHECK: add r1, r0, r7
+; CHECK: add r1, r0, r8
+; CHECK: add r1, r0, r9
+; CHECK: add r1, r0, r10
+; CHECK: add r1, r0, r11
+; CHECK: add r1, r0, r12
+; CHECK: add r1, r0, r13
+; CHECK: add r1, r0, r14
+; CHECK: add r1, r0, r15
 ; CHECK: call onestack
 ; CHECK: pop #0, r0
   %1 = call i256 @onestack(i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0)
@@ -127,28 +126,25 @@ define i256 @call.onestack() nounwind {
 
 ; CHECK-LABEL: call.twostack
 define i256 @call.twostack() nounwind {
-; CHECK: sfll #2, r2, r2
-; CHECK: sflh #0, r2, r2
-; CHECK: push #0, r2
-; CHECK: sfll #1, r2, r2
-; CHECK: sflh #0, r2, r2
-; CHECK: push #0, r2
-; CHECK: sfll #0, r2, r2
-; CHECK: sflh #0, r2, r2
-; CHECK: add r2, r0, r1
-; CHECK: add r2, r0, r3
-; CHECK: add r2, r0, r4
-; CHECK: add r2, r0, r5
-; CHECK: add r2, r0, r6
-; CHECK: add r2, r0, r7
-; CHECK: add r2, r0, r8
-; CHECK: add r2, r0, r9
-; CHECK: add r2, r0, r10
-; CHECK: add r2, r0, r11
-; CHECK: add r2, r0, r12
-; CHECK: add r2, r0, r13
-; CHECK: add r2, r0, r14
-; CHECK: add r2, r0, r15
+; CHECK: add 2, 0, r1
+; CHECK: push #0, r1
+; CHECK: add 1, 0, r1
+; CHECK: push #0, r1
+; CHECK: add 0, 0, r1
+; CHECK: add r1, r0, r2
+; CHECK: add r1, r0, r3
+; CHECK: add r1, r0, r4
+; CHECK: add r1, r0, r5
+; CHECK: add r1, r0, r6
+; CHECK: add r1, r0, r7
+; CHECK: add r1, r0, r8
+; CHECK: add r1, r0, r9
+; CHECK: add r1, r0, r10
+; CHECK: add r1, r0, r11
+; CHECK: add r1, r0, r12
+; CHECK: add r1, r0, r13
+; CHECK: add r1, r0, r14
+; CHECK: add r1, r0, r15
 ; CHECK: call twostack
 ; CHECK: pop #1, r0
   %1 = call i256 @twostack(i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 1, i256 2)
@@ -171,11 +167,9 @@ define i256 @sum17(i256 %a1, i256 %a2, i256 %a3, i256 %a4, i256 %a5, i256 %a6, i
   %12 = add i256 %11, %a13
   %13 = add i256 %12, %a14
   %14 = add i256 %13, %a15
-; CHECK: mov 1(sp), r3
-; CHECK: add r2, r3, r2
+; CHECK: add stack-[1], r1, r1
   %15 = add i256 %14, %a16
-; CHECK: mov 2(sp), r3
-; CHECK: add r2, r3, r1
+; CHECK: add stack-[2], r1, r1
   %16 = add i256 %15, %a17
   ret i256 %16
 }

--- a/llvm/test/CodeGen/SyncVM/constant-materialization.ll
+++ b/llvm/test/CodeGen/SyncVM/constant-materialization.ll
@@ -5,15 +5,14 @@ target triple = "syncvm"
 
 ; CHECK-LABEL: small_constant
 define i256 @small_constant(i256 %a) nounwind {
-; CHECK: add #42, r1, r1
+; CHECK: add 42, r1, r1
   %1 = add i256 %a, 42
   ret i256 %1
 }
 
 ; CHECK-LABEL: big_constant
 define i256 @big_constant(i256 %a) nounwind {
-; CHECK: sfll #340282366920938463463374607431768211455, r2, r2
-; CHECK: sflh #340282366920938463463374607431768211455, r2, r2
+; CHECK: add code[CPI1_0], r1, r1
   %1 = add i256 -1, %a
   ret i256 %1
 }

--- a/llvm/test/CodeGen/SyncVM/diamond.ll
+++ b/llvm/test/CodeGen/SyncVM/diamond.ll
@@ -6,13 +6,14 @@ target triple = "syncvm"
 ; CHECK-LABEL: diamond
 define i256 @diamond(i256 %p1, i256 %p2, i256 %x, i256 %y) nounwind {
   %1 = icmp ugt i256 %p1, %p2
+; CHECK: jump.gt r0, .LBB0_1, .LBB0_2
   br i1 %1, label %l1, label %l2
 l1:
   %2 = add i256 %p1, %x
   br label %exit
 l2:
   %3 = add i256 %p2, %y
-; CHECK: j .LBB0_3, .LBB0_3
+; CHECK: jump r0, .LBB0_3, .LBB0_3
   br label %exit
 exit:
   %4 = phi i256 [ %2, %l1  ], [ %3, %l2 ]


### PR DESCRIPTION
This is part of the effort to revamp calling convention in isa-1.1

* remove R1 as reserved register at the beginning
* make R1 as return register. (Currently does not support returning more than 1 values from function.)
* rebased to isa-1.1
* fixed some llvm-lit cases
