### PR TITLE
Printing constants in consecutive space

### DIFF
--- a/llvm/test/CodeGen/SyncVM/immediate.ll
+++ b/llvm/test/CodeGen/SyncVM/immediate.ll
@@ -3,6 +3,8 @@
 target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
 target triple = "syncvm"
 
+; CHECK-LABEL: .text
+
 ; CHECK-LABEL: materialize_small_imm
 define i256 @materialize_small_imm() nounwind {
   ; CHECK: add 65535, r0, r1
@@ -69,3 +71,39 @@ define i256 @materialize_bigimm_in_sub_operation_2(i256 %par) nounwind {
   %res = sub i256 -42, %par
   ret i256 %res
 }
+; The follow checks constant pool emitting
+
+; CHECK-LABEL: .rodata
+
+; materialize_big_imm
+; CHECK-LABEL: CPI1_0:
+; CHECK: .cell 65536
+
+; materialize_negative_imm
+; CHECK-LABEL: CPI2_0:
+; CHECK: .cell -1
+
+; materialize_bigimm_in_operation
+; CHECK-LABEL: CPI4_0:
+; CHECK: .cell -42
+
+; materialize_bigimm_in_operation_2
+; CHECK-LABEL: CPI5_0:
+; CHECK: .cell -42
+
+; materialize_bigimm_in_and_operation
+; CHECK-LABEL: CPI6_0:
+; CHECK: .cell -42
+
+; materialize_bigimm_in_xor_operation
+; CHECK-LABEL: CPI7_0:
+; CHECK: .cell -42
+
+; materialize_bigimm_in_sub_operation
+; CHECK-LABEL: CPI8_0:
+; CHECK: .cell -42
+
+; materialize_bigimm_in_sub_operation_2
+; CHECK-LABEL: CPI9_0:
+; CHECK: .cell -42
+


### PR DESCRIPTION
A bit hacky way to print assembly so that global constants are collected into a single section `.rodata` (at the end of file).