### PR TITLE
Fix returndata not saved in THROW issue

### DIFF
--- a/llvm/lib/Target/SyncVM/SyncVMExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMExpandPseudoInsts.cpp
@@ -37,6 +37,7 @@ public:
 private:
   void expandConst(MachineInstr &MI) const;
   void expandLoadConst(MachineInstr &MI) const;
+  void expandThrow(MachineInstr& MI) const;
   const TargetInstrInfo *TII;
   LLVMContext *Context;
 };
@@ -254,17 +255,30 @@ bool SyncVMExpandPseudo::runOnMachineFunction(MachineFunction &MF) {
             .add(MI.getOperand(1));
         PseudoInst.push_back(&MI);
       } else if (MI.getOpcode() == SyncVM::CALL) {
-        // One of the problem: the backend cannot restrict frontend to not emit
-        // calls (Should we reinforce it?) so this route is needed.
-        // If a call is generated, it is incomplete as it misses EH label info,
-        // pad 0 instead.
-        BuildMI(*MI.getParent(), &MI, MI.getDebugLoc(),
-                TII->get(SyncVM::NEAR_CALL))
-            .addReg(SyncVM::R0)
-            .add(MI.getOperand(0))
-            .addExternalSymbol(
-                "DEFAULT_UNWIND"); // Linker inserts a basic block
-                                   // which bubbles up the exception.
+        // Special handling of calling to __cxa_throw.
+        // If we are calling into the throw wrapper function, we jump into a 
+        // local frame with unwind path of `DEFAULT_UNWIND`, which will turn
+        // our prepared THROW into a PANIC. This will cause values in registers
+        // not propagated back to upper level, causing lost of returndata 
+        auto *func_opnd = MI.getOperand(0).getGlobal();
+        auto func_name = func_opnd->getName();
+        if (func_name == "__cxa_throw") {
+          BuildMI(*MI.getParent(), &MI, MI.getDebugLoc(),
+                TII->get(SyncVM::THROW));
+        } else {
+          // One of the problem: the backend cannot restrict frontend to not emit
+          // calls (Should we reinforce it?) so this route is needed.
+          // If a call is generated, it is incomplete as it misses EH label info,
+          // pad 0 instead.
+          BuildMI(*MI.getParent(), &MI, MI.getDebugLoc(),
+                  TII->get(SyncVM::NEAR_CALL))
+              .addReg(SyncVM::R0)
+              .add(MI.getOperand(0))
+              .addExternalSymbol(
+                  "DEFAULT_UNWIND"); // Linker inserts a basic block
+                                     // which bubbles up the exception.
+        }
+
         PseudoInst.push_back(&MI);
       }
     }


### PR DESCRIPTION
After wrapping the THROW into a wrapper call, we artifically adds
a new local frame with no unwind path, which will result in lost
of register values in case of exception.

The fix is to directly inline calls to the wrapper call. In this case
we just simply replace the call with THROW.