### PR TITLE
Fix clobbering non-reg operands

### DIFF
--- a/llvm/lib/Target/SyncVM/SyncVMExpandSelect.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMExpandSelect.cpp
@@ -145,7 +145,9 @@ bool SyncVMExpandSelect::runOnMachineFunction(MachineFunction &MF) {
           return BuildMI(MBB, &MI, DL, TII->get(CMovOpc));
         }();
         // early clobber the definition:
-        CMov->getOperand(0).setIsEarlyClobber(true);
+        if (NumDefs) {
+          CMov->getOperand(0).setIsEarlyClobber(true);
+        }
         // SEL src0 -> CMOV src0
         for (unsigned i = Src0ArgPos; i < Src1ArgPos; ++i)
           CMov.add(MI.getOperand(i));

--- a/llvm/test/CodeGen/SyncVM/ra_regress.ll
+++ b/llvm/test/CodeGen/SyncVM/ra_regress.ll
@@ -1,0 +1,33 @@
+; RUN: llc -O0 < %s | FileCheck %s
+
+; ModuleID = 'Test_65'
+source_filename = "Test_65"
+target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
+target triple = "syncvm"
+
+; CHECK-LABEL: test_length 
+define i256 @test_length(i256 %arg1) {
+entry:
+
+; CKECK: sub!    r4, r5, r4
+; CKECK: add     r1, r0, r1
+; CKECK: add.eq  r3, r0, r1
+  %comparison_result24 = icmp slt i256 35, %arg1
+  %comparison_result_extended25 = zext i1 %comparison_result24 to i256
+
+; CHECK: sub!    r1, r2, r1
+; CHECK: add     0, r0, r1
+; CHECK: add.ne  1, r0, r1
+; CHECK: and     1, r1, r1
+  %comparison_result26 = icmp eq i256 %comparison_result_extended25, 0
+  %comparison_result_extended27 = zext i1 %comparison_result26 to i256
+
+; CHECK: sub!    r1, r2, r1
+; CHECK: add     0, r0, r1
+; CHECK: add.eq  1, r0, r1
+; CHECK: and     1, r1, r1
+  %if_condition_compared28 = icmp ne i256 %comparison_result_extended27, 0
+  %ret_value = zext i1 %if_condition_compared28 to i256
+  ret i256 %ret_value
+}
+


### PR DESCRIPTION
SEL instrutions are expanded into a series of instructions, and we tag
one of the def register as being clobbered for register allocator.

SEL has many addressing types, some do not have target register.
avoid tagging non-register operands.

Also updates the regression test.