### PR TITLE
Instantly select R0 for zero

### DIFF
--- a/llvm/lib/Target/SyncVM/SyncVMISelDAGToDAG.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMISelDAGToDAG.cpp
@@ -350,6 +350,14 @@ void SyncVMDAGToDAGISel::Select(SDNode *Node) {
     auto cn = cast<ConstantSDNode>(Node);
     auto val = cn->getAPIntValue();
 
+    // if it is loading zero value, just select R0 to save its materialization
+    // in another register
+    if (val == 0) {
+      auto R0 = CurDAG->getRegister(SyncVM::R0, MVT::i256);
+      ReplaceNode(Node, R0.getNode());
+      return;
+    }
+
     // if it cannot fit into the imm field of an instruction ... put it into
     // pool
     if (!val.isIntN(16) || val.isNegative()) {

--- a/llvm/test/CodeGen/SyncVM/calling-convensions.ll
+++ b/llvm/test/CodeGen/SyncVM/calling-convensions.ll
@@ -290,47 +290,48 @@ define i256 @caller_i128.retabi(i256 %a1) nounwind {
 
 ; CHECK-LABEL: call.onestack
 define i256 @call.onestack() nounwind {
+; TODO: Check calling conventions onse callee-saved and caller-saver registers defined
 ; CHECK: context.sp r1
 ; CHECK: add 0, r0, stack[r1 - 0]
-; CHECK: add 0, r0, r1
-; CHECK: add r1, r0, r2
-; CHECK: add r1, r0, r3
-; CHECK: add r1, r0, r4
-; CHECK: add r1, r0, r5
-; CHECK: add r1, r0, r6
-; CHECK: add r1, r0, r7
-; CHECK: add r1, r0, r8
-; CHECK: add r1, r0, r9
-; CHECK: add r1, r0, r10
-; CHECK: add r1, r0, r11
-; CHECK: add r1, r0, r12
-; CHECK: add r1, r0, r13
-; CHECK: add r1, r0, r14
-; CHECK: near_call r0, @onestack, @DEFAULT_UNWIND
+; CHECK: add r0, r0, r1
+; CHECK: add r0, r0, r2
+; CHECK: add r0, r0, r3
+; CHECK: add r0, r0, r4
+; CHECK: add r0, r0, r5
+; CHECK: add r0, r0, r6
+; CHECK: add r0, r0, r7
+; CHECK: add r0, r0, r8
+; CHECK: add r0, r0, r9
+; CHECK: add r0, r0, r10
+; CHECK: add r0, r0, r11
+; CHECK: add r0, r0, r12
+; CHECK: add r0, r0, r13
+; CHECK: add r0, r0, r14
+; CHECK: near_call r0, @onestack
   %1 = call i256 @onestack(i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0)
   ret i256 %1
 }
+
 
 ; CHECK-LABEL: call.onestackabi
 define i256 @call.onestackabi() nounwind {
   %ptr = bitcast i256(i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256)* @onestack to i256*
 ; CHECK: context.sp r1
 ; CHECK: add 0, r0, stack[r1 - 0]
-; CHECK: add 0, r0, r1
 ; CHECK: add 42, r0, r15
-; CHECK: add r1, r0, r2
-; CHECK: add r1, r0, r3
-; CHECK: add r1, r0, r4
-; CHECK: add r1, r0, r5
-; CHECK: add r1, r0, r6
-; CHECK: add r1, r0, r7
-; CHECK: add r1, r0, r8
-; CHECK: add r1, r0, r9
-; CHECK: add r1, r0, r10
-; CHECK: add r1, r0, r11
-; CHECK: add r1, r0, r12
-; CHECK: add r1, r0, r13
-; CHECK: add r1, r0, r14
+; CHECK: add r0, r0, r2
+; CHECK: add r0, r0, r3
+; CHECK: add r0, r0, r4
+; CHECK: add r0, r0, r5
+; CHECK: add r0, r0, r6
+; CHECK: add r0, r0, r7
+; CHECK: add r0, r0, r8
+; CHECK: add r0, r0, r9
+; CHECK: add r0, r0, r10
+; CHECK: add r0, r0, r11
+; CHECK: add r0, r0, r12
+; CHECK: add r0, r0, r13
+; CHECK: add r0, r0, r14
 ; CHECK: near_call r15, @onestack, @DEFAULT_UNWIND
   %1 = call i256(i256*, i256, ...) @llvm.syncvm.nearcall(i256* %ptr, i256 42, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0)
   ret i256 %1
@@ -342,21 +343,20 @@ define i256 @call.twostackabi() nounwind {
 ; CHECK: context.sp      r1
 ; CHECK: add 2, r0, stack[r1 + 1]
 ; CHECK: add 1, r0, stack[r1 - 0]
-; CHECK: add 0, r0, r1
 ; CHECK: add 42, r0, r15
-; CHECK: add r1, r0, r2
-; CHECK: add r1, r0, r3
-; CHECK: add r1, r0, r4
-; CHECK: add r1, r0, r5
-; CHECK: add r1, r0, r6
-; CHECK: add r1, r0, r7
-; CHECK: add r1, r0, r8
-; CHECK: add r1, r0, r9
-; CHECK: add r1, r0, r10
-; CHECK: add r1, r0, r11
-; CHECK: add r1, r0, r12
-; CHECK: add r1, r0, r13
-; CHECK: add r1, r0, r14
+; CHECK: add r0, r0, r2
+; CHECK: add r0, r0, r3
+; CHECK: add r0, r0, r4
+; CHECK: add r0, r0, r5
+; CHECK: add r0, r0, r6
+; CHECK: add r0, r0, r7
+; CHECK: add r0, r0, r8
+; CHECK: add r0, r0, r9
+; CHECK: add r0, r0, r10
+; CHECK: add r0, r0, r11
+; CHECK: add r0, r0, r12
+; CHECK: add r0, r0, r13
+; CHECK: add r0, r0, r14
 ; CHECK: near_call r15, @twostack, @DEFAULT_UNWIND
   %1 = call i256(i256*, i256, ...) @llvm.syncvm.nearcall(i256* %ptr, i256 42, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 0, i256 1, i256 2)
   ret i256 %1

--- a/llvm/test/CodeGen/SyncVM/cxa_throw.ll
+++ b/llvm/test/CodeGen/SyncVM/cxa_throw.ll
@@ -15,7 +15,7 @@ entry:
 catch:                                            ; preds = %entry
   %landing = landingpad { i8*, i32 }
           catch i8* null
-  ; CHECK: add 0, r0, r1
+  ; CHECK: add r0, r0, r1
   ; CHECK: revert
   call void @__cxa_throw(i8* null, i8* null, i8* null)
   unreachable
@@ -36,7 +36,7 @@ entry:
   br i1 %3, label %throw, label %join
 
 throw:                                            ; preds = %entry
-  ; CHECK: add 0, r0, r1
+  ; CHECK: add r0, r0, r1
   ; CHECK: revert
   call void @__cxa_throw(i8* null, i8* null, i8* null)
   unreachable

--- a/llvm/test/CodeGen/SyncVM/immediate.ll
+++ b/llvm/test/CodeGen/SyncVM/immediate.ll
@@ -5,6 +5,12 @@ target triple = "syncvm"
 
 ; CHECK-LABEL: .text
 
+; CHECK-LABEL: materialize_zero
+define i256 @materialize_zero() nounwind {
+  ; CHECK: add r0, r0, r1
+  ret i256 0
+}
+
 ; CHECK-LABEL: materialize_small_imm
 define i256 @materialize_small_imm() nounwind {
   ; CHECK: add 65535, r0, r1
@@ -70,7 +76,7 @@ define i256 @materialize_bigimm_in_sub_operation(i256 %par) nounwind {
 
 ; CHECK-LABEL: materialize_bigimm_in_sub_operation_2
 define i256 @materialize_bigimm_in_sub_operation_2(i256 %par) nounwind {
-  ; CHECK: add @CPI{{[0-9]}}_{{[0-9]}}[0], r0, r2
+  ; CHECK: add @CPI{{[0-9]*}}_{{[0-9]}}[0], r0, r2
   %res = sub i256 -42, %par
   ret i256 %res
 }
@@ -79,34 +85,34 @@ define i256 @materialize_bigimm_in_sub_operation_2(i256 %par) nounwind {
 ; CHECK-LABEL: .rodata
 
 ; materialize_big_imm
-; CHECK-LABEL: CPI1_0:
+; CHECK-LABEL: CPI2_0:
 ; CHECK: .cell 65536
 
 ; materialize_negative_imm
-; CHECK-LABEL: CPI2_0:
+; CHECK-LABEL: CPI3_0:
 ; CHECK: .cell -1
 
 ; materialize_bigimm_in_operation
-; CHECK-LABEL: CPI4_0:
-; CHECK: .cell -42
-
-; materialize_bigimm_in_operation_2
 ; CHECK-LABEL: CPI5_0:
 ; CHECK: .cell -42
 
-; materialize_bigimm_in_and_operation
+; materialize_bigimm_in_operation_2
 ; CHECK-LABEL: CPI6_0:
 ; CHECK: .cell -42
 
-; materialize_bigimm_in_xor_operation
+; materialize_bigimm_in_and_operation
 ; CHECK-LABEL: CPI7_0:
 ; CHECK: .cell -42
 
-; materialize_bigimm_in_sub_operation
+; materialize_bigimm_in_xor_operation
 ; CHECK-LABEL: CPI8_0:
 ; CHECK: .cell -42
 
-; materialize_bigimm_in_sub_operation_2
+; materialize_bigimm_in_sub_operation
 ; CHECK-LABEL: CPI9_0:
+; CHECK: .cell -42
+
+; materialize_bigimm_in_sub_operation_2
+; CHECK-LABEL: CPI10_0:
 ; CHECK: .cell -42
 

--- a/llvm/test/CodeGen/SyncVM/ra_regress.ll
+++ b/llvm/test/CodeGen/SyncVM/ra_regress.ll
@@ -9,20 +9,20 @@ target triple = "syncvm"
 define i256 @test_length(i256 %arg1) {
 entry:
 
-; CKECK: sub!    r4, r5, r4
-; CKECK: add     r1, r0, r1
-; CKECK: add.eq  r3, r0, r1
+; CKECK: sub!    r2, r1, r2
+; CKECK: add     0, r0, r1
+; CKECK: add.eq  r3, r0, r2
   %comparison_result24 = icmp slt i256 35, %arg1
   %comparison_result_extended25 = zext i1 %comparison_result24 to i256
 
-; CHECK: sub!    r1, r2, r1
+; CHECK: sub!    r1, r0, r1
 ; CHECK: add     0, r0, r1
 ; CHECK: add.ne  1, r0, r1
 ; CHECK: and     1, r1, r1
   %comparison_result26 = icmp eq i256 %comparison_result_extended25, 0
   %comparison_result_extended27 = zext i1 %comparison_result26 to i256
 
-; CHECK: sub!    r1, r2, r1
+; CHECK: sub!    r1, r0, r1
 ; CHECK: add     0, r0, r1
 ; CHECK: add.eq  1, r0, r1
 ; CHECK: and     1, r1, r1


### PR DESCRIPTION
Small opt to save one `ADDirr_p` instruction, which is a common case