### PR TITLE
Enable MachineBlockPlacement pass

### DIFF
--- a/llvm/lib/CodeGen/MachineBlockPlacement.cpp
+++ b/llvm/lib/CodeGen/MachineBlockPlacement.cpp
@@ -3293,7 +3293,6 @@ void MachineBlockPlacement::initDupThreshold() {
 }
 
 bool MachineBlockPlacement::runOnMachineFunction(MachineFunction &MF) {
-  return false;
   if (skipFunction(MF.getFunction()))
     return false;
 


### PR DESCRIPTION
Previously in the result returned by `analyzeBranch`, `FBB` was not set in the scenario that there is a conditional branch and a non-conditional at the end of BB.
