### PR TITLE
Do not fold umul into umul.overflow

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -4200,8 +4200,17 @@ Instruction *InstCombinerImpl::foldICmpBinOp(ICmpInst &I,
     }
   }
 
+  // SyncVM local begin
+  // At this moment SyncVM sees a regression over folding umul
+  Triple TT(I.getFunction()->getParent()->getTargetTriple());
+  if (!TT.isSyncVM()) {
+  // SyncVM local end
   if (Value *V = foldUnsignedMultiplicationOverflowCheck(I))
     return replaceInstUsesWith(I, V);
+  // SyncVM local begin
+  }
+  // SyncVM local end
+
 
   if (Value *V = foldICmpWithLowBitMaskedVal(I, Builder))
     return replaceInstUsesWith(I, V);


### PR DESCRIPTION
At this moment we do not benefit from this check