### PR TITLE
Enable MOVcrs and MOVsrs in ISEL

### DIFF
--- a/llvm/lib/Target/SyncVM/SyncVMISelDAGToDAG.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMISelDAGToDAG.cpp
@@ -97,6 +97,29 @@ private:
                           SDValue &Disp);
   bool SelectStackAddrCommon(SDValue Addr, SDValue &Base1, SDValue &Base2,
                              SDValue &Disp, bool IsAdjusted);
+  bool SelectLoadFromStack(SDValue N, SDValue &Base1, SDValue &Base2,
+                             SDValue &Disp) {
+    if (!N.hasOneUse() || !isa<LoadSDNode>(N)) {
+      return false;
+    }
+    LoadSDNode* Load = cast<LoadSDNode>(N);
+    if (Load->getAddressSpace() != SyncVMAS::AS_STACK || !Load->isUnindexed()) {
+      return false;
+    }
+    return SelectStackAddr(Load->getBasePtr(), Base1, Base2, Disp);
+  }
+
+  bool SelectLoadFromMem(SDValue N, SDValue &Base, SDValue &Disp) {
+    if (!N.hasOneUse() || !isa<LoadSDNode>(N)) {
+      return false;
+    }
+    LoadSDNode* Load = cast<LoadSDNode>(N);
+    if (Load->getAddressSpace() != SyncVMAS::AS_CODE || !Load->isUnindexed()) {
+      return false;
+    }
+    return SelectMemAddr(Load->getBasePtr(), Base, Disp);
+  }
+
   SyncVMISelAddressMode MergeAddr(const SyncVMISelAddressMode &LHS,
                                   const SyncVMISelAddressMode &RHS, SDLoc DL);
 };

--- a/llvm/lib/Target/SyncVM/SyncVMInstrInfo.td
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrInfo.td
@@ -173,6 +173,9 @@ def memaddr      : ComplexPattern<iPTR, 2, "SelectMemAddr", [], []>;
 def stackaddr    : ComplexPattern<iPTR, 3, "SelectStackAddr", [], []>;
 def adjstackaddr : ComplexPattern<iPTR, 3, "SelectAdjStackAddr", [], []>;
 
+def load_from_mem   : ComplexPattern<i256, 2, "SelectLoadFromMem", [], []>;
+def load_from_stack : ComplexPattern<i256, 3, "SelectLoadFromStack", [], []>;
+
 //===----------------------------------------------------------------------===//
 // Pattern Fragments Definitions.
 //===----------------------------------------------------------------------===//
@@ -928,8 +931,8 @@ defm ADD  : ArithICommutable<2,  "add", add>;
 defm SUB  : ArithINonCommutable<4, "sub", sub>;
 
 // MOV patterns
-def : Pat<(store_stack (load_code memaddr:$src), stackaddr:$dst),  (ADDcrs_p memaddr:$src, R0, stackaddr:$dst)>;
-def : Pat<(store_stack (load_stack stackaddr:$src), stackaddr:$dst),  (ADDsrs_p stackaddr:$src, R0, stackaddr:$dst)>;
+def : Pat<(store_stack load_from_mem:$src, stackaddr:$dst),  (ADDcrs_p load_from_mem:$src, R0, stackaddr:$dst)>;
+def : Pat<(store_stack load_from_stack:$src, stackaddr:$dst),  (ADDsrs_p stackaddr:$src, R0, stackaddr:$dst)>;
 def : Pat<(imm16:$val),  (ADDirr_p imm16:$val, R0)>;
 def : Pat<(load_code memaddr:$addr),  (ADDcrr_p memaddr:$addr, R0)>;
 def : Pat<(load_stack stackaddr:$addr),  (ADDsrr_p stackaddr:$addr, R0)>;

--- a/llvm/test/CodeGen/SyncVM/mov.ll
+++ b/llvm/test/CodeGen/SyncVM/mov.ll
@@ -53,9 +53,7 @@ define void @movirs(i256 %rs1) nounwind {
 ; CHECK-LABEL: movcrs
 define void @movcrs() nounwind {
   %valptr = alloca i256
-; TODO: CPR-447 should be `add code[val], r0, stack-[1]`
-; CHECK: add @val[0], r0, r[[REG:[0-9]+]]
-; CHECK: add r[[REG]], r0, stack-[1]
+; CHECK: add @val[0], r0, stack-[1]
   %val = load i256, i256 addrspace(4)* @val
   store i256 %val, i256* %valptr
   ret void
@@ -65,9 +63,7 @@ define void @movcrs() nounwind {
 define void @movsrs() nounwind {
   %valptr = alloca i256
   %destptr = alloca i256
-; TODO: CPR-447 should be `add stack-[2], r0, stack-[1]`
-; CHECK: stack-[2], r0, r[[REG:[0-9]+]]
-; CHECK: r[[REG]], r0, stack-[1]
+; CHECK: add stack-[2], r0, stack-[1]
   %val = load i256, i256* %valptr
   store i256 %val, i256* %destptr
   ret void


### PR DESCRIPTION
For some reason, `store_*` and `load_*`, if used in conjunction in a pattern,
does not make the tablegen to emit code for that pattern. Using complex pattern
can work around this issue.