### PR TITLE
Disable building lookup tables from switch

### DIFF
--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -1266,7 +1266,9 @@ void PassBuilder::addVectorPasses(OptimizationLevel Level,
   // before SLP vectorization.
   FPM.addPass(SimplifyCFGPass(SimplifyCFGOptions()
                                   .forwardSwitchCondToPhi(true)
-                                  .convertSwitchToLookupTable(true)
+                                  // SyncVM local begin
+                                  .convertSwitchToLookupTable(false)
+                                  // SyncVM local begin
                                   .needCanonicalLoops(false)
                                   .hoistCommonInsts(true)
                                   .sinkCommonInsts(true)));

--- a/llvm/lib/Target/SyncVM/SyncVMBytesToCells.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMBytesToCells.cpp
@@ -172,7 +172,7 @@ bool SyncVMBytesToCells::runOnMachineFunction(MachineFunction &MF) {
           MO0Reg.ChangeToRegister(NewVR, false);
         }
         MachineOperand &Const = MI.getOperand(Op0Start + 2);
-        Const.ChangeToImmediate(Const.getImm() / 32);
+        Const.ChangeToImmediate(getImmOrCImm(Const) / 32);
       };
       for (unsigned OpNo = 0; OpNo < 3; ++OpNo)
         if (isStackOp(MI, OpNo)) {

--- a/llvm/lib/Transforms/IPO/PassManagerBuilder.cpp
+++ b/llvm/lib/Transforms/IPO/PassManagerBuilder.cpp
@@ -592,7 +592,9 @@ void PassManagerBuilder::addVectorPasses(legacy::PassManagerBase &PM,
   // before SLP vectorization.
   PM.add(createCFGSimplificationPass(SimplifyCFGOptions()
                                          .forwardSwitchCondToPhi(true)
-                                         .convertSwitchToLookupTable(true)
+                                         // SyncVM local begin
+                                         .convertSwitchToLookupTable(false)
+                                         // SyncVM local end
                                          .needCanonicalLoops(false)
                                          .hoistCommonInsts(true)
                                          .sinkCommonInsts(true)));


### PR DESCRIPTION
Despite the command-line option, LLVM unconditioally enables lookup
table building for switch. These tables are global constants and thus
every record there is 4 times as bigger as a single instruction.