### PR TITLE
[WIP] ISEL: Use complex pattern for stack/code operand

### DIFF
--- a/llvm/lib/Target/SyncVM/SyncVMISelDAGToDAG.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMISelDAGToDAG.cpp
@@ -98,6 +98,29 @@ private:
                              SDValue &Disp, bool IsAdjusted);
   SyncVMISelAddressMode MergeAddr(const SyncVMISelAddressMode &LHS,
                                   const SyncVMISelAddressMode &RHS, SDLoc DL);
+
+  bool SelectLoadFromStack(SDValue N, SDValue &Base1, SDValue &Base2,
+                           SDValue &Disp) {
+    if (!N.hasOneUse() || !isa<LoadSDNode>(N)) {
+      return false;
+    }
+    LoadSDNode *Load = cast<LoadSDNode>(N);
+    if (Load->getAddressSpace() != SyncVMAS::AS_STACK || !Load->isUnindexed()) {
+      return false;
+    }
+    return SelectStackAddr(Load->getBasePtr(), Base1, Base2, Disp);
+  }
+
+  bool SelectLoadFromMem(SDValue N, SDValue &Base, SDValue &Disp) {
+    if (!N.hasOneUse() || !isa<LoadSDNode>(N)) {
+      return false;
+    }
+    LoadSDNode *Load = cast<LoadSDNode>(N);
+    if (Load->getAddressSpace() != SyncVMAS::AS_CODE || !Load->isUnindexed()) {
+      return false;
+    }
+    return SelectMemAddr(Load->getBasePtr(), Base, Disp);
+  }
 };
 } // end anonymous namespace
 

--- a/llvm/lib/Target/SyncVM/SyncVMISelLowering.h
+++ b/llvm/lib/Target/SyncVM/SyncVMISelLowering.h
@@ -60,6 +60,7 @@ public:
   SDValue LowerSRA(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerSDIV(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerSREM(SDValue Op, SelectionDAG &DAG) const;
+  SDValue LowerSDIVREM(SDValue Op, SelectionDAG &DAG) const;
 
   SDValue LowerINTRINSIC_VOID(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerINTRINSIC_WO_CHAIN(SDValue Op, SelectionDAG &DAG) const;

--- a/llvm/lib/Target/SyncVM/SyncVMInstrInfo.td
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrInfo.td
@@ -196,6 +196,9 @@ def memaddr      : ComplexPattern<iPTR, 2, "SelectMemAddr", [], []>;
 def stackaddr    : ComplexPattern<iPTR, 3, "SelectStackAddr", [], []>;
 def adjstackaddr : ComplexPattern<iPTR, 3, "SelectAdjStackAddr", [], []>;
 
+def load_from_mem   : ComplexPattern<i256, 2, "SelectLoadFromMem", [], []>;
+def load_from_stack : ComplexPattern<i256, 3, "SelectLoadFromStack", [], []>;
+
 //===----------------------------------------------------------------------===//
 // Pattern Fragments Definitions.
 //===----------------------------------------------------------------------===//
@@ -952,7 +955,7 @@ multiclass Arith2<bits<8> opcode, string asmstring, SDPatternOperator node, bit 
   let isPseudo = 1, isCodeGenOnly = 1 in
   def srrr_p : Pseudo<(outs GR256:$rd0, GR256:$rd1), (ins stackop:$src0, GR256:$rs1),
                       !strconcat(asmstring, "\t$src0, $rs1, $rd0, $rd1"),
-                      [(set GR256:$rd0, GR256:$rd1, (node (load_stack stackaddr:$src0), GR256:$rs1))]> {
+                      [(set GR256:$rd0, GR256:$rd1, (node load_from_stack:$src0, GR256:$rs1))]> {
                         let DestAddrMode = ToRegReg.Value;
                         let OperandAddrMode = OpndSR.Value;
                       }

--- a/llvm/test/CodeGen/SyncVM/sdiv.ll
+++ b/llvm/test/CodeGen/SyncVM/sdiv.ll
@@ -1,0 +1,443 @@
+; RUN: llc < %s | FileCheck %s
+
+target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
+target triple = "syncvm"
+
+@val = addrspace(4) global i256 42
+
+; CHECK-LABEL: sremrrr
+define i256 @sremrrr(i256 %rs1, i256 %rs2) nounwind {
+; CHECK:        div.s   @CPI0_0[0], [[REG2:r[0-9]+]], [[REG2]], [[REG3:r[0-9]+]]
+; CHECK-NEXT:   add     @CPI0_0[0], r0, [[REG4:r[0-9]+]]
+; CHECK-NEXT:   sub     [[REG4]], [[REG3:r[0-9]+]], [[REG5:r[0-9]+]]
+; CHECK-NEXT:   sub.s!  0, [[REG2]], [[REG2]]
+; CHECK-NEXT:   add     [[REG3]], r0, [[REG2]]
+; CHECK-NEXT:   add.ne  [[REG5]], r0, [[REG2]]
+; CHECK-NEXT:   div.s   @CPI0_0[0], [[REG1:r[0-9]+]], [[REG3]], [[REG5]]
+; CHECK-NEXT:   sub     [[REG4]], [[REG5]], [[REG4]]
+; CHECK-NEXT:   sub.s!  0, [[REG3]], [[REG3]]
+; CHECK-NEXT:   add     [[REG5]], r0, [[REG3]]
+; CHECK-NEXT:   add.ne  [[REG4]], r0, [[REG3]]
+; CHECK-NEXT:   div     [[REG3]], [[REG2]], [[REG2]], [[REG3]]
+; CHECK-NEXT:   and     @CPI0_0[0], [[REG1]], [[REG1]]
+; CHECK-NEXT:   sub     0, [[REG3]], [[REG2]]
+; CHECK-NEXT:   sub.s!  0, [[REG1]], [[REG1]]
+; CHECK-NEXT:   add     [[REG2]], r0, [[REG1]]
+; CHECK-NEXT:   add.eq  [[REG3]], r0, [[REG1]]
+; CHECK-NEXT:   sub.s!  0, [[REG3]], [[REG2]]
+; CHECK-NEXT:   add.eq  [[REG3]], r0, [[REG1]]
+  %res = srem i256 %rs1, %rs2
+  ret i256 %res
+}
+
+; CHECK-LABEL: sremirr
+define i256 @sremirr(i256 %rs1) nounwind {
+; TODO: Special handling of signed division by a constant
+  %res = urem i256 42, %rs1
+  ret i256 %res
+}
+
+; CHECK-LABEL: sremxrr
+define i256 @sremxrr(i256 %rs1) nounwind {
+; TODO: Special handling of signed division by a constant
+  %res = srem i256 %rs1, 42
+  ret i256 %res
+}
+
+; CHECK-LABEL: sremcrr
+define i256 @sremcrr(i256 %rs1) nounwind {
+  %val = load i256, i256 addrspace(4)* @val
+  %res = srem i256 %val, %rs1
+  ret i256 %res
+}
+
+; CHECK-LABEL: sremyrr
+define i256 @sremyrr(i256 %rs1) nounwind {
+  %val = load i256, i256 addrspace(4)* @val
+  %res = srem i256 %rs1, %val
+  ret i256 %res
+}
+
+; CHECK-LABEL: sremsrr
+define i256 @sremsrr(i256 %rs1) nounwind {
+  %valptr = alloca i256
+  %val = load i256, i256* %valptr
+  %res = srem i256 %val, %rs1
+  ret i256 %res
+}
+
+; CHECK-LABEL: sremzrr
+define i256 @sremzrr(i256 %rs1) nounwind {
+  %valptr = alloca i256
+  %val = load i256, i256* %valptr
+  %res = srem i256 %rs1, %val
+  ret i256 %res
+}
+
+; CHECK-LABEL: sremrrs
+define void @sremrrs(i256 %rs1, i256 %rs2) nounwind {
+  %valptr = alloca i256
+  %res = srem i256 %rs1, %rs2
+  store i256 %res, i256* %valptr
+  ret void
+}
+
+; CHECK-LABEL: sremirs
+define void @sremirs(i256 %rs1) nounwind {
+  %valptr = alloca i256
+  %res = srem i256 42, %rs1
+  store i256 %res, i256* %valptr
+  ret void
+}
+
+; CHECK-LABEL: sremxrs
+define void @sremxrs(i256 %rs1) nounwind {
+  %valptr = alloca i256
+  %res = srem i256 %rs1, 42
+  store i256 %res, i256* %valptr
+  ret void
+}
+
+; CHECK-LABEL: sremcrs
+define void @sremcrs(i256 %rs1) nounwind {
+  %valptr = alloca i256
+  %val = load i256, i256 addrspace(4)* @val
+  %res = srem i256 %val, %rs1
+  store i256 %res, i256* %valptr
+  ret void
+}
+
+; CHECK-LABEL: sremyrs
+define void @sremyrs(i256 %rs1) nounwind {
+  %valptr = alloca i256
+  %val = load i256, i256 addrspace(4)* @val
+  %res = srem i256 %rs1, %val
+  store i256 %res, i256* %valptr
+  ret void
+}
+
+; CHECK-LABEL: sremsrs
+define void @sremsrs(i256 %rs1) nounwind {
+  %valptr = alloca i256
+  %destptr = alloca i256
+  %val = load i256, i256* %valptr
+  %res = srem i256 %val, %rs1
+  store i256 %res, i256* %destptr
+  ret void
+}
+
+; CHECK-LABEL: sremzrs
+define void @sremzrs(i256 %rs1) nounwind {
+  %valptr = alloca i256
+  %destptr = alloca i256
+  %val = load i256, i256* %valptr
+  %res = srem i256 %rs1, %val
+  store i256 %res, i256* %destptr
+  ret void
+}
+
+; CHECK-LABEL: sdivrrr
+define i256 @sdivrrr(i256 %rs1, i256 %rs2) nounwind {
+; CHECK:         div.s   @CPI14_0[0], [[REG2]], [[REG2]], [[REG3]]
+; CHECK-NEXT:    add     @CPI14_0[0], r0, [[REG4]]
+; CHECK-NEXT:    sub     [[REG4]], [[REG3]], [[REG5]]
+; CHECK-NEXT:    sub.s!  0, [[REG2]], r6
+; CHECK-NEXT:    add.ne  [[REG5]], r0, [[REG3]]
+; CHECK-NEXT:    div.s   @CPI14_0[0], [[REG1]], [[REG1]], [[REG5]]
+; CHECK-NEXT:    xor     [[REG1]], [[REG2]], [[REG2]]
+; CHECK-NEXT:    sub     [[REG4]], [[REG5]], [[REG4]]
+; CHECK-NEXT:    sub.s!  0, [[REG1]], [[REG1]]
+; CHECK-NEXT:    add     [[REG5]], r0, [[REG1]]
+; CHECK-NEXT:    add.ne  [[REG4]], r0, [[REG1]]
+; CHECK-NEXT:    div     [[REG1]], [[REG3]], [[REG1]], [[REG3]]
+; CHECK-NEXT:    shl.s   255, [[REG2]], [[REG2]]
+; CHECK-NEXT:    sub     [[REG2]], [[REG1]], [[REG3]]
+; CHECK-NEXT:    or      [[REG3]], [[REG2]], [[REG3]]
+; CHECK-NEXT:    sub.s!  0, [[REG2]], [[REG2]]
+; CHECK-NEXT:    add     [[REG3]], r0, [[REG2]]
+; CHECK-NEXT:    add.eq  [[REG1]], r0, [[REG2]]
+; CHECK-NEXT:    sub.s!  0, [[REG1]], [[REG3]]
+; CHECK-NEXT:    add.ne  [[REG2]], r0, [[REG1]]
+  %res = sdiv i256 %rs1, %rs2
+  ret i256 %res
+}
+
+; CHECK-LABEL: sdivirr
+define i256 @sdivirr(i256 %rs1) nounwind {
+; TODO: div 42, [[REG1]], [[REG1]], r{{[0-9]+}}
+  %res = sdiv i256 42, %rs1
+  ret i256 %res
+}
+
+; CHECK-LABEL: sdivxrr
+define i256 @sdivxrr(i256 %rs1) nounwind {
+; TODO: div.s 42, [[REG1]], [[REG1]], r{{[0-9]+}}
+  %res = sdiv i256 %rs1, 42
+  ret i256 %res
+}
+
+; CHECK-LABEL: sdivcrr
+define i256 @sdivcrr(i256 %rs1) nounwind {
+; TODO: div @val[0], [[REG1]], [[REG1]], r{{[0-9]+}}
+  %val = load i256, i256 addrspace(4)* @val
+  %res = sdiv i256 %val, %rs1
+  ret i256 %res
+}
+
+; CHECK-LABEL: sdivyrr
+define i256 @sdivyrr(i256 %rs1) nounwind {
+; TODO: div.s @val[0], [[REG1]], [[REG1]], r{{[0-9]+}}
+  %val = load i256, i256 addrspace(4)* @val
+  %res = sdiv i256 %rs1, %val
+  ret i256 %res
+}
+
+; CHECK-LABEL: sdivsrr
+define i256 @sdivsrr(i256 %rs1) nounwind {
+  %valptr = alloca i256
+; TODO: div stack-[1], [[REG1]], [[REG1]], r{{[0-9]+}}
+  %val = load i256, i256* %valptr
+  %res = sdiv i256 %val, %rs1
+  ret i256 %res
+}
+
+; CHECK-LABEL: sdivzrr
+define i256 @sdivzrr(i256 %rs1) nounwind {
+  %valptr = alloca i256
+; TODO: div.s stack-[1], [[REG1]], [[REG1]], r{{[0-9]+}}
+  %val = load i256, i256* %valptr
+  %res = sdiv i256 %rs1, %val
+  ret i256 %res
+}
+
+; CHECK-LABEL: sdivrrs
+define void @sdivrrs(i256 %rs1, i256 %rs2) nounwind {
+  %valptr = alloca i256
+  %res = sdiv i256 %rs1, %rs2
+  store i256 %res, i256* %valptr
+  ret void
+}
+
+; CHECK-LABEL: sdivirs
+define void @sdivirs(i256 %rs1) nounwind {
+  %valptr = alloca i256
+  %res = sdiv i256 42, %rs1
+  store i256 %res, i256* %valptr
+  ret void
+}
+
+; CHECK-LABEL: sdivxrs
+define void @sdivxrs(i256 %rs1) nounwind {
+  %valptr = alloca i256
+  %res = sdiv i256 %rs1, 42
+  store i256 %res, i256* %valptr
+  ret void
+}
+
+; CHECK-LABEL: sdivcrs
+define void @sdivcrs(i256 %rs1) nounwind {
+  %valptr = alloca i256
+  %val = load i256, i256 addrspace(4)* @val
+  %res = sdiv i256 %val, %rs1
+  store i256 %res, i256* %valptr
+  ret void
+}
+
+; CHECK-LABEL: sdivyrs
+define void @sdivyrs(i256 %rs1) nounwind {
+  %valptr = alloca i256
+  %val = load i256, i256 addrspace(4)* @val
+  %res = sdiv i256 %rs1, %val
+  store i256 %res, i256* %valptr
+  ret void
+}
+
+; CHECK-LABEL: sdivsrs
+define void @sdivsrs(i256 %rs1) nounwind {
+  %valptr = alloca i256
+  %destptr = alloca i256
+  %val = load i256, i256* %valptr
+  %res = sdiv i256 %val, %rs1
+  store i256 %res, i256* %destptr
+  ret void
+}
+
+; CHECK-LABEL: sdivzrs
+define void @sdivzrs(i256 %rs1) nounwind {
+  %valptr = alloca i256
+  %destptr = alloca i256
+; TODO: div.s stack-[2], [[REG1]], stack-[1], r{{[0-9]+}}
+  %val = load i256, i256* %valptr
+  %res = sdiv i256 %rs1, %val
+  store i256 %res, i256* %destptr
+  ret void
+}
+
+; CHECK-LABEL: sdivremrrrr
+define i256 @sdivremrrrr(i256 %rs1, i256 %rs2) nounwind {
+; CHECK:       div.s   @CPI28_0[0], [[REG2]], [[REG2]], [[REG3]]
+; CHECK-NEXT:  add     @CPI28_0[0], r0, [[REG4]]
+; CHECK-NEXT:  sub     [[REG4]], [[REG3]], [[REG5]]
+; CHECK-NEXT:  sub.s!  0, [[REG2]], [[REG6:r[0-9]+]]
+; CHECK-NEXT:  add.ne  [[REG5]], r0, [[REG3]]
+; CHECK-NEXT:  div.s   @CPI28_0[0], [[REG1]], [[REG5]], [[REG6]]
+; CHECK-NEXT:  xor     [[REG5]], [[REG2]], [[REG2]]
+; CHECK-NEXT:  sub     [[REG4]], [[REG6]], [[REG4]]
+; CHECK-NEXT:  sub.s!  0, [[REG5]], [[REG5]]
+; CHECK-NEXT:  add.eq  [[REG6]], r0, [[REG4]]
+; CHECK-NEXT:  div     [[REG4]], [[REG3]], [[REG3]], [[REG4]]
+; CHECK-NEXT:  shl.s   255, [[REG2]], [[REG2]]
+; CHECK-NEXT:  sub     [[REG2]], [[REG3]], [[REG5]]
+; CHECK-NEXT:  or      [[REG5]], [[REG2]], [[REG5]]
+; CHECK-NEXT:  sub.s!  0, [[REG2]], [[REG2]]
+; CHECK-NEXT:  add     [[REG5]], r0, [[REG2]]
+; CHECK-NEXT:  add.eq  [[REG3]], r0, [[REG2]]
+; CHECK-NEXT:  and     @CPI28_0[0], [[REG1]], [[REG1]]
+; CHECK-NEXT:  sub     0, [[REG4]], [[REG5]]
+; CHECK-NEXT:  sub.s!  0, [[REG1]], [[REG1]]
+; CHECK-NEXT:  add     [[REG5]], r0, [[REG1]]
+; CHECK-NEXT:  add.eq  [[REG4]], r0, [[REG1]]
+; CHECK-NEXT:  sub.s!  0, [[REG4]], [[REG5]]
+; CHECK-NEXT:  add.eq  [[REG4]], r0, [[REG1]]
+; CHECK-NEXT:  sub.s!  0, [[REG3]], [[REG4]]
+; CHECK-NEXT:  add.eq  [[REG3]], r0, [[REG2]]
+  %res1 = srem i256 %rs1, %rs2
+  %res2 = sdiv i256 %rs1, %rs2
+  %res = add i256 %res1, %res2
+  ret i256 %res
+}
+
+; CHECK-LABEL: sdivremirrr
+define i256 @sdivremirrr(i256 %rs1) nounwind {
+; CHECK: div 42, r{{[0-9]+}}, r{{[0-9]+}}, r{{[0-9]+}}
+; CHECK: add r{{[0-9]+}}, r{{[0-9]+}}, r{{[0-9]+}}
+  %res1 = srem i256 42, %rs1
+  %res2 = sdiv i256 42, %rs1
+  %res = add i256 %res1, %res2
+  ret i256 %res
+}
+
+; CHECK-LABEL: sdivremxrrr
+define i256 @sdivremxrrr(i256 %rs1) nounwind {
+; CHECK: div r{{[0-9]+}}, r{{[0-9]+}}, r{{[0-9]+}}, r{{[0-9]+}}
+; CHECK: add r{{[0-9]+}}, r{{[0-9]+}}, r{{[0-9]+}}
+  %res1 = srem i256 %rs1, 42
+  %res2 = sdiv i256 %rs1, 42
+  %res = add i256 %res1, %res2
+  ret i256 %res
+}
+
+; CHECK-LABEL: sdivremcrrr
+define i256 @sdivremcrrr(i256 %rs1) nounwind {
+; CHECK: div r{{[0-9]+}}, r{{[0-9]+}}, r{{[0-9]+}}, r{{[0-9]+}}
+; CHECK: add r{{[0-9]+}}, r{{[0-9]+}}, r{{[0-9]+}}
+  %val = load i256, i256 addrspace(4)* @val
+  %res1 = srem i256 %val, %rs1
+  %res2 = sdiv i256 %val, %rs1
+  %res = add i256 %res1, %res2
+  ret i256 %res
+}
+
+; CHECK-LABEL: sdivremyrrr
+define i256 @sdivremyrrr(i256 %rs1) nounwind {
+; CHECK: div r{{[0-9]+}}, r{{[0-9]+}}, r{{[0-9]+}}, r{{[0-9]+}}
+; CHECK: add r{{[0-9]+}}, r{{[0-9]+}}, r{{[0-9]+}}
+  %val = load i256, i256 addrspace(4)* @val
+  %res1 = srem i256 %rs1, %val
+  %res2 = sdiv i256 %rs1, %val
+  %res = add i256 %res1, %res2
+  ret i256 %res
+}
+
+; CHECK-LABEL: sdivremsrrr
+define i256 @sdivremsrrr(i256 %rs1) nounwind {
+  %valptr = alloca i256
+; CHECK: div r{{[0-9]+}}, r{{[0-9]+}}, r{{[0-9]+}}, r{{[0-9]+}}
+; CHECK: add r{{[0-9]+}}, r{{[0-9]+}}, r{{[0-9]+}}
+  %val = load i256, i256* %valptr
+  %res1 = srem i256 %val, %rs1
+  %res2 = sdiv i256 %val, %rs1
+  %res = add i256 %res1, %res2
+  ret i256 %res
+}
+
+; CHECK-LABEL: sdivremzrrr
+define i256 @sdivremzrrr(i256 %rs1) nounwind {
+  %valptr = alloca i256
+; CHECK: div r{{[0-9]+}}, r{{[0-9]+}}, r{{[0-9]+}}, r{{[0-9]+}}
+; CHECK: add r{{[0-9]+}}, r{{[0-9]+}}, r{{[0-9]+}}
+  %val = load i256, i256* %valptr
+  %res1 = srem i256 %rs1, %val
+  %res2 = sdiv i256 %rs1, %val
+  %res = add i256 %res1, %res2
+  ret i256 %res
+}
+
+; CHECK-LABEL: sdivremrrsr
+define i256 @sdivremrrsr(i256 %rs1, i256 %rs2) nounwind {
+  %valptr = alloca i256
+  %res = sdiv i256 %rs1, %rs2
+  %rem = srem i256 %rs1, %rs2
+  store i256 %res, i256* %valptr
+  ret i256 %rem
+}
+
+; CHECK-LABEL: sdivremirsr
+define i256 @sdivremirsr(i256 %rs1) nounwind {
+  %valptr = alloca i256
+  %res = sdiv i256 42, %rs1
+  %rem = srem i256 42, %rs1
+  store i256 %res, i256* %valptr
+  ret i256 %rem
+}
+
+; CHECK-LABEL: sdivremxrsr
+define i256 @sdivremxrsr(i256 %rs1) nounwind {
+  %valptr = alloca i256
+  %res = sdiv i256 %rs1, 42
+  %rem = srem i256 %rs1, 42
+  store i256 %res, i256* %valptr
+  ret i256 %rem
+}
+
+; CHECK-LABEL: sdivremcrsr
+define i256 @sdivremcrsr(i256 %rs1) nounwind {
+  %valptr = alloca i256
+  %val = load i256, i256 addrspace(4)* @val
+  %res = sdiv i256 %val, %rs1
+  %rem = srem i256 %val, %rs1
+  store i256 %res, i256* %valptr
+  ret i256 %rem
+}
+
+; CHECK-LABEL: sdivremyrsr
+define i256 @sdivremyrsr(i256 %rs1) nounwind {
+  %valptr = alloca i256
+  %val = load i256, i256 addrspace(4)* @val
+  %res = sdiv i256 %rs1, %val
+  %rem = srem i256 %rs1, %val
+  store i256 %res, i256* %valptr
+  ret i256 %rem
+}
+
+; CHECK-LABEL: sdivremsrsr
+define i256 @sdivremsrsr(i256 %rs1) nounwind {
+  %valptr = alloca i256
+  %destptr = alloca i256
+  %val = load i256, i256* %valptr
+  %res = sdiv i256 %val, %rs1
+  %rem = srem i256 %val, %rs1
+  store i256 %res, i256* %destptr
+  ret i256 %rem
+}
+
+; CHECK-LABEL: sdivremzrsr
+define i256 @sdivremzrsr(i256 %rs1) nounwind {
+  %valptr = alloca i256
+  %destptr = alloca i256
+  %val = load i256, i256* %valptr
+  %res = sdiv i256 %rs1, %val
+  %rem = srem i256 %rs1, %val
+  store i256 %res, i256* %destptr
+  ret i256 %rem
+}

--- a/llvm/test/CodeGen/SyncVM/udiv.ll
+++ b/llvm/test/CodeGen/SyncVM/udiv.ll
@@ -1,49 +1,49 @@
 ; RUN: llc < %s | FileCheck %s
 
-target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
+target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "syncvm"
 
 @val = addrspace(4) global i256 42
 
-; CHECK-LABEL: remrrr
-define i256 @remrrr(i256 %rs1, i256 %rs2) nounwind {
+; CHECK-LABEL: uremrrr
+define i256 @uremrrr(i256 %rs1, i256 %rs2) nounwind {
 ; CHECK: div r1, r2, r{{[0-9]+}}, r1
   %res = urem i256 %rs1, %rs2
   ret i256 %res
 }
 
-; CHECK-LABEL: remirr
-define i256 @remirr(i256 %rs1) nounwind {
+; CHECK-LABEL: uremirr
+define i256 @uremirr(i256 %rs1) nounwind {
 ; CHECK: div 42, r1, r{{[0-9]+}}, r1
   %res = urem i256 42, %rs1
   ret i256 %res
 }
 
-; CHECK-LABEL: remxrr
-define i256 @remxrr(i256 %rs1) nounwind {
+; CHECK-LABEL: uremxrr
+define i256 @uremxrr(i256 %rs1) nounwind {
 ; CHECK: div.s 42, r1, r{{[0-9]+}}, r1
   %res = urem i256 %rs1, 42
   ret i256 %res
 }
 
-; CHECK-LABEL: remcrr
-define i256 @remcrr(i256 %rs1) nounwind {
+; CHECK-LABEL: uremcrr
+define i256 @uremcrr(i256 %rs1) nounwind {
 ; CHECK: div @val[0], r1, r{{[0-9]+}}, r1
   %val = load i256, i256 addrspace(4)* @val
   %res = urem i256 %val, %rs1
   ret i256 %res
 }
 
-; CHECK-LABEL: remyrr
-define i256 @remyrr(i256 %rs1) nounwind {
+; CHECK-LABEL: uremyrr
+define i256 @uremyrr(i256 %rs1) nounwind {
 ; CHECK: div.s @val[0], r1, r{{[0-9]+}}, r1
   %val = load i256, i256 addrspace(4)* @val
   %res = urem i256 %rs1, %val
   ret i256 %res
 }
 
-; CHECK-LABEL: remsrr
-define i256 @remsrr(i256 %rs1) nounwind {
+; CHECK-LABEL: uremsrr
+define i256 @uremsrr(i256 %rs1) nounwind {
   %valptr = alloca i256
 ; CHECK: div stack-[1], r1, r{{[0-9]+}}, r1
   %val = load i256, i256* %valptr
@@ -51,8 +51,8 @@ define i256 @remsrr(i256 %rs1) nounwind {
   ret i256 %res
 }
 
-; CHECK-LABEL: remzrr
-define i256 @remzrr(i256 %rs1) nounwind {
+; CHECK-LABEL: uremzrr
+define i256 @uremzrr(i256 %rs1) nounwind {
   %valptr = alloca i256
 ; CHECK: div.s stack-[1], r1, r{{[0-9]+}}, r1
   %val = load i256, i256* %valptr
@@ -60,8 +60,8 @@ define i256 @remzrr(i256 %rs1) nounwind {
   ret i256 %res
 }
 
-; CHECK-LABEL: remrrs
-define void @remrrs(i256 %rs1, i256 %rs2) nounwind {
+; CHECK-LABEL: uremrrs
+define void @uremrrs(i256 %rs1, i256 %rs2) nounwind {
   %valptr = alloca i256
   %res = urem i256 %rs1, %rs2
 ; CHECK: div r1, r2, r{{[0-9]+}}, r[[REG:[0-9]+]]
@@ -70,8 +70,8 @@ define void @remrrs(i256 %rs1, i256 %rs2) nounwind {
   ret void
 }
 
-; CHECK-LABEL: remirs
-define void @remirs(i256 %rs1) nounwind {
+; CHECK-LABEL: uremirs
+define void @uremirs(i256 %rs1) nounwind {
   %valptr = alloca i256
 ; CHECK: div 42, r1, r{{[0-9]+}}, r[[REG:[0-9]+]]
 ; CHECK: add r[[REG]], r0, stack-[1]
@@ -80,8 +80,8 @@ define void @remirs(i256 %rs1) nounwind {
   ret void
 }
 
-; CHECK-LABEL: remxrs
-define void @remxrs(i256 %rs1) nounwind {
+; CHECK-LABEL: uremxrs
+define void @uremxrs(i256 %rs1) nounwind {
   %valptr = alloca i256
 ; CHECK: div.s 42, r1, r{{[0-9]+}}, r[[REG:[0-9]+]]
 ; CHECK: add r[[REG]], r0, stack-[1]
@@ -90,8 +90,8 @@ define void @remxrs(i256 %rs1) nounwind {
   ret void
 }
 
-; CHECK-LABEL: remcrs
-define void @remcrs(i256 %rs1) nounwind {
+; CHECK-LABEL: uremcrs
+define void @uremcrs(i256 %rs1) nounwind {
   %valptr = alloca i256
 ; CHECK: div @val[0], r1, r{{[0-9]+}}, r[[REG:[0-9]+]]
 ; CHECK: add r[[REG]], r0, stack-[1]
@@ -101,8 +101,8 @@ define void @remcrs(i256 %rs1) nounwind {
   ret void
 }
 
-; CHECK-LABEL: remyrs
-define void @remyrs(i256 %rs1) nounwind {
+; CHECK-LABEL: uremyrs
+define void @uremyrs(i256 %rs1) nounwind {
   %valptr = alloca i256
 ; CHECK: div.s @val[0], r1, r{{[0-9]+}}, r[[REG:[0-9]+]]
 ; CHECK: add r[[REG]], r0, stack-[1]
@@ -112,8 +112,8 @@ define void @remyrs(i256 %rs1) nounwind {
   ret void
 }
 
-; CHECK-LABEL: remsrs
-define void @remsrs(i256 %rs1) nounwind {
+; CHECK-LABEL: uremsrs
+define void @uremsrs(i256 %rs1) nounwind {
   %valptr = alloca i256
   %destptr = alloca i256
 ; CHECK: div stack-[2], r1, r{{[0-9]+}}, r[[REG:[0-9]+]]
@@ -124,8 +124,8 @@ define void @remsrs(i256 %rs1) nounwind {
   ret void
 }
 
-; CHECK-LABEL: remzrs
-define void @remzrs(i256 %rs1) nounwind {
+; CHECK-LABEL: uremzrs
+define void @uremzrs(i256 %rs1) nounwind {
   %valptr = alloca i256
   %destptr = alloca i256
 ; CHECK: div.s stack-[2], r1, r{{[0-9]+}}, r[[REG:[0-9]+]]
@@ -136,45 +136,45 @@ define void @remzrs(i256 %rs1) nounwind {
   ret void
 }
 
-; CHECK-LABEL: divrrr
-define i256 @divrrr(i256 %rs1, i256 %rs2) nounwind {
+; CHECK-LABEL: udivrrr
+define i256 @udivrrr(i256 %rs1, i256 %rs2) nounwind {
 ; CHECK: div r1, r2, r1, r{{[0-9]+}}
   %res = udiv i256 %rs1, %rs2
   ret i256 %res
 }
 
-; CHECK-LABEL: divirr
-define i256 @divirr(i256 %rs1) nounwind {
+; CHECK-LABEL: udivirr
+define i256 @udivirr(i256 %rs1) nounwind {
 ; CHECK: div 42, r1, r1, r{{[0-9]+}}
   %res = udiv i256 42, %rs1
   ret i256 %res
 }
 
-; CHECK-LABEL: divxrr
-define i256 @divxrr(i256 %rs1) nounwind {
+; CHECK-LABEL: udivxrr
+define i256 @udivxrr(i256 %rs1) nounwind {
 ; CHECK: div.s 42, r1, r1, r{{[0-9]+}}
   %res = udiv i256 %rs1, 42
   ret i256 %res
 }
 
-; CHECK-LABEL: divcrr
-define i256 @divcrr(i256 %rs1) nounwind {
+; CHECK-LABEL: udivcrr
+define i256 @udivcrr(i256 %rs1) nounwind {
 ; CHECK: div @val[0], r1, r1, r{{[0-9]+}}
   %val = load i256, i256 addrspace(4)* @val
   %res = udiv i256 %val, %rs1
   ret i256 %res
 }
 
-; CHECK-LABEL: divyrr
-define i256 @divyrr(i256 %rs1) nounwind {
+; CHECK-LABEL: udivyrr
+define i256 @udivyrr(i256 %rs1) nounwind {
 ; CHECK: div.s @val[0], r1, r1, r{{[0-9]+}}
   %val = load i256, i256 addrspace(4)* @val
   %res = udiv i256 %rs1, %val
   ret i256 %res
 }
 
-; CHECK-LABEL: divsrr
-define i256 @divsrr(i256 %rs1) nounwind {
+; CHECK-LABEL: udivsrr
+define i256 @udivsrr(i256 %rs1) nounwind {
   %valptr = alloca i256
 ; CHECK: div stack-[1], r1, r1, r{{[0-9]+}}
   %val = load i256, i256* %valptr
@@ -182,8 +182,8 @@ define i256 @divsrr(i256 %rs1) nounwind {
   ret i256 %res
 }
 
-; CHECK-LABEL: divzrr
-define i256 @divzrr(i256 %rs1) nounwind {
+; CHECK-LABEL: udivzrr
+define i256 @udivzrr(i256 %rs1) nounwind {
   %valptr = alloca i256
 ; CHECK: div.s stack-[1], r1, r1, r{{[0-9]+}}
   %val = load i256, i256* %valptr
@@ -191,8 +191,8 @@ define i256 @divzrr(i256 %rs1) nounwind {
   ret i256 %res
 }
 
-; CHECK-LABEL: divrrs
-define void @divrrs(i256 %rs1, i256 %rs2) nounwind {
+; CHECK-LABEL: udivrrs
+define void @udivrrs(i256 %rs1, i256 %rs2) nounwind {
   %valptr = alloca i256
   %res = udiv i256 %rs1, %rs2
 ; TODO: div r1, r2, stack-[1], r{{[0-9]+}}
@@ -200,8 +200,8 @@ define void @divrrs(i256 %rs1, i256 %rs2) nounwind {
   ret void
 }
 
-; CHECK-LABEL: divirs
-define void @divirs(i256 %rs1) nounwind {
+; CHECK-LABEL: udivirs
+define void @udivirs(i256 %rs1) nounwind {
   %valptr = alloca i256
 ; TODO: div 42, r1, stack-[1], r{{[0-9]+}}
   %res = udiv i256 42, %rs1
@@ -209,8 +209,8 @@ define void @divirs(i256 %rs1) nounwind {
   ret void
 }
 
-; CHECK-LABEL: divxrs
-define void @divxrs(i256 %rs1) nounwind {
+; CHECK-LABEL: udivxrs
+define void @udivxrs(i256 %rs1) nounwind {
   %valptr = alloca i256
 ; TODO: div.s 42, r1, stack-[1], r{{[0-9]+}}
   %res = udiv i256 %rs1, 42
@@ -218,8 +218,8 @@ define void @divxrs(i256 %rs1) nounwind {
   ret void
 }
 
-; CHECK-LABEL: divcrs
-define void @divcrs(i256 %rs1) nounwind {
+; CHECK-LABEL: udivcrs
+define void @udivcrs(i256 %rs1) nounwind {
   %valptr = alloca i256
 ; TODO: div @val[0], r1, stack-[1], r{{[0-9]+}}
   %val = load i256, i256 addrspace(4)* @val
@@ -228,8 +228,8 @@ define void @divcrs(i256 %rs1) nounwind {
   ret void
 }
 
-; CHECK-LABEL: divyrs
-define void @divyrs(i256 %rs1) nounwind {
+; CHECK-LABEL: udivyrs
+define void @udivyrs(i256 %rs1) nounwind {
   %valptr = alloca i256
 ; TODO: div.s @val[0], r1, stack-[1], r{{[0-9]+}}
   %val = load i256, i256 addrspace(4)* @val
@@ -238,8 +238,8 @@ define void @divyrs(i256 %rs1) nounwind {
   ret void
 }
 
-; CHECK-LABEL: divsrs
-define void @divsrs(i256 %rs1) nounwind {
+; CHECK-LABEL: udivsrs
+define void @udivsrs(i256 %rs1) nounwind {
   %valptr = alloca i256
   %destptr = alloca i256
 ; TODO: div stack-[2], r1, stack-[1], r{{[0-9]+}}
@@ -249,8 +249,8 @@ define void @divsrs(i256 %rs1) nounwind {
   ret void
 }
 
-; CHECK-LABEL: divzrs
-define void @divzrs(i256 %rs1) nounwind {
+; CHECK-LABEL: udivzrs
+define void @udivzrs(i256 %rs1) nounwind {
   %valptr = alloca i256
   %destptr = alloca i256
 ; TODO: div.s stack-[2], r1, stack-[1], r{{[0-9]+}}
@@ -411,3 +411,4 @@ define i256 @udivremzrsr(i256 %rs1) nounwind {
   store i256 %res, i256* %destptr
   ret i256 %rem
 }
+


### PR DESCRIPTION
`load_code` and `load_stack` are not working for some reason. And it turns out using complex patterns can work around such issues. 

This should enable stack-operand addressing mode pattern matching in the ISEL phase. Previously we were not able to emit such instructions.