### PR TITLE
Preserve r3, r4 in a syscall

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -9722,7 +9722,9 @@ TargetLowering::LowerCallTo(TargetLowering::CallLoweringInfo &CLI) const {
          "LowerCall didn't return a valid chain!");
   assert((!CLI.IsTailCall || InVals.empty()) &&
          "LowerCall emitted a return value for a tail call!");
-  assert((CLI.IsTailCall || InVals.size() == CLI.Ins.size()) &&
+  // SyncVM local begin
+  assert((CLI.IsTailCall || CLI.IsVarArg || InVals.size() == CLI.Ins.size()) &&
+  // SyncVM local end
          "LowerCall didn't emit the correct number of values!");
 
   // For a tail call, the return value is merely live-out and there aren't

--- a/llvm/lib/Target/SyncVM/syncvm-runtime.ll
+++ b/llvm/lib/Target/SyncVM/syncvm-runtime.ll
@@ -299,7 +299,7 @@ define {i8 addrspace(3)*, i1}* @__farcall(i256 %abi_params, i256 %address, {i8 a
 entry:
   %in_res_result_ptr = getelementptr {i8 addrspace(3)*, i1}, {i8 addrspace(3)*, i1}* %in_res, i32 0, i32 0
   %in_res_flag_ptr = getelementptr {i8 addrspace(3)*, i1}, {i8 addrspace(3)*, i1}* %in_res, i32 0, i32 1
-  %invoke_res = invoke i8 addrspace(3)* @__farcall_int(i256 %abi_params, i256 %address)
+  %invoke_res = invoke i8 addrspace(3)*(i256, i256, ...) @__farcall_int(i256 %abi_params, i256 %address)
     to label %ok unwind label %err
 ok:
   store i8 addrspace(3)* %invoke_res, i8 addrspace(3)** %in_res_result_ptr
@@ -337,7 +337,7 @@ define {i8 addrspace(3)*, i1}* @__delegatecall(i256 %abi_params, i256 %address, 
 entry:
   %in_res_result_ptr = getelementptr {i8 addrspace(3)*, i1}, {i8 addrspace(3)*, i1}* %in_res, i32 0, i32 0
   %in_res_flag_ptr = getelementptr {i8 addrspace(3)*, i1}, {i8 addrspace(3)*, i1}* %in_res, i32 0, i32 1
-  %invoke_res = invoke i8 addrspace(3)* @__delegatecall_int(i256 %abi_params, i256 %address)
+  %invoke_res = invoke i8 addrspace(3)*(i256, i256, ...) @__delegatecall_int(i256 %abi_params, i256 %address)
     to label %ok unwind label %err
 ok:
   store i8 addrspace(3)* %invoke_res, i8 addrspace(3)** %in_res_result_ptr
@@ -375,7 +375,7 @@ define {i8 addrspace(3)*, i1}* @__systemcall(i256 %abi_params, i256 %address, i2
 entry:
   %in_res_result_ptr = getelementptr {i8 addrspace(3)*, i1}, {i8 addrspace(3)*, i1}* %in_res, i32 0, i32 0
   %in_res_flag_ptr = getelementptr {i8 addrspace(3)*, i1}, {i8 addrspace(3)*, i1}* %in_res, i32 0, i32 1
-  %invoke_res = invoke i8 addrspace(3)* @__farcall_int(i256 %abi_params, i256 %address)
+  %invoke_res = invoke i8 addrspace(3)*(i256, i256, ...) @__farcall_int(i256 %abi_params, i256 %address, i256 %p0, i256 %p1)
     to label %ok unwind label %err
 ok:
   store i8 addrspace(3)* %invoke_res, i8 addrspace(3)** %in_res_result_ptr
@@ -394,7 +394,7 @@ define {i8 addrspace(3)*, i1}* @__systemdelegatecall(i256 %abi_params, i256 %add
 entry:
   %in_res_result_ptr = getelementptr {i8 addrspace(3)*, i1}, {i8 addrspace(3)*, i1}* %in_res, i32 0, i32 0
   %in_res_flag_ptr = getelementptr {i8 addrspace(3)*, i1}, {i8 addrspace(3)*, i1}* %in_res, i32 0, i32 1
-  %invoke_res = invoke i8 addrspace(3)* @__delegatecall_int(i256 %abi_params, i256 %address)
+  %invoke_res = invoke i8 addrspace(3)*(i256, i256, ...) @__delegatecall_int(i256 %abi_params, i256 %address, i256 %p0, i256 %p1)
     to label %ok unwind label %err
 ok:
   store i8 addrspace(3)* %invoke_res, i8 addrspace(3)** %in_res_result_ptr
@@ -506,9 +506,9 @@ declare void @llvm.syncvm.throw(i256)
 declare void @llvm.syncvm.sstore(i256 %key, i256 %val)
 declare i256 @llvm.syncvm.sload(i256 %key)
 declare i256 @llvm.syncvm.iflt(i256, i256)
-declare i8 addrspace(3)* @__farcall_int(i256, i256)
+declare i8 addrspace(3)* @__farcall_int(i256, i256, ...)
 declare i8 addrspace(3)* @__staticcall_int(i256, i256)
-declare i8 addrspace(3)* @__delegatecall_int(i256, i256)
+declare i8 addrspace(3)* @__delegatecall_int(i256, i256, ...)
 declare i8 addrspace(3)* @__mimiccall_int(i256, i256, i256)
 declare i32 @__personality()
 

--- a/llvm/test/CodeGen/SyncVM/intrinsic.ll
+++ b/llvm/test/CodeGen/SyncVM/intrinsic.ll
@@ -199,8 +199,15 @@ define i256 @ifgtii() {
   ret i256 %res
 }
 
+; CHECK-LABEL: invoke.farcall
 define void @invoke.farcall({i256, i1}* %res) {
   call {i256, i1}* @__farcall(i256 0, i256 0, {i256, i1}* %res)
+  ret void
+}
+
+; CHECK-LABEL: invoke.systemcall
+define void @invoke.systemcall({i256, i1}* %res) {
+  call {i256, i1}* @__systemcall(i256 0, i256 1, i256 2, i256 3, {i256, i1}* %res)
   ret void
 }
 
@@ -230,3 +237,4 @@ declare i256 @llvm.syncvm.iflt(i256, i256)
 declare i256 @llvm.syncvm.ifgt(i256, i256)
 
 declare {i256, i1}* @__farcall(i256, i256, {i256, i1}*)
+declare {i256, i1}* @__systemcall(i256, i256, i256, i256, {i256, i1}*)


### PR DESCRIPTION
Make farcall, delegatecall vararg, and pass syscall parameters to them, so the register allocation doesn't consider r3, r4 dead.