### PR TITLE
Support all external calls variations

### DIFF
--- a/llvm/lib/Target/SyncVM/SyncVMISelLowering.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMISelLowering.cpp
@@ -290,9 +290,11 @@ SyncVMTargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
       .Case("__farcall_int", SyncVMISD::FARCALL)
       .Case("__farcall_int_l", SyncVMISD::FARCALL)
       .Case("__staticcall_int", SyncVMISD::STATICCALL)
+      .Case("__staticcall_int_l", SyncVMISD::STATICCALL)
       .Case("__delegatecall_int", SyncVMISD::DELEGATECALL)
       .Case("__delegatecall_int_l", SyncVMISD::DELEGATECALL)
       .Case("__mimiccall_int", SyncVMISD::MIMICCALL)
+      .Case("__mimiccall_int_l", SyncVMISD::MIMICCALL)
       .Default(0);
 
     bool is_mimic = farcall_opc == SyncVMISD::MIMICCALL;

--- a/llvm/lib/Target/SyncVM/SyncVMInstrInfo.td
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrInfo.td
@@ -1120,12 +1120,16 @@ def FAR_CALLL  : ICall<80, CFNormal, (ins GR256:$abi, GR256:$address, GR256:$op1
                "far_call\t$abi, $address, $unwind", [(SyncVMfarcall GR256:$abi, GR256:$address, GR256:$op1, GR256:$op2, bb:$unwind)]>;
 def STATIC_CALL  : ICall<10, CFNormal, (ins GR256:$abi, GR256:$address, jmptarget:$unwind),
                "far_call.static\t$abi, $address, $unwind", [(SyncVMstaticcall GR256:$abi, GR256:$address, bb:$unwind)]>;
+def STATIC_CALLL  : ICall<100, CFNormal, (ins GR256:$abi, GR256:$address, GR256:$op1, GR256:$op2, jmptarget:$unwind),
+               "far_call.static\t$abi, $address, $unwind", [(SyncVMstaticcall GR256:$abi, GR256:$address, GR256:$op1, GR256:$op2, bb:$unwind)]>;
 def DELEGATE_CALL  : ICall<11, CFDelegate, (ins GR256:$abi, GR256:$address, jmptarget:$unwind),
                "far_call.delegate\t$abi, $address, $unwind", [(SyncVMdelegatecall GR256:$abi, GR256:$address, bb:$unwind)]>;
 def DELEGATE_CALLL  : ICall<110, CFDelegate, (ins GR256:$abi, GR256:$address, GR256:$op1, GR256:$op2, jmptarget:$unwind),
                "far_call.delegate\t$abi, $address, $unwind", [(SyncVMdelegatecall GR256:$abi, GR256:$address, GR256:$op1, GR256:$op2, bb:$unwind)]>;
 def MIMIC_CALL  : ICall<12, CFMimic, (ins GR256:$abi, GR256:$address, GR256:$mimic, jmptarget:$unwind),
                "far_call.mimic\t$abi, $address, $unwind", [(SyncVMmimiccall GR256:$abi, GR256:$address, GR256:$mimic, bb:$unwind)]>;
+def MIMIC_CALLL  : ICall<120, CFMimic, (ins GR256:$abi, GR256:$address, GR256:$op1, GR256:$op2, GR256:$mimic, jmptarget:$unwind),
+               "far_call.mimic\t$abi, $address, $unwind", [(SyncVMmimiccall GR256:$abi, GR256:$address, GR256:$op1, GR256:$op2, GR256:$mimic, bb:$unwind)]>;
 }
 
 def : Pat<(store_stack (add GR256:$rs0, neg_imm16:$imm), stackaddr:$dst0),

--- a/llvm/lib/Target/SyncVM/syncvm-runtime.ll
+++ b/llvm/lib/Target/SyncVM/syncvm-runtime.ll
@@ -371,7 +371,7 @@ err:
   ret {i8 addrspace(3)*, i1}* %in_res
 }
 
-define {i8 addrspace(3)*, i1}* @__systemcall(i256 %abi_params, i256 %address, i256 %p0, i256 %p1, {i8 addrspace(3)*, i1}* %in_res) personality i32 ()* @__personality {
+define {i8 addrspace(3)*, i1}* @__system_call(i256 %abi_params, i256 %address, i256 %p0, i256 %p1, {i8 addrspace(3)*, i1}* %in_res) personality i32 ()* @__personality {
 entry:
   %in_res_result_ptr = getelementptr {i8 addrspace(3)*, i1}, {i8 addrspace(3)*, i1}* %in_res, i32 0, i32 0
   %in_res_flag_ptr = getelementptr {i8 addrspace(3)*, i1}, {i8 addrspace(3)*, i1}* %in_res, i32 0, i32 1
@@ -390,7 +390,26 @@ err:
   ret {i8 addrspace(3)*, i1}* %in_res
 }
 
-define {i8 addrspace(3)*, i1}* @__systemdelegatecall(i256 %abi_params, i256 %address, i256 %p0, i256 %p1, {i8 addrspace(3)*, i1}* %in_res) personality i32 ()* @__personality {
+define {i8 addrspace(3)*, i1}* @__system_staticcall(i256 %abi_params, i256 %address, i256 %p0, i256 %p1, {i8 addrspace(3)*, i1}* %in_res) personality i32 ()* @__personality {
+entry:
+  %in_res_result_ptr = getelementptr {i8 addrspace(3)*, i1}, {i8 addrspace(3)*, i1}* %in_res, i32 0, i32 0
+  %in_res_flag_ptr = getelementptr {i8 addrspace(3)*, i1}, {i8 addrspace(3)*, i1}* %in_res, i32 0, i32 1
+  %invoke_res = invoke i8 addrspace(3)* @__staticcall_int_l(i256 %abi_params, i256 %address, i256 %p0, i256 %p1)
+    to label %ok unwind label %err
+ok:
+  store i8 addrspace(3)* %invoke_res, i8 addrspace(3)** %in_res_result_ptr
+  store i1 1, i1* %in_res_flag_ptr
+  ret {i8 addrspace(3)*, i1}* %in_res
+
+err:
+  %res.2 = landingpad {i8 addrspace(3)*, i256} cleanup
+  %res = extractvalue {i8 addrspace(3)*, i256} %res.2, 0
+  store i8 addrspace(3)* %res, i8 addrspace(3)** %in_res_result_ptr
+  store i1 0, i1* %in_res_flag_ptr
+  ret {i8 addrspace(3)*, i1}* %in_res
+}
+
+define {i8 addrspace(3)*, i1}* @__system_delegatecall(i256 %abi_params, i256 %address, i256 %p0, i256 %p1, {i8 addrspace(3)*, i1}* %in_res) personality i32 ()* @__personality {
 entry:
   %in_res_result_ptr = getelementptr {i8 addrspace(3)*, i1}, {i8 addrspace(3)*, i1}* %in_res, i32 0, i32 0
   %in_res_flag_ptr = getelementptr {i8 addrspace(3)*, i1}, {i8 addrspace(3)*, i1}* %in_res, i32 0, i32 1
@@ -409,6 +428,184 @@ err:
   ret {i8 addrspace(3)*, i1}* %in_res
 }
 
+define {i8 addrspace(3)*, i1}* @__system_mimiccall(i256 %abi_params, i256 %address, i256 %p0, i256 %p1, i256 %mimic, {i8 addrspace(3)*, i1}* %in_res) personality i32 ()* @__personality {
+entry:
+  %in_res_result_ptr = getelementptr {i8 addrspace(3)*, i1}, {i8 addrspace(3)*, i1}* %in_res, i32 0, i32 0
+  %in_res_flag_ptr = getelementptr {i8 addrspace(3)*, i1}, {i8 addrspace(3)*, i1}* %in_res, i32 0, i32 1
+  %invoke_res = invoke i8 addrspace(3)* @__mimiccall_int_l(i256 %abi_params, i256 %address, i256 %p0, i256 %p1, i256 %mimic)
+    to label %ok unwind label %err
+ok:
+  store i8 addrspace(3)* %invoke_res, i8 addrspace(3)** %in_res_result_ptr
+  store i1 1, i1* %in_res_flag_ptr
+  ret {i8 addrspace(3)*, i1}* %in_res
+
+err:
+  %res.2 = landingpad {i8 addrspace(3)*, i256} cleanup
+  %res = extractvalue {i8 addrspace(3)*, i256} %res.2, 0
+  store i8 addrspace(3)* %res, i8 addrspace(3)** %in_res_result_ptr
+  store i1 0, i1* %in_res_flag_ptr
+  ret {i8 addrspace(3)*, i1}* %in_res
+}
+
+define {i8 addrspace(3)*, i1}* @__farcall_byref(i8 addrspace(3)* %abi_params.r, i256 %address, {i8 addrspace(3)*, i1}* %in_res) personality i32 ()* @__personality {
+entry:
+  %abi_params = ptrtoint i8 addrspace(3)* %abi_params.r to i256
+  %in_res_result_ptr = getelementptr {i8 addrspace(3)*, i1}, {i8 addrspace(3)*, i1}* %in_res, i32 0, i32 0
+  %in_res_flag_ptr = getelementptr {i8 addrspace(3)*, i1}, {i8 addrspace(3)*, i1}* %in_res, i32 0, i32 1
+  %invoke_res = invoke i8 addrspace(3)* @__farcall_int(i256 %abi_params, i256 %address)
+    to label %ok unwind label %err
+ok:
+  store i8 addrspace(3)* %invoke_res, i8 addrspace(3)** %in_res_result_ptr
+  store i1 1, i1* %in_res_flag_ptr
+  ret {i8 addrspace(3)*, i1}* %in_res
+
+err:
+  %res.2 = landingpad {i8 addrspace(3)*, i256} cleanup
+  %res = extractvalue {i8 addrspace(3)*, i256} %res.2, 0
+  store i8 addrspace(3)* %res, i8 addrspace(3)** %in_res_result_ptr
+  store i1 0, i1* %in_res_flag_ptr
+  ret {i8 addrspace(3)*, i1}* %in_res
+}
+
+define {i8 addrspace(3)*, i1}* @__staticcall_byref(i8 addrspace(3)* %abi_params.r, i256 %address, {i8 addrspace(3)*, i1}* %in_res) personality i32 ()* @__personality {
+entry:
+  %abi_params = ptrtoint i8 addrspace(3)* %abi_params.r to i256
+  %in_res_result_ptr = getelementptr {i8 addrspace(3)*, i1}, {i8 addrspace(3)*, i1}* %in_res, i32 0, i32 0
+  %in_res_flag_ptr = getelementptr {i8 addrspace(3)*, i1}, {i8 addrspace(3)*, i1}* %in_res, i32 0, i32 1
+  %invoke_res = invoke i8 addrspace(3)* @__staticcall_int(i256 %abi_params, i256 %address)
+    to label %ok unwind label %err
+ok:
+  store i8 addrspace(3)* %invoke_res, i8 addrspace(3)** %in_res_result_ptr
+  store i1 1, i1* %in_res_flag_ptr
+  ret {i8 addrspace(3)*, i1}* %in_res
+
+err:
+  %res.2 = landingpad {i8 addrspace(3)*, i256} cleanup
+  %res = extractvalue {i8 addrspace(3)*, i256} %res.2, 0
+  store i8 addrspace(3)* %res, i8 addrspace(3)** %in_res_result_ptr
+  store i1 0, i1* %in_res_flag_ptr
+  ret {i8 addrspace(3)*, i1}* %in_res
+}
+
+define {i8 addrspace(3)*, i1}* @__delegatecall_byref(i8 addrspace(3)* %abi_params.r, i256 %address, {i8 addrspace(3)*, i1}* %in_res) personality i32 ()* @__personality {
+entry:
+  %abi_params = ptrtoint i8 addrspace(3)* %abi_params.r to i256
+  %in_res_result_ptr = getelementptr {i8 addrspace(3)*, i1}, {i8 addrspace(3)*, i1}* %in_res, i32 0, i32 0
+  %in_res_flag_ptr = getelementptr {i8 addrspace(3)*, i1}, {i8 addrspace(3)*, i1}* %in_res, i32 0, i32 1
+  %invoke_res = invoke i8 addrspace(3)* @__delegatecall_int(i256 %abi_params, i256 %address)
+    to label %ok unwind label %err
+ok:
+  store i8 addrspace(3)* %invoke_res, i8 addrspace(3)** %in_res_result_ptr
+  store i1 1, i1* %in_res_flag_ptr
+  ret {i8 addrspace(3)*, i1}* %in_res
+
+err:
+  %res.2 = landingpad {i8 addrspace(3)*, i256} cleanup
+  %res = extractvalue {i8 addrspace(3)*, i256} %res.2, 0
+  store i8 addrspace(3)* %res, i8 addrspace(3)** %in_res_result_ptr
+  store i1 0, i1* %in_res_flag_ptr
+  ret {i8 addrspace(3)*, i1}* %in_res
+}
+
+define {i8 addrspace(3)*, i1}* @__mimiccall_byref(i8 addrspace(3)* %abi_params.r, i256 %address, i256 %mimic, {i8 addrspace(3)*, i1}* %in_res) personality i32 ()* @__personality {
+entry:
+  %abi_params = ptrtoint i8 addrspace(3)* %abi_params.r to i256
+  %in_res_result_ptr = getelementptr {i8 addrspace(3)*, i1}, {i8 addrspace(3)*, i1}* %in_res, i32 0, i32 0
+  %in_res_flag_ptr = getelementptr {i8 addrspace(3)*, i1}, {i8 addrspace(3)*, i1}* %in_res, i32 0, i32 1
+  %invoke_res = invoke i8 addrspace(3)* @__mimiccall_int(i256 %abi_params, i256 %address, i256 %mimic)
+    to label %ok unwind label %err
+ok:
+  store i8 addrspace(3)* %invoke_res, i8 addrspace(3)** %in_res_result_ptr
+  store i1 1, i1* %in_res_flag_ptr
+  ret {i8 addrspace(3)*, i1}* %in_res
+
+err:
+  %res.2 = landingpad {i8 addrspace(3)*, i256} cleanup
+  %res = extractvalue {i8 addrspace(3)*, i256} %res.2, 0
+  store i8 addrspace(3)* %res, i8 addrspace(3)** %in_res_result_ptr
+  store i1 0, i1* %in_res_flag_ptr
+  ret {i8 addrspace(3)*, i1}* %in_res
+}
+
+define {i8 addrspace(3)*, i1}* @__system_call_byref(i8 addrspace(3)* %abi_params.r, i256 %address, i256 %p0, i256 %p1, {i8 addrspace(3)*, i1}* %in_res) personality i32 ()* @__personality {
+entry:
+  %abi_params = ptrtoint i8 addrspace(3)* %abi_params.r to i256
+  %in_res_result_ptr = getelementptr {i8 addrspace(3)*, i1}, {i8 addrspace(3)*, i1}* %in_res, i32 0, i32 0
+  %in_res_flag_ptr = getelementptr {i8 addrspace(3)*, i1}, {i8 addrspace(3)*, i1}* %in_res, i32 0, i32 1
+  %invoke_res = invoke i8 addrspace(3)* @__farcall_int_l(i256 %abi_params, i256 %address, i256 %p0, i256 %p1)
+    to label %ok unwind label %err
+ok:
+  store i8 addrspace(3)* %invoke_res, i8 addrspace(3)** %in_res_result_ptr
+  store i1 1, i1* %in_res_flag_ptr
+  ret {i8 addrspace(3)*, i1}* %in_res
+
+err:
+  %res.2 = landingpad {i8 addrspace(3)*, i256} cleanup
+  %res = extractvalue {i8 addrspace(3)*, i256} %res.2, 0
+  store i8 addrspace(3)* %res, i8 addrspace(3)** %in_res_result_ptr
+  store i1 0, i1* %in_res_flag_ptr
+  ret {i8 addrspace(3)*, i1}* %in_res
+}
+
+define {i8 addrspace(3)*, i1}* @__system_staticcall_byref(i8 addrspace(3)* %abi_params.r, i256 %address, i256 %p0, i256 %p1, {i8 addrspace(3)*, i1}* %in_res) personality i32 ()* @__personality {
+entry:
+  %abi_params = ptrtoint i8 addrspace(3)* %abi_params.r to i256
+  %in_res_result_ptr = getelementptr {i8 addrspace(3)*, i1}, {i8 addrspace(3)*, i1}* %in_res, i32 0, i32 0
+  %in_res_flag_ptr = getelementptr {i8 addrspace(3)*, i1}, {i8 addrspace(3)*, i1}* %in_res, i32 0, i32 1
+  %invoke_res = invoke i8 addrspace(3)* @__staticcall_int_l(i256 %abi_params, i256 %address, i256 %p0, i256 %p1)
+    to label %ok unwind label %err
+ok:
+  store i8 addrspace(3)* %invoke_res, i8 addrspace(3)** %in_res_result_ptr
+  store i1 1, i1* %in_res_flag_ptr
+  ret {i8 addrspace(3)*, i1}* %in_res
+
+err:
+  %res.2 = landingpad {i8 addrspace(3)*, i256} cleanup
+  %res = extractvalue {i8 addrspace(3)*, i256} %res.2, 0
+  store i8 addrspace(3)* %res, i8 addrspace(3)** %in_res_result_ptr
+  store i1 0, i1* %in_res_flag_ptr
+  ret {i8 addrspace(3)*, i1}* %in_res
+}
+
+define {i8 addrspace(3)*, i1}* @__system_delegatecall_byref(i8 addrspace(3)* %abi_params.r, i256 %address, i256 %p0, i256 %p1, {i8 addrspace(3)*, i1}* %in_res) personality i32 ()* @__personality {
+entry:
+  %abi_params = ptrtoint i8 addrspace(3)* %abi_params.r to i256
+  %in_res_result_ptr = getelementptr {i8 addrspace(3)*, i1}, {i8 addrspace(3)*, i1}* %in_res, i32 0, i32 0
+  %in_res_flag_ptr = getelementptr {i8 addrspace(3)*, i1}, {i8 addrspace(3)*, i1}* %in_res, i32 0, i32 1
+  %invoke_res = invoke i8 addrspace(3)* @__delegatecall_int_l(i256 %abi_params, i256 %address, i256 %p0, i256 %p1)
+    to label %ok unwind label %err
+ok:
+  store i8 addrspace(3)* %invoke_res, i8 addrspace(3)** %in_res_result_ptr
+  store i1 1, i1* %in_res_flag_ptr
+  ret {i8 addrspace(3)*, i1}* %in_res
+
+err:
+  %res.2 = landingpad {i8 addrspace(3)*, i256} cleanup
+  %res = extractvalue {i8 addrspace(3)*, i256} %res.2, 0
+  store i8 addrspace(3)* %res, i8 addrspace(3)** %in_res_result_ptr
+  store i1 0, i1* %in_res_flag_ptr
+  ret {i8 addrspace(3)*, i1}* %in_res
+}
+
+define {i8 addrspace(3)*, i1}* @__system_mimiccall_byref(i8 addrspace(3)* %abi_params.r, i256 %address, i256 %p0, i256 %p1, i256 %mimic, {i8 addrspace(3)*, i1}* %in_res) personality i32 ()* @__personality {
+entry:
+  %abi_params = ptrtoint i8 addrspace(3)* %abi_params.r to i256
+  %in_res_result_ptr = getelementptr {i8 addrspace(3)*, i1}, {i8 addrspace(3)*, i1}* %in_res, i32 0, i32 0
+  %in_res_flag_ptr = getelementptr {i8 addrspace(3)*, i1}, {i8 addrspace(3)*, i1}* %in_res, i32 0, i32 1
+  %invoke_res = invoke i8 addrspace(3)* @__mimiccall_int_l(i256 %abi_params, i256 %address, i256 %p0, i256 %p1, i256 %mimic)
+    to label %ok unwind label %err
+ok:
+  store i8 addrspace(3)* %invoke_res, i8 addrspace(3)** %in_res_result_ptr
+  store i1 1, i1* %in_res_flag_ptr
+  ret {i8 addrspace(3)*, i1}* %in_res
+
+err:
+  %res.2 = landingpad {i8 addrspace(3)*, i256} cleanup
+  %res = extractvalue {i8 addrspace(3)*, i256} %res.2, 0
+  store i8 addrspace(3)* %res, i8 addrspace(3)** %in_res_result_ptr
+  store i1 0, i1* %in_res_flag_ptr
+  ret {i8 addrspace(3)*, i1}* %in_res
+}
 define void @__sstore(i256 %val, i256 %key) {
   call void @llvm.syncvm.sstore(i256 %key, i256 %val)
   ret void
@@ -509,9 +706,11 @@ declare i256 @llvm.syncvm.iflt(i256, i256)
 declare i8 addrspace(3)* @__farcall_int(i256, i256)
 declare i8 addrspace(3)* @__farcall_int_l(i256, i256, i256, i256)
 declare i8 addrspace(3)* @__staticcall_int(i256, i256)
+declare i8 addrspace(3)* @__staticcall_int_l(i256, i256, i256, i256)
 declare i8 addrspace(3)* @__delegatecall_int(i256, i256)
 declare i8 addrspace(3)* @__delegatecall_int_l(i256, i256, i256, i256)
 declare i8 addrspace(3)* @__mimiccall_int(i256, i256, i256)
+declare i8 addrspace(3)* @__mimiccall_int_l(i256, i256, i256, i256, i256)
 declare i32 @__personality()
 
 attributes #0 = { nounwind readnone }

--- a/llvm/test/CodeGen/SyncVM/calling-convensions.ll
+++ b/llvm/test/CodeGen/SyncVM/calling-convensions.ll
@@ -431,6 +431,21 @@ define i256 @callee_small_argtypes(i1 %a1, i2 %a2, i8 %a8, i16 %a16, i32 %a32, i
   ret i256 %x7
 }
 
+; CHECK-LABEL: fat.ptr.arg
+define void @fat.ptr.arg(i256 addrspace(3)* %ptr) {
+  %slot = alloca i256 addrspace(3)*
+  ; CHECK: ptr.add r1, r0, stack-[1]
+  store i256 addrspace(3)* %ptr, i256 addrspace(3)** %slot
+  ret void
+}
+
+; CHECK-LABEL: fat.ptr.call
+define void @fat.ptr.call(i256 %a1, i256 addrspace(3)* %ptr) {
+  ; CHECK: add r2, r0, r1
+  call void @fat.ptr.arg(i256 addrspace(3)* %ptr)
+  ret void
+}
+
 declare i256 @i1.arg(i1 %a1) nounwind
 declare i256 @i8.arg(i8 %a1) nounwind
 declare i256 @i16.arg(i16 %a1) nounwind

--- a/llvm/test/CodeGen/SyncVM/intrinsic.ll
+++ b/llvm/test/CodeGen/SyncVM/intrinsic.ll
@@ -201,15 +201,216 @@ define i256 @ifgtii() {
 
 ; CHECK-LABEL: invoke.farcall
 define void @invoke.farcall({i256, i1}* %res) {
+  ; CHECK: near_call r0, @__farcall, @DEFAULT_UNWIND
   call {i256, i1}* @__farcall(i256 0, i256 0, {i256, i1}* %res)
   ret void
 }
 
-; CHECK-LABEL: invoke.systemcall
-define void @invoke.systemcall({i256, i1}* %res) {
-  call {i256, i1}* @__systemcall(i256 0, i256 1, i256 2, i256 3, {i256, i1}* %res)
+; CHECK-LABEL: invoke.staticcall
+define void @invoke.staticcall({i256, i1}* %res) {
+  ; CHECK: near_call r0, @__staticcall, @DEFAULT_UNWIND
+  call {i256, i1}* @__staticcall(i256 0, i256 0, {i256, i1}* %res)
   ret void
 }
+
+; CHECK-LABEL: invoke.delegatecall
+define void @invoke.delegatecall({i256, i1}* %res) {
+  ; CHECK: near_call r0, @__delegatecall, @DEFAULT_UNWIND
+  call {i256, i1}* @__delegatecall(i256 0, i256 0, {i256, i1}* %res)
+  ret void
+}
+
+; CHECK-LABEL: invoke.mimiccall
+define void @invoke.mimiccall({i256, i1}* %res) {
+  ; CHECK: near_call r0, @__mimiccall, @DEFAULT_UNWIND
+  call {i256, i1}* @__mimiccall(i256 0, i256 0, i256 0, {i256, i1}* %res)
+  ret void
+}
+
+; CHECK-LABEL: invoke.system_call
+define void @invoke.system_call({i256, i1}* %res) {
+  ; CHECK: near_call r0, @__system_call, @DEFAULT_UNWIND
+  call {i256, i1}* @__system_call(i256 0, i256 1, i256 2, i256 3, {i256, i1}* %res)
+  ret void
+}
+
+; CHECK-LABEL: invoke.system_staticcall
+define void @invoke.system_staticcall({i256, i1}* %res) {
+  ; CHECK: near_call r0, @__system_staticcall, @DEFAULT_UNWIND
+  call {i256, i1}* @__system_staticcall(i256 0, i256 1, i256 2, i256 3, {i256, i1}* %res)
+  ret void
+}
+
+; CHECK-LABEL: invoke.system_delegatecall
+define void @invoke.system_delegatecall({i256, i1}* %res) {
+  ; CHECK: near_call r0, @__system_delegatecall, @DEFAULT_UNWIND
+  call {i256, i1}* @__system_delegatecall(i256 0, i256 1, i256 2, i256 3, {i256, i1}* %res)
+  ret void
+}
+
+; CHECK-LABEL: invoke.system_mimiccall
+define void @invoke.system_mimiccall({i256, i1}* %res) {
+  ; CHECK: near_call r0, @__system_mimiccall, @DEFAULT_UNWIND
+  call {i256, i1}* @__system_mimiccall(i256 0, i256 1, i256 2, i256 3, i256 4, {i256, i1}* %res)
+  ret void
+}
+
+; CHECK-LABEL: invoke.farcall_byref
+define void @invoke.farcall_byref({i256, i1}* %res, i8 addrspace(3)* %a1) {
+  ; CHECK: ptr.add r2, r0, r1
+  ; CHECK: near_call r0, @__farcall_byref, @DEFAULT_UNWIND
+  call {i256, i1}* @__farcall_byref(i8 addrspace(3)* %a1, i256 0, {i256, i1}* %res)
+  ret void
+}
+
+; CHECK-LABEL: invoke.staticcall_byref
+define void @invoke.staticcall_byref({i256, i1}* %res, i8 addrspace(3)* %a1) {
+  ; CHECK: near_call r0, @__staticcall_byref, @DEFAULT_UNWIND
+  call {i256, i1}* @__staticcall_byref(i8 addrspace(3)* %a1, i256 0, {i256, i1}* %res)
+  ret void
+}
+
+; CHECK-LABEL: invoke.delegatecall_byref
+define void @invoke.delegatecall_byref({i256, i1}* %res, i8 addrspace(3)* %a1) {
+  ; CHECK: near_call r0, @__delegatecall_byref, @DEFAULT_UNWIND
+  call {i256, i1}* @__delegatecall_byref(i8 addrspace(3)* %a1, i256 0, {i256, i1}* %res)
+  ret void
+}
+
+; CHECK-LABEL: invoke.mimiccall_byref
+define void @invoke.mimiccall_byref({i256, i1}* %res, i8 addrspace(3)* %a1) {
+  ; CHECK: near_call r0, @__mimiccall_byref, @DEFAULT_UNWIND
+  call {i256, i1}* @__mimiccall_byref(i8 addrspace(3)* %a1, i256 0, i256 0, {i256, i1}* %res)
+  ret void
+}
+
+; CHECK-LABEL: invoke.system_call_byref
+define void @invoke.system_call_byref({i256, i1}* %res, i8 addrspace(3)* %a1) {
+  ; CHECK: near_call r0, @__system_call_byref, @DEFAULT_UNWIND
+  call {i256, i1}* @__system_call_byref(i8 addrspace(3)* %a1, i256 1, i256 2, i256 3, {i256, i1}* %res)
+  ret void
+}
+
+; CHECK-LABEL: invoke.system_staticcall_byref
+define void @invoke.system_staticcall_byref({i256, i1}* %res, i8 addrspace(3)* %a1) {
+  ; CHECK: near_call r0, @__system_staticcall_byref, @DEFAULT_UNWIND
+  call {i256, i1}* @__system_staticcall_byref(i8 addrspace(3)* %a1, i256 1, i256 2, i256 3, {i256, i1}* %res)
+  ret void
+}
+
+; CHECK-LABEL: invoke.system_delegatecall_byref
+define void @invoke.system_delegatecall_byref({i256, i1}* %res, i8 addrspace(3)* %a1) {
+  ; CHECK: near_call r0, @__system_delegatecall_byref, @DEFAULT_UNWIND
+  call {i256, i1}* @__system_delegatecall_byref(i8 addrspace(3)* %a1, i256 1, i256 2, i256 3, {i256, i1}* %res)
+  ret void
+}
+
+; CHECK-LABEL: invoke.system_mimiccall_byref
+define void @invoke.system_mimiccall_byref({i256, i1}* %res, i8 addrspace(3)* %a1) {
+  ; CHECK: near_call r0, @__system_mimiccall_byref, @DEFAULT_UNWIND
+  call {i256, i1}* @__system_mimiccall_byref(i8 addrspace(3)* %a1, i256 1, i256 2, i256 3, i256 4, {i256, i1}* %res)
+  ret void
+}
+
+; CHECK-LABEL: __farcall
+; CHECK-NOT: r1
+; CHECK-NOT: r2
+; CHECK: far_call r1, r2
+
+; CHECK-LABEL: __staticcall
+; CHECK-NOT: r1
+; CHECK-NOT: r2
+; CHECK: far_call.static r1, r2
+
+; CHECK-LABEL: __delegatecall
+; CHECK-NOT: r1
+; CHECK-NOT: r2
+; CHECK: far_call.delegate r1, r2
+
+; CHECK-LABEL: __mimiccall
+; CHECK-NOT: r1
+; CHECK-NOT: r2
+; CHECK-NOT: r3
+; CHECK: far_call.mimic r1, r2
+
+; CHECK-LABEL: __system_call
+; CHECK-NOT: r1
+; CHECK-NOT: r2
+; CHECK-NOT: r3
+; CHECK-NOT: r4
+; CHECK: far_call r1, r2
+
+; CHECK-LABEL: __system_staticcall
+; CHECK-NOT: r1
+; CHECK-NOT: r2
+; CHECK-NOT: r3
+; CHECK-NOT: r4
+; CHECK: far_call.static r1, r2
+
+; CHECK-LABEL: __system_delegatecall
+; CHECK-NOT: r1
+; CHECK-NOT: r2
+; CHECK-NOT: r3
+; CHECK-NOT: r4
+; CHECK: far_call.delegate r1, r2
+
+; CHECK-LABEL: __system_mimiccall
+; CHECK-NOT: r1
+; CHECK-NOT: r2
+; CHECK-NOT: r3
+; CHECK-NOT: r4
+; CHECK-NOT: r5
+; CHECK: far_call.mimic r1, r2
+
+; CHECK-LABEL: __farcall_byref
+; CHECK-NOT: r1
+; CHECK-NOT: r2
+; CHECK: far_call r1, r2
+
+; CHECK-LABEL: __staticcall_byref
+; CHECK-NOT: r1
+; CHECK-NOT: r2
+; CHECK: far_call.static r1, r2
+
+; CHECK-LABEL: __delegatecall_byref
+; CHECK-NOT: r1
+; CHECK-NOT: r2
+; CHECK: far_call.delegate r1, r2
+
+; CHECK-LABEL: __mimiccall_byref
+; CHECK-NOT: r1
+; CHECK-NOT: r2
+; CHECK-NOT: r3
+; CHECK: far_call.mimic r1, r2
+
+; CHECK-LABEL: __system_call_byref
+; CHECK-NOT: r1
+; CHECK-NOT: r2
+; CHECK-NOT: r3
+; CHECK-NOT: r4
+; CHECK: far_call r1, r2
+
+; CHECK-LABEL: __system_staticcall_byref
+; CHECK-NOT: r1
+; CHECK-NOT: r2
+; CHECK-NOT: r3
+; CHECK-NOT: r4
+; CHECK: far_call.static r1, r2
+
+; CHECK-LABEL: __system_delegatecall_byref
+; CHECK-NOT: r1
+; CHECK-NOT: r2
+; CHECK-NOT: r3
+; CHECK-NOT: r4
+; CHECK: far_call.delegate r1, r2
+
+; CHECK-LABEL: __system_mimiccall_byref
+; CHECK-NOT: r1
+; CHECK-NOT: r2
+; CHECK-NOT: r3
+; CHECK-NOT: r4
+; CHECK-NOT: r5
+; CHECK: far_call.mimic r1, r2
 
 declare i8* @llvm.stacksave()
 declare void @llvm.stackrestore(i8*)
@@ -237,4 +438,19 @@ declare i256 @llvm.syncvm.iflt(i256, i256)
 declare i256 @llvm.syncvm.ifgt(i256, i256)
 
 declare {i256, i1}* @__farcall(i256, i256, {i256, i1}*)
-declare {i256, i1}* @__systemcall(i256, i256, i256, i256, {i256, i1}*)
+declare {i256, i1}* @__staticcall(i256, i256, {i256, i1}*)
+declare {i256, i1}* @__delegatecall(i256, i256, {i256, i1}*)
+declare {i256, i1}* @__mimiccall(i256, i256, i256, {i256, i1}*)
+declare {i256, i1}* @__system_call(i256, i256, i256, i256, {i256, i1}*)
+declare {i256, i1}* @__system_staticcall(i256, i256, i256, i256, {i256, i1}*)
+declare {i256, i1}* @__system_delegatecall(i256, i256, i256, i256, {i256, i1}*)
+declare {i256, i1}* @__system_mimiccall(i256, i256, i256, i256, i256, {i256, i1}*)
+
+declare {i256, i1}* @__farcall_byref(i8 addrspace(3)*, i256, {i256, i1}*)
+declare {i256, i1}* @__staticcall_byref(i8 addrspace(3)*, i256, {i256, i1}*)
+declare {i256, i1}* @__delegatecall_byref(i8 addrspace(3)*, i256, {i256, i1}*)
+declare {i256, i1}* @__mimiccall_byref(i8 addrspace(3)*, i256, i256, {i256, i1}*)
+declare {i256, i1}* @__system_call_byref(i8 addrspace(3)*, i256, i256, i256, {i256, i1}*)
+declare {i256, i1}* @__system_staticcall_byref(i8 addrspace(3)*, i256, i256, i256, {i256, i1}*)
+declare {i256, i1}* @__system_delegatecall_byref(i8 addrspace(3)*, i256, i256, i256, {i256, i1}*)
+declare {i256, i1}* @__system_mimiccall_byref(i8 addrspace(3)*, i256, i256, i256, i256, {i256, i1}*)


### PR DESCRIPTION
* Make a copy of each far call runtime function and make each copy to take i8 addrspace(3)* as the first argument.
* Handle COPY from a function parameter to a register when the parameter is a generic pointer.