### PR TITLE
Remove the Homebrew installation of cmake

### DIFF
--- a/build_gnu.sh
+++ b/build_gnu.sh
@@ -8,10 +8,6 @@ TARGET_BUILD="${ROOT_DIR}/build-target/"
 TARGET_INSTALL='/opt/llvm-release/'
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
-    if [[ -z ${CI_RUNNING+x} ]]; then
-        brew update
-        brew install cmake
-    fi
 
     cmake \
         -S 'llvm' \


### PR DESCRIPTION
when running on MacOS not under CI.
This now fails as the script runs under sudo, and the Building wiki already requires cmake.
I’m too new to know how to test this thoroughly, but it couldn’t have worked on Macintosh, and should have no effect except on MacOS not under CI.