### PR TITLE
Fix B0-related fat pointer failures

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineInstrBuilder.h
+++ b/llvm/include/llvm/CodeGen/MachineInstrBuilder.h
@@ -485,6 +485,15 @@ MachineInstrBuilder BuildMI(MachineBasicBlock &BB,
                             ArrayRef<MachineOperand> MOs,
                             const MDNode *Variable, const MDNode *Expr);
 
+// SyncVM local begin
+/// This helper function builds a COPY instruction. And if it is a fat pointer
+/// copy, it will also tag the instruction to notify our backend to emit
+/// corresponding instructions.
+MachineInstrBuilder BuildCOPY(MachineBasicBlock &BB,
+                              MachineBasicBlock::iterator I, const DebugLoc &DL,
+                              const TargetInstrInfo *TII, Register DestReg);
+// SyncVM local end
+
 /// Clone a DBG_VALUE whose value has been spilled to FrameIndex.
 MachineInstr *buildDbgValueForSpill(MachineBasicBlock &BB,
                                     MachineBasicBlock::iterator I,

--- a/llvm/include/llvm/CodeGen/TargetInstrInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetInstrInfo.h
@@ -191,10 +191,8 @@ private:
 
 public:
   // SyncVM local begin
-  virtual void tagFatPointerCopy(MachineInstr &MI) const {
-    llvm_unreachable("Target does not support fat pointers");
-  }
-  // SyncVM local end  
+  virtual void tagFatPointerCopy(MachineInstr&) const {}
+  // SyncVM local end
   /// These methods return the opcode of the frame setup/destroy instructions
   /// if they exist (-1 otherwise).  Some targets use pseudo instructions in
   /// order to abstract away the difference between operating with a frame

--- a/llvm/lib/CodeGen/EarlyIfConversion.cpp
+++ b/llvm/lib/CodeGen/EarlyIfConversion.cpp
@@ -620,8 +620,9 @@ void SSAIfConv::replacePHIInstrs() {
     if (hasSameValue(*MRI, TII, PI.TReg, PI.FReg)) {
       // We do not need the select instruction if both incoming values are
       // equal, but we do need a COPY.
-      BuildMI(*Head, FirstTerm, HeadDL, TII->get(TargetOpcode::COPY), DstReg)
-          .addReg(PI.TReg);
+      // SyncVM local begin
+      BuildCOPY(*Head, FirstTerm, HeadDL, TII, DstReg).addReg(PI.TReg);
+      // SyncVM local end
     } else {
       TII->insertSelect(*Head, FirstTerm, HeadDL, DstReg, Cond, PI.TReg,
                         PI.FReg);

--- a/llvm/lib/CodeGen/MachineBasicBlock.cpp
+++ b/llvm/lib/CodeGen/MachineBasicBlock.cpp
@@ -623,8 +623,10 @@ MachineBasicBlock::addLiveIn(MCRegister PhysReg, const TargetRegisterClass *RC) 
 
   // No luck, create a virtual register.
   Register VirtReg = MRI.createVirtualRegister(RC);
-  BuildMI(*this, I, DebugLoc(), TII.get(TargetOpcode::COPY), VirtReg)
-    .addReg(PhysReg, RegState::Kill);
+  // SyncVM local begin
+  BuildCOPY(*this, I, DebugLoc(), &TII, VirtReg)
+      .addReg(PhysReg, RegState::Kill);
+  // SyncVM local end
   if (!LiveIn)
     addLiveIn(PhysReg);
   return VirtReg;

--- a/llvm/lib/CodeGen/MachineInstr.cpp
+++ b/llvm/lib/CodeGen/MachineInstr.cpp
@@ -2380,3 +2380,20 @@ unsigned MachineInstr::getDebugInstrNum(MachineFunction &MF) {
     DebugInstrNum = MF.getNewDebugInstrNum();
   return DebugInstrNum;
 }
+
+// SyncVM local begin
+MachineInstrBuilder llvm::BuildCOPY(MachineBasicBlock &BB,
+                                    MachineBasicBlock::iterator I,
+                                    const DebugLoc &DL,
+                                    const TargetInstrInfo *TII,
+                                    Register DestReg) {
+  MachineInstrBuilder MIB =
+      BuildMI(BB, I, DL, TII->get(TargetOpcode::COPY), DestReg);
+  // get triple
+  Triple triple = Triple(BB.getParent()->getTarget().getTargetTriple());
+  if (triple.isSyncVM()) {
+    TII->tagFatPointerCopy(*MIB);
+  }
+  return MIB;
+}
+// SyncVM local end

--- a/llvm/lib/CodeGen/MachinePipeliner.cpp
+++ b/llvm/lib/CodeGen/MachinePipeliner.cpp
@@ -402,9 +402,11 @@ void MachinePipeliner::preprocessPhiNodes(MachineBasicBlock &B) {
       MachineBasicBlock &PredB = *PI.getOperand(i+1).getMBB();
       MachineBasicBlock::iterator At = PredB.getFirstTerminator();
       const DebugLoc &DL = PredB.findDebugLoc(At);
-      auto Copy = BuildMI(PredB, At, DL, TII->get(TargetOpcode::COPY), NewReg)
-                    .addReg(RegOp.getReg(), getRegState(RegOp),
-                            RegOp.getSubReg());
+      // SyncVM local begin
+      auto Copy =
+          BuildCOPY(PredB, At, DL, TII, NewReg)
+              .addReg(RegOp.getReg(), getRegState(RegOp), RegOp.getSubReg());
+      // SyncVM local end
       Slots.insertMachineInstrInMaps(*Copy);
       RegOp.setReg(NewReg);
       RegOp.setSubReg(0);

--- a/llvm/lib/CodeGen/MachineRegisterInfo.cpp
+++ b/llvm/lib/CodeGen/MachineRegisterInfo.cpp
@@ -477,9 +477,11 @@ MachineRegisterInfo::EmitLiveInCopies(MachineBasicBlock *EntryMBB,
         --i; --e;
       } else {
         // Emit a copy.
-        BuildMI(*EntryMBB, EntryMBB->begin(), DebugLoc(),
-                TII.get(TargetOpcode::COPY), LiveIns[i].second)
-          .addReg(LiveIns[i].first);
+        // SyncVM local begin
+        BuildCOPY(*EntryMBB, EntryMBB->begin(), DebugLoc(), &TII,
+                  LiveIns[i].second)
+            .addReg(LiveIns[i].first);
+        // SyncVM local end
 
         // Add the register to the entry block live-in set.
         EntryMBB->addLiveIn(LiveIns[i].first);

--- a/llvm/lib/CodeGen/PeepholeOptimizer.cpp
+++ b/llvm/lib/CodeGen/PeepholeOptimizer.cpp
@@ -603,9 +603,10 @@ optimizeExtInstr(MachineInstr &MI, MachineBasicBlock &MBB,
         RC = MRI->getRegClass(UseMI->getOperand(0).getReg());
 
       Register NewVR = MRI->createVirtualRegister(RC);
-      BuildMI(*UseMBB, UseMI, UseMI->getDebugLoc(),
-              TII->get(TargetOpcode::COPY), NewVR)
-        .addReg(DstReg, 0, SubIdx);
+      // SyncVM local begin
+      BuildCOPY(*UseMBB, UseMI, UseMI->getDebugLoc(), TII, NewVR)
+          .addReg(DstReg, 0, SubIdx);
+      // SyncVM local end
       if (UseSrcSubIdx)
         UseMO->setSubReg(0);
 
@@ -1024,7 +1025,10 @@ public:
       // Get rid of the sub-register index.
       CopyLike.RemoveOperand(2);
       // Morph the operation into a COPY.
+      // SyncVM local begin
       CopyLike.setDesc(TII.get(TargetOpcode::COPY));
+      TII.tagFatPointerCopy(CopyLike);
+      // SyncVM local end
       return true;
     }
     CopyLike.getOperand(CurrentSrcIdx + 1).setImm(NewSubReg);

--- a/llvm/lib/CodeGen/RegAllocFast.cpp
+++ b/llvm/lib/CodeGen/RegAllocFast.cpp
@@ -875,9 +875,10 @@ void RegAllocFast::defineLiveThroughVirtReg(MachineInstr &MI, unsigned OpNum,
         std::next((MachineBasicBlock::iterator)MI.getIterator());
       LLVM_DEBUG(dbgs() << "Copy " << printReg(LRI->PhysReg, TRI) << " to "
                         << printReg(PrevReg, TRI) << '\n');
-      BuildMI(*MBB, InsertBefore, MI.getDebugLoc(),
-              TII->get(TargetOpcode::COPY), PrevReg)
-        .addReg(LRI->PhysReg, llvm::RegState::Kill);
+      // SyncVM local begin
+      BuildCOPY(*MBB, InsertBefore, MI.getDebugLoc(), TII, PrevReg)
+          .addReg(LRI->PhysReg, llvm::RegState::Kill);
+      // SyncVM local end
     }
     MachineOperand &MO = MI.getOperand(OpNum);
     if (MO.getSubReg() && !MO.isUndef()) {

--- a/llvm/lib/CodeGen/RegisterCoalescer.cpp
+++ b/llvm/lib/CodeGen/RegisterCoalescer.cpp
@@ -1199,9 +1199,11 @@ bool RegisterCoalescer::removePartialRedundancy(const CoalescerPair &CP,
                       << printMBBReference(*CopyLeftBB) << '\t' << CopyMI);
 
     // Insert new copy to CopyLeftBB.
-    MachineInstr *NewCopyMI = BuildMI(*CopyLeftBB, InsPos, CopyMI.getDebugLoc(),
-                                      TII->get(TargetOpcode::COPY), IntB.reg())
-                                  .addReg(IntA.reg());
+    // SyncVM local begin
+    MachineInstr *NewCopyMI =
+        BuildCOPY(*CopyLeftBB, InsPos, CopyMI.getDebugLoc(), TII, IntB.reg())
+            .addReg(IntA.reg());
+    // SyncVM local end
     SlotIndex NewCopyIdx =
         LIS->InsertMachineInstrInMaps(*NewCopyMI).getRegSlot();
     IntB.createDeadDef(NewCopyIdx, LIS->getVNInfoAllocator());

--- a/llvm/lib/CodeGen/SelectionDAG/InstrEmitter.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/InstrEmitter.cpp
@@ -176,8 +176,9 @@ EmitCopyFromReg(SDNode *Node, unsigned ResNo, bool IsClone, bool IsCloned,
   } else {
     // Create the reg, emit the copy.
     VRBase = MRI->createVirtualRegister(DstRC);
-    BuildMI(*MBB, InsertPos, Node->getDebugLoc(), TII->get(TargetOpcode::COPY),
-            VRBase).addReg(SrcReg);
+    // SyncVM local begin
+    BuildCOPY(*MBB, InsertPos, Node->getDebugLoc(), TII, VRBase).addReg(SrcReg);
+    // SyncVM local end
   }
 
   SDValue Op(Node, ResNo);
@@ -327,8 +328,10 @@ InstrEmitter::AddRegisterOperand(MachineInstrBuilder &MIB,
         OpRC = TRI->getAllocatableClass(OpRC);
         assert(OpRC && "Constraints cannot be fulfilled for allocation");
         Register NewVReg = MRI->createVirtualRegister(OpRC);
-        BuildMI(*MBB, InsertPos, Op.getNode()->getDebugLoc(),
-                TII->get(TargetOpcode::COPY), NewVReg).addReg(VReg);
+        // SyncVM local begin
+        BuildCOPY(*MBB, InsertPos, Op.getNode()->getDebugLoc(), TII, NewVReg)
+            .addReg(VReg);
+        // SyncVM local end
         VReg = NewVReg;
       } else {
         assert(ConstrainedRC->isAllocatable() &&
@@ -399,8 +402,10 @@ void InstrEmitter::AddOperand(MachineInstrBuilder &MIB,
 
     if (OpRC && IIRC && OpRC != IIRC && Register::isVirtualRegister(VReg)) {
       Register NewVReg = MRI->createVirtualRegister(IIRC);
-      BuildMI(*MBB, InsertPos, Op.getNode()->getDebugLoc(),
-               TII->get(TargetOpcode::COPY), NewVReg).addReg(VReg);
+      // SyncVM local begin
+      BuildCOPY(*MBB, InsertPos, Op.getNode()->getDebugLoc(), TII, NewVReg)
+          .addReg(VReg);
+      // SyncVM local end
       VReg = NewVReg;
     }
     // Turn additional physreg operands into implicit uses on non-variadic
@@ -618,8 +623,9 @@ InstrEmitter::EmitCopyToRegClassNode(SDNode *Node,
   const TargetRegisterClass *DstRC =
     TRI->getAllocatableClass(TRI->getRegClass(DstRCIdx));
   Register NewVReg = MRI->createVirtualRegister(DstRC);
-  BuildMI(*MBB, InsertPos, Node->getDebugLoc(), TII->get(TargetOpcode::COPY),
-    NewVReg).addReg(VReg);
+  // SyncVM local begin
+  BuildCOPY(*MBB, InsertPos, Node->getDebugLoc(), TII, NewVReg).addReg(VReg);
+  // SyncVM local end
 
   SDValue Op(Node, 0);
   bool isNew = VRBaseMap.insert(std::make_pair(Op, NewVReg)).second;
@@ -1167,8 +1173,10 @@ EmitSpecialNode(SDNode *Node, bool IsClone, bool IsCloned,
     if (SrcReg == DestReg) // Coalesced away the copy? Ignore.
       break;
 
-    BuildMI(*MBB, InsertPos, Node->getDebugLoc(), TII->get(TargetOpcode::COPY),
-            DestReg).addReg(SrcReg);
+    // SyncVM local begin
+    BuildCOPY(*MBB, InsertPos, Node->getDebugLoc(), TII, DestReg)
+        .addReg(SrcReg);
+    // SyncVM local end
     break;
   }
   case ISD::CopyFromReg: {

--- a/llvm/lib/CodeGen/SelectionDAG/ScheduleDAGSDNodes.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/ScheduleDAGSDNodes.cpp
@@ -826,8 +826,9 @@ EmitPhysRegCopy(SUnit *SU, DenseMap<SUnit*, Register> &VRBaseMap,
           break;
         }
       }
-      BuildMI(*BB, InsertPos, DebugLoc(), TII->get(TargetOpcode::COPY), Reg)
-        .addReg(VRI->second);
+      // SyncVM local begin
+      BuildCOPY(*BB, InsertPos, DebugLoc(), TII, Reg).addReg(VRI->second);
+      // SyncVM local end
     } else {
       // Copy from physical register.
       assert(Pred.getReg() && "Unknown physical register!");
@@ -835,8 +836,9 @@ EmitPhysRegCopy(SUnit *SU, DenseMap<SUnit*, Register> &VRBaseMap,
       bool isNew = VRBaseMap.insert(std::make_pair(SU, VRBase)).second;
       (void)isNew; // Silence compiler warning.
       assert(isNew && "Node emitted out of order - early");
-      BuildMI(*BB, InsertPos, DebugLoc(), TII->get(TargetOpcode::COPY), VRBase)
-          .addReg(Pred.getReg());
+      // SyncVM local begin
+      BuildCOPY(*BB, InsertPos, DebugLoc(), TII, VRBase).addReg(Pred.getReg());
+      // SyncVM local end
     }
     break;
   }

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -3028,7 +3028,10 @@ void SelectionDAGBuilder::visitLandingPad(const LandingPadInst &LP) {
   if (FuncInfo.ExceptionPointerVirtReg) {
     // SyncVM local begin
     if (ValueVTs[0] == MVT::fatptr) {
-      Ops[0] = DAG.getCopyFromReg(DAG.getEntryNode(), dl, FuncInfo.ExceptionPointerVirtReg, ValueVTs[0]);
+      // SyncVM-specific EH convention: $r1 contains exception pointer
+      Ops[0] = DAG.getRegister(
+          TLI.getRegisterByName("r1", LLT(), DAG.getMachineFunction()),
+          ValueVTs[0]);
     } else {
     // SyncVM local end
     Ops[0] = DAG.getZExtOrTrunc(

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
@@ -1268,9 +1268,10 @@ bool SelectionDAGISel::PrepareEHLandingPad() {
         assert(EHPhysReg && "target lacks exception pointer register");
         MBB->addLiveIn(EHPhysReg);
         unsigned VReg = FuncInfo->getCatchPadExceptionPointerVReg(CPI, PtrRC);
-        BuildMI(*MBB, FuncInfo->InsertPt, SDB->getCurDebugLoc(),
-                TII->get(TargetOpcode::COPY), VReg)
+        // SyncVM local begin
+        BuildCOPY(*MBB, FuncInfo->InsertPt, SDB->getCurDebugLoc(), TII, VReg)
             .addReg(EHPhysReg, RegState::Kill);
+        // SyncVM local end
       }
     }
     return true;

--- a/llvm/lib/CodeGen/TailDuplicator.cpp
+++ b/llvm/lib/CodeGen/TailDuplicator.cpp
@@ -448,9 +448,10 @@ void TailDuplicator::duplicateInstruction(
             if (NewRC == nullptr)
               NewRC = OrigRC;
             Register NewReg = MRI->createVirtualRegister(NewRC);
-            BuildMI(*PredBB, NewMI, NewMI.getDebugLoc(),
-                    TII->get(TargetOpcode::COPY), NewReg)
+            // SyncVM local begin
+            BuildCOPY(*PredBB, NewMI, NewMI.getDebugLoc(), TII, NewReg)
                 .addReg(VI->second.Reg, 0, VI->second.SubReg);
+            // SyncVM local end
             LocalVRMap.erase(VI);
             LocalVRMap.insert(std::make_pair(Reg, RegSubRegPair(NewReg, 0)));
             MO.setReg(NewReg);
@@ -1027,10 +1028,14 @@ void TailDuplicator::appendCopies(MachineBasicBlock *MBB,
       SmallVectorImpl<std::pair<Register, RegSubRegPair>> &CopyInfos,
       SmallVectorImpl<MachineInstr*> &Copies) {
   MachineBasicBlock::iterator Loc = MBB->getFirstTerminator();
-  const MCInstrDesc &CopyD = TII->get(TargetOpcode::COPY);
+  // SyncVM local begin
+  //const MCInstrDesc &CopyD = TII->get(TargetOpcode::COPY);
+  // SyncVM local end
   for (auto &CI : CopyInfos) {
-    auto C = BuildMI(*MBB, Loc, DebugLoc(), CopyD, CI.first)
-                .addReg(CI.second.Reg, 0, CI.second.SubReg);
+    // SyncVM local begin
+    auto C = BuildCOPY(*MBB, Loc, DebugLoc(), TII, CI.first)
+                 .addReg(CI.second.Reg, 0, CI.second.SubReg);
+    // SyncVM local end
     Copies.push_back(C);
   }
 }

--- a/llvm/lib/CodeGen/TwoAddressInstructionPass.cpp
+++ b/llvm/lib/CodeGen/TwoAddressInstructionPass.cpp
@@ -1406,8 +1406,10 @@ TwoAddressInstructionPass::processTiedPairs(MachineInstr *MI,
 #endif
 
     // Emit a copy.
-    MachineInstrBuilder MIB = BuildMI(*MI->getParent(), MI, MI->getDebugLoc(),
-                                      TII->get(TargetOpcode::COPY), RegA);
+    // SyncVM local begin
+    MachineInstrBuilder MIB =
+        BuildCOPY(*MI->getParent(), MI, MI->getDebugLoc(), TII, RegA);
+    // SyncVM local end
     // If this operand is folding a truncation, the truncation now moves to the
     // copy so that the register classes remain valid for the operands.
     MIB.addReg(RegB, 0, SubRegB);
@@ -1696,7 +1698,9 @@ eliminateRegSequence(MachineBasicBlock::iterator &MBBI) {
                                    TII->get(TargetOpcode::COPY))
                                .addReg(DstReg, RegState::Define, SubIdx)
                                .add(UseMO);
-
+    // SyncVM local begin
+    TII->tagFatPointerCopy(*CopyMI);
+    // SyncVM local end
     // The first def needs an undef flag because there is no live register
     // before it.
     if (!DefEmitted) {

--- a/llvm/lib/CodeGen/UnreachableBlockElim.cpp
+++ b/llvm/lib/CodeGen/UnreachableBlockElim.cpp
@@ -189,9 +189,11 @@ bool UnreachableMachineBlockElim::runOnMachineFunction(MachineFunction &F) {
             // insert a COPY instead of simply replacing the output
             // with the input.
             const TargetInstrInfo *TII = F.getSubtarget().getInstrInfo();
-            BuildMI(*BB, BB->getFirstNonPHI(), phi->getDebugLoc(),
-                    TII->get(TargetOpcode::COPY), OutputReg)
+            // SyncVM local begin
+            BuildCOPY(*BB, BB->getFirstNonPHI(), phi->getDebugLoc(), TII,
+                      OutputReg)
                 .addReg(InputReg, getRegState(Input), InputSub);
+            // SyncVM local end
           }
           phi++->eraseFromParent();
         }

--- a/llvm/lib/Target/SyncVM/SyncVMISelLowering.h
+++ b/llvm/lib/Target/SyncVM/SyncVMISelLowering.h
@@ -231,6 +231,9 @@ private:
       return MVT::fatptr;
     return TargetLowering::getPointerTy(DL, AS);
   }
+
+  Register getRegisterByName(const char *RegName, LLT VT,
+                             const MachineFunction &MF) const override;
 };
 } // namespace llvm
 

--- a/llvm/lib/Target/SyncVM/SyncVMInstrInfo.h
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrInfo.h
@@ -87,7 +87,7 @@ public:
   bool isSilent(const MachineInstr &MI) const;
   GenericInstruction genericInstructionFor(const MachineInstr &MI) const;
 
-  void tagFatPointerCopy(MachineInstr &MI) const override;
+  void tagFatPointerCopy(MachineInstr &) const override;
 };
 
 } // namespace llvm


### PR DESCRIPTION
B0 exposes some fat pointe ruse cases that are not optimized out but cause failures. This patch is an attempt to resolve those issues.