### PR TITLE
NFC Prevent early isel in CopyFromReg

### DIFF
--- a/llvm/lib/Target/SyncVM/SyncVMISelLowering.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMISelLowering.cpp
@@ -101,8 +101,6 @@ SyncVMTargetLowering::SyncVMTargetLowering(const TargetMachine &TM,
   setOperationAction(ISD::ZERO_EXTEND, MVT::i256, Custom);
   setOperationAction(ISD::ANY_EXTEND, MVT::i256, Custom);
 
-  setOperationAction(ISD::CopyFromReg, MVT::fatptr, Custom);
-
   setTargetDAGCombine(ISD::ZERO_EXTEND);
 
   setJumpIsExpensive(false);
@@ -181,8 +179,7 @@ SyncVMTargetLowering::LowerReturn(SDValue Chain, CallingConv::ID CallConv,
     CCValAssign &VA = RVLocs[i];
     assert(VA.isRegLoc() && "Can only return in registers!");
 
-    Chain = DAG.getCopyToReg(Chain, DL, VA.getLocReg(),
-                             OutVals[i], Flag);
+    Chain = DAG.getCopyToReg(Chain, DL, VA.getLocReg(), OutVals[i], Flag);
 
     // Guarantee that all emitted copies are stuck together,
     // avoiding something bad.
@@ -190,7 +187,7 @@ SyncVMTargetLowering::LowerReturn(SDValue Chain, CallingConv::ID CallConv,
     RetOps.push_back(DAG.getRegister(VA.getLocReg(), VA.getLocVT()));
   }
 
-  RetOps[0] = Chain;  // Update chain.
+  RetOps[0] = Chain; // Update chain.
 
   // Add the flag if we have it.
   if (Flag.getNode())
@@ -563,8 +560,6 @@ SDValue SyncVMTargetLowering::LowerOperation(SDValue Op,
     return LowerSTACKSAVE(Op, DAG);
   case ISD::STACKRESTORE:
     return LowerSTACKRESTORE(Op, DAG);
-  case ISD::CopyFromReg:
-    return LowerCopyFromReg(Op, DAG);
   }
 }
 
@@ -816,6 +811,9 @@ SDValue SyncVMTargetLowering::LowerSELECT_CC(SDValue Op,
   return DAG.getNode(SyncVMISD::SELECT_CC, DL, VTs, Ops);
 }
 
+// TODO: CPR-885 Get rid of LowerCopyToReg in ISelLowering
+// It seems an outdated design solution from SyncVM v1.0. We should check if it
+// still needed, and if it is, use BytesToCells pass instead.
 SDValue SyncVMTargetLowering::LowerCopyToReg(SDValue Op,
                                              SelectionDAG &DAG) const {
   SDLoc DL(Op);
@@ -893,21 +891,6 @@ SDValue SyncVMTargetLowering::LowerSTACKRESTORE(SDValue Op,
                      CurrentSP.getValue(1), SPDelta);
 }
 
-SDValue SyncVMTargetLowering::LowerCopyFromReg(SDValue Op,
-                                               SelectionDAG &DAG) const {
-  SDLoc DL(Op);
-
-  if (Op.getSimpleValueType() != MVT::fatptr) {
-    return SDValue();
-  }
-
-  std::vector<SDValue> Ops =
-      makeArrayRef<SDValue>({Op->op_begin(), Op->op_end()});
-
-  SDVTList Tys = Op->getVTList();
-  return DAG.getNode(SyncVMISD::COPY_FROM_PTRREG, DL, Tys, Ops);
-}
-
 void SyncVMTargetLowering::ReplaceNodeResults(SDNode *N,
                                               SmallVectorImpl<SDValue> &Results,
                                               SelectionDAG &DAG) const {
@@ -950,8 +933,9 @@ SDValue SyncVMTargetLowering::PerformDAGCombine(SDNode *N,
   return val;
 }
 
-Register SyncVMTargetLowering::getRegisterByName(const char *RegName, LLT VT,
-                                              const MachineFunction &MF) const {
+Register
+SyncVMTargetLowering::getRegisterByName(const char *RegName, LLT VT,
+                                        const MachineFunction &MF) const {
   Register Reg = StringSwitch<unsigned>(RegName)
                      .Case("r0", SyncVM::R0)
                      .Case("r1", SyncVM::R1)


### PR DESCRIPTION
The patch extends existing COPY tagging logic so that a COPY is tagged
with MIFlag::IsFatPointer if either source or destination is a fat
pointer register. It allows to remove ISelLowering::LowerCopyFromReg
which broke LLVM logic around late lowering of COPY, thus
* Chains and glue are no longer broken after CopyFromReg is lowered
  to a real instruction (ptr.add).
* Register coalescing removes unnecessary fat pointer moves.