### PR TITLE
[CI] Run LLVM Lit tests on CI (fresh branch)

### DIFF
--- a/.github/workflows/compiler-integration-tests.yml
+++ b/.github/workflows/compiler-integration-tests.yml
@@ -107,6 +107,9 @@ jobs:
         if: always() && steps.compiler_tester_run.outcome == 'failure' && env.RUN_SEGFAULT_STEP == 'true'
         run: ${DOCKER_CMD} sh -c 'cd compiler-tester && ./segfault.sh'
 
+      - name: Testing with LLVM Lit.
+        run: ${DOCKER_CMD} sh -c 'cd compiler-llvm && ninja -C build-target check-llvm'
+
       - uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}

--- a/build_gnu.sh
+++ b/build_gnu.sh
@@ -21,7 +21,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
         -DLLVM_TARGETS_TO_BUILD='SyncVM' \
         -DLLVM_DEFAULT_TARGET_TRIPLE='syncvm' \
         -DLLVM_OPTIMIZED_TABLEGEN='On' \
-        -DLLVM_BUILD_TESTS='Off' \
+        -DLLVM_BUILD_TESTS='On' \
         -DLLVM_BUILD_DOCS='Off' \
         -DLLVM_INCLUDE_DOCS='Off' \
         -DLLVM_INCLUDE_TESTS='On' \
@@ -58,10 +58,10 @@ elif [[ -f '/etc/arch-release' ]]; then
         -DLLVM_DEFAULT_TARGET_TRIPLE='syncvm' \
         -DLLVM_OPTIMIZED_TABLEGEN='On' \
         -DLLVM_USE_LINKER='lld' \
-        -DLLVM_BUILD_TESTS='Off' \
+        -DLLVM_BUILD_TESTS='On' \
         -DLLVM_BUILD_DOCS='Off' \
         -DLLVM_INCLUDE_DOCS='Off' \
-        -DLLVM_INCLUDE_TESTS='Off' \
+        -DLLVM_INCLUDE_TESTS='On' \
         -DLLVM_ENABLE_ASSERTIONS='On' \
         -DLLVM_ENABLE_TERMINFO='Off' \
         -DLLVM_ENABLE_DOXYGEN='Off' \
@@ -96,10 +96,10 @@ elif [[ "$OSTYPE" == "linux-gnu" ]]; then
         -DLLVM_DEFAULT_TARGET_TRIPLE='syncvm' \
         -DLLVM_OPTIMIZED_TABLEGEN='On' \
         -DLLVM_USE_LINKER="lld-${LLVM_VERSION}" \
-        -DLLVM_BUILD_TESTS='Off' \
+        -DLLVM_BUILD_TESTS='On' \
         -DLLVM_BUILD_DOCS='Off' \
         -DLLVM_INCLUDE_DOCS='Off' \
-        -DLLVM_INCLUDE_TESTS='Off' \
+        -DLLVM_INCLUDE_TESTS='On' \
         -DLLVM_ENABLE_ASSERTIONS='On' \
         -DLLVM_ENABLE_TERMINFO='Off' \
         -DLLVM_ENABLE_DOXYGEN='Off' \


### PR DESCRIPTION
_(Fresh copy of https://github.com/matter-labs/compiler-llvm/pull/135)_

Run LLVM Lit’s check-llvm tests, in the Integration Tests GitHub Action,
rather than a separate run or one of the broken LLVM Actions, at least for now. It runs 15712 tests in 25.31s; it increases the duration of the integration testing and benchmarking Actions by about two minutes each.