### PR TITLE
[CI] Raise the MacOS deployment target to 11.0.

### DIFF
--- a/build_gnu.sh
+++ b/build_gnu.sh
@@ -32,7 +32,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
         -DLLVM_ENABLE_ZLIB='Off' \
         -DLLVM_ENABLE_LIBXML2='Off' \
         -DLLVM_ENABLE_BINDINGS='Off' \
-        -DCMAKE_OSX_DEPLOYMENT_TARGET='10.9'
+        -DCMAKE_OSX_DEPLOYMENT_TARGET='11.0'
 elif [[ -f '/etc/arch-release' ]]; then
     if [[ -z ${CI_RUNNING+x} ]]; then
         sudo pacman --sync --refresh --sysupgrade --noconfirm \


### PR DESCRIPTION
Our previous value, 10.9, causes an error with our build setup:
>    'shared_mutex' is unavailable: introduced in macOS 10.12
There are ways around this; see https://reviews.llvm.org/D66313, but testing MacOS 11, 12, and 13 seems reasonable.
