### PR TITLE
Link runtime library early

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -5522,7 +5522,12 @@ SDValue SelectionDAG::FoldSymbolOffset(unsigned Opcode, EVT VT,
   auto *C2 = dyn_cast<ConstantSDNode>(N2);
   if (!C2)
     return SDValue();
-  int64_t Offset = C2->getSExtValue();
+    // SyncVM local begin
+    // In case the offset is negative, it overflows 64 bits with SyncVM's i256.
+    // Though the architecture guarantees the offset fits 64 bits wide
+    // signed integer, so it's ok to truncate.
+  int64_t Offset = C2->getAPIntValue().trunc(64).getSExtValue();
+    // SyncVM local end
   switch (Opcode) {
   case ISD::ADD: break;
   case ISD::SUB: Offset = -uint64_t(Offset); break;

--- a/llvm/lib/Target/SyncVM/SyncVM.h
+++ b/llvm/lib/Target/SyncVM/SyncVM.h
@@ -11,6 +11,7 @@
 #include "MCTargetDesc/SyncVMMCTargetDesc.h"
 #include "llvm/CodeGen/MachineOperand.h"
 #include "llvm/IR/Constants.h"
+#include "llvm/IR/PassManager.h"
 #include "llvm/Target/TargetMachine.h"
 
 namespace SyncVMCC {
@@ -73,7 +74,7 @@ ModulePass   *createSyncVMExpandUMAPass();
 ModulePass   *createSyncVMIndirectUMAPass();
 ModulePass   *createSyncVMIndirectExternalCallPass();
 ModulePass   *createSyncVMLowerIntrinsicsPass();
-ModulePass   *createSyncVMLinkRuntimePass();
+ModulePass   *createSyncVMLinkRuntimePass(bool);
 FunctionPass *createSyncVMAddConditionsPass();
 FunctionPass *createSyncVMAllocaHoistingPass();
 FunctionPass *createSyncVMBytesToCellsPass();
@@ -100,6 +101,11 @@ void initializeSyncVMPeepholePass(PassRegistry &);
 void initializeSyncVMPropagateGenericPointersPass(PassRegistry &);
 void initializeSyncVMStackAddressConstantPropagationPass(PassRegistry &);
 void initializeSyncVMCombineFlagSettingPass(PassRegistry &);
+
+struct SyncVMLinkRuntimePass : PassInfoMixin<SyncVMLinkRuntimePass> {
+  SyncVMLinkRuntimePass() {}
+  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+};
 
 } // end namespace llvm;
 

--- a/llvm/lib/Target/SyncVM/SyncVMISelLowering.h
+++ b/llvm/lib/Target/SyncVM/SyncVMISelLowering.h
@@ -180,6 +180,11 @@ public:
     return SyncVM::R1;
   }
 
+  Register
+  getExceptionSelectorRegister(const Constant *PersonalityFn) const override {
+    return SyncVM::R2;
+  }
+
   // MVT::i256 is the only legal type, so DAG combiner should never reduce
   // loads.
   bool shouldReduceLoadWidth(SDNode *Load, ISD::LoadExtType ExtTy,

--- a/llvm/lib/Target/SyncVM/SyncVMLinkRuntime.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMLinkRuntime.cpp
@@ -1,9 +1,23 @@
 //===--- SyncVMLinkRuntime.cpp - inject runtime library into the module ---===//
+//
+/// \file
+/// Implement pass which links runtime (syncvm-runtime.ll).
+/// SyncVM doesn't have a proper linker and all programs consist of a single
+/// module. The pass links the runtime into the program module.
+/// It supposed to be called twice:
+/// * First, in the beginning of optimization pipeline, the pass links
+///   the context of syncvm-runtime.ll and internalize functions that marked
+///   with internalize-early attribute.
+/// * Second, it runs before code generation, and it internalize the rest of
+///   the runtime which is marked with internalize-late. It also wraps invoke
+///   sstore intrinsic inro a runtime call.
+//============================================================================//
 
 #include "llvm/IR/Function.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/IntrinsicsSyncVM.h"
 #include "llvm/IRReader/IRReader.h"
 #include "llvm/Linker/Linker.h"
 #include "llvm/Pass.h"
@@ -24,6 +38,14 @@ void initializeSyncVMLinkRuntimePass(PassRegistry &);
 } // namespace llvm
 
 static ExitOnError ExitOnErr;
+/// The attribute to internalize a runtime function in the beginning of opt
+/// pipeline. Functions that are used directly by a frontend are generally
+/// marked with it.
+static const char INTERNALIZE_EARLY[] = "internalize-early";
+/// The attribute to internalize a runtime function in the beginning of llc
+/// pipeline. LLVM instructions and intrinsics that are lowered to a runtime
+/// call are marked with it.
+static const char INTERNALIZE_LATE[] = "internalize-late";
 
 namespace {
 /// Link the runtime library into the module.
@@ -31,7 +53,8 @@ namespace {
 struct SyncVMLinkRuntime : public ModulePass {
 public:
   static char ID;
-  SyncVMLinkRuntime() : ModulePass(ID) {
+  SyncVMLinkRuntime(bool OnlyInternalize = false)
+      : ModulePass(ID), OnlyInternalize(OnlyInternalize) {
     initializeSyncVMIndirectExternalCallPass(*PassRegistry::getPassRegistry());
   }
   bool runOnModule(Module &M) override;
@@ -45,6 +68,7 @@ public:
   }
 
 private:
+  bool OnlyInternalize;
 };
 } // namespace
 
@@ -55,9 +79,9 @@ INITIALIZE_PASS(SyncVMLinkRuntime, "syncvm-link-runtime",
 
 const char *LL_DATA =
 #include "SyncVMRT.inc"
-;
+    ;
 
-bool SyncVMLinkRuntime::runOnModule(Module &M) {
+static bool SyncVMLinkRuntimeImpl(Module &M) {
   Linker L(M);
   LLVMContext &C = M.getContext();
   unsigned Flags = Linker::Flags::None;
@@ -73,7 +97,13 @@ bool SyncVMLinkRuntime::runOnModule(Module &M) {
   LinkErr = L.linkInModule(
       std::move(RTM), Flags, [](Module &M, const StringSet<> &GVS) {
         internalizeModule(M, [&GVS](const GlobalValue &GV) {
-          return !GV.hasName() || (GVS.count(GV.getName()) == 0);
+          // Keep original symbols as they are
+          if (!GV.hasName() || (GVS.count(GV.getName()) == 0))
+            return true;
+          // Internalize linked-in symbols with "internalize-early" attribute.
+          if (auto *F = llvm::dyn_cast<Function>(&GV))
+            return !F->hasFnAttribute(INTERNALIZE_EARLY);
+          return false;
         });
       });
   if (LinkErr) {
@@ -83,6 +113,61 @@ bool SyncVMLinkRuntime::runOnModule(Module &M) {
   return true;
 }
 
-ModulePass *llvm::createSyncVMLinkRuntimePass() {
-  return new SyncVMLinkRuntime();
+// TODO: CPR-988 Replace with __sstore runtime function.
+static Function *createSStoreFunction(Module &M) {
+  LLVMContext &C = M.getContext();
+  Type *Int256Ty = Type::getInt256Ty(C);
+  std::vector<Type *> ArgTy = {Int256Ty, Int256Ty};
+  M.getOrInsertFunction(
+      "__sstore",
+      FunctionType::get(Type::getVoidTy(C), {Int256Ty, Int256Ty}, false));
+  Function *Result = M.getFunction("__sstore");
+  auto *Entry = BasicBlock::Create(C, "entry", Result);
+  auto *SStoreIntFn = Intrinsic::getDeclaration(&M, Intrinsic::syncvm_sstore);
+
+  IRBuilder<> Builder(Entry);
+  Builder.CreateCall(SStoreIntFn, {Result->getArg(0), Result->getArg(1)});
+  Builder.CreateRetVoid();
+  return Result;
+}
+
+bool SyncVMLinkRuntime::runOnModule(Module &M) {
+  if (!OnlyInternalize)
+    return SyncVMLinkRuntimeImpl(M);
+  bool Changed = internalizeModule(M, [](const GlobalValue &GV) {
+    // Only keep entry public
+    if (!GV.hasName())
+      return true;
+    // Internalize linked-in symbols with "internalize-late" attribute.
+    if (auto *F = llvm::dyn_cast<Function>(&GV))
+      return !F->hasFnAttribute(INTERNALIZE_LATE);
+    return false;
+  });
+  // sstore can throw, so externalize invoke sstore by wrapping into a function.
+  Function *SStoreF = nullptr;
+  for (auto &F : M)
+    for (auto &BB : F)
+      for (auto &I : BB) {
+        auto Invoke = dyn_cast<InvokeInst>(&I);
+        if (!Invoke)
+          continue;
+        Intrinsic::ID IntID = Invoke->getIntrinsicID();
+        if (IntID != Intrinsic::syncvm_sstore)
+          continue;
+        if (!SStoreF)
+          SStoreF = createSStoreFunction(M);
+        Invoke->setCalledFunction(SStoreF);
+        Changed = true;
+      }
+  return Changed;
+}
+
+ModulePass *llvm::createSyncVMLinkRuntimePass(bool OnlyInternalize) {
+  return new SyncVMLinkRuntime(OnlyInternalize);
+}
+
+PreservedAnalyses SyncVMLinkRuntimePass::run(Module &M,
+                                             ModuleAnalysisManager &AM) {
+  SyncVMLinkRuntimeImpl(M);
+  return PreservedAnalyses::all();
 }

--- a/llvm/lib/Target/SyncVM/syncvm-runtime.ll
+++ b/llvm/lib/Target/SyncVM/syncvm-runtime.ll
@@ -70,7 +70,7 @@ entry:
   ret i256 %result
 }
 
-define i256 @__ulongrem(i256 %0, i256 %1, i256 %2) local_unnamed_addr #0 {
+define i256 @__ulongrem(i256 %0, i256 %1, i256 %2) #0 {
   %.not = icmp ult i256 %1, %2
   br i1 %.not, label %4, label %51
 
@@ -190,7 +190,7 @@ slow:
   ret i256 %res
 }
 
-define i256 @__small_load_as0(i256 %addr, i256 %size_in_bits) {
+define i256 @__small_load_as0(i256 %addr, i256 %size_in_bits) #3 {
 entry:
   %offset_lead_bytes = urem i256 %addr, 32
   %offset_lead_bits = mul nuw nsw i256 %offset_lead_bytes, 8
@@ -223,7 +223,7 @@ two_cells:
   ret i256 %two_cells_res
 }
 
-define void @__small_store_as0(i256 %addr, i256 %size_in_bits, i256 %value) {
+define void @__small_store_as0(i256 %addr, i256 %size_in_bits, i256 %value) #3 {
 entry:
   %offset_lead_bytes = urem i256 %addr, 32
   %offset_lead_bits = mul nuw nsw i256 %offset_lead_bytes, 8
@@ -274,13 +274,13 @@ two_cells:
   ret void
 }
 
-define void @__cxa_throw(i8* %addr, i8*, i8*) {
+define void @__cxa_throw(i8* %addr, i8*, i8*) #4 {
   %addrval = ptrtoint i8* %addr to i256
   call void @llvm.syncvm.throw(i256 %addrval)
   unreachable
 }
 
-define i256 @__signextend(i256 %numbyte, i256 %value) #1 {
+define i256 @__signextend(i256 %numbyte, i256 %value) #0 {
   %numbit_byte = mul nuw nsw i256 %numbyte, 8
   %numbit = add nsw nuw i256 %numbit_byte, 7
   %numbit_inv = sub i256 256, %numbit
@@ -295,7 +295,7 @@ define i256 @__signextend(i256 %numbyte, i256 %value) #1 {
   ret i256 %result
 }
 
-define {i8 addrspace(3)*, i1} @__farcall(i256 %abi_params, i256 %address) personality i32 ()* @__personality {
+define {i8 addrspace(3)*, i1} @__farcall(i256 %abi_params, i256 %address) #2 personality i32 ()* @__personality {
 entry:
   %invoke_res = invoke i8 addrspace(3)* @__farcall_int(i256 %abi_params, i256 %address)
     to label %ok unwind label %err
@@ -310,7 +310,7 @@ err:
   ret {i8 addrspace(3)*, i1} %res.2f
 }
 
-define {i8 addrspace(3)*, i1} @__staticcall(i256 %abi_params, i256 %address) personality i32 ()* @__personality {
+define {i8 addrspace(3)*, i1} @__staticcall(i256 %abi_params, i256 %address) #2 personality i32 ()* @__personality {
 entry:
   %invoke_res = invoke i8 addrspace(3)* @__staticcall_int(i256 %abi_params, i256 %address)
     to label %ok unwind label %err
@@ -325,7 +325,7 @@ err:
   ret {i8 addrspace(3)*, i1} %res.2f
 }
 
-define {i8 addrspace(3)*, i1} @__delegatecall(i256 %abi_params, i256 %address) personality i32 ()* @__personality {
+define {i8 addrspace(3)*, i1} @__delegatecall(i256 %abi_params, i256 %address) #2 personality i32 ()* @__personality {
 entry:
   %invoke_res = invoke i8 addrspace(3)* @__delegatecall_int(i256 %abi_params, i256 %address)
     to label %ok unwind label %err
@@ -340,7 +340,7 @@ err:
   ret {i8 addrspace(3)*, i1} %res.2f
 }
 
-define {i8 addrspace(3)*, i1} @__mimiccall(i256 %abi_params, i256 %address, i256 %mimic) personality i32 ()* @__personality {
+define {i8 addrspace(3)*, i1} @__mimiccall(i256 %abi_params, i256 %address, i256 %mimic) #2 personality i32 ()* @__personality {
 entry:
   %invoke_res = invoke i8 addrspace(3)* @__mimiccall_int(i256 %abi_params, i256 %address, i256 %mimic)
     to label %ok unwind label %err
@@ -355,7 +355,7 @@ err:
   ret {i8 addrspace(3)*, i1} %res.2f
 }
 
-define {i8 addrspace(3)*, i1} @__system_call(i256 %abi_params, i256 %address, i256 %p0, i256 %p1) personality i32 ()* @__personality {
+define {i8 addrspace(3)*, i1} @__system_call(i256 %abi_params, i256 %address, i256 %p0, i256 %p1) #2 personality i32 ()* @__personality {
 entry:
   %invoke_res = invoke i8 addrspace(3)* @__farcall_int_l(i256 %abi_params, i256 %address, i256 %p0, i256 %p1)
     to label %ok unwind label %err
@@ -370,7 +370,7 @@ err:
   ret {i8 addrspace(3)*, i1} %res.2f
 }
 
-define {i8 addrspace(3)*, i1} @__system_staticcall(i256 %abi_params, i256 %address, i256 %p0, i256 %p1) personality i32 ()* @__personality {
+define {i8 addrspace(3)*, i1} @__system_staticcall(i256 %abi_params, i256 %address, i256 %p0, i256 %p1) #2 personality i32 ()* @__personality {
 entry:
   %invoke_res = invoke i8 addrspace(3)* @__staticcall_int_l(i256 %abi_params, i256 %address, i256 %p0, i256 %p1)
     to label %ok unwind label %err
@@ -385,7 +385,7 @@ err:
   ret {i8 addrspace(3)*, i1} %res.2f
 }
 
-define {i8 addrspace(3)*, i1} @__system_delegatecall(i256 %abi_params, i256 %address, i256 %p0, i256 %p1) personality i32 ()* @__personality {
+define {i8 addrspace(3)*, i1} @__system_delegatecall(i256 %abi_params, i256 %address, i256 %p0, i256 %p1) #2 personality i32 ()* @__personality {
 entry:
   %invoke_res = invoke i8 addrspace(3)* @__delegatecall_int_l(i256 %abi_params, i256 %address, i256 %p0, i256 %p1)
     to label %ok unwind label %err
@@ -400,7 +400,7 @@ err:
   ret {i8 addrspace(3)*, i1} %res.2f
 }
 
-define {i8 addrspace(3)*, i1} @__system_mimiccall(i256 %abi_params, i256 %address, i256 %p0, i256 %p1, i256 %mimic) personality i32 ()* @__personality {
+define {i8 addrspace(3)*, i1} @__system_mimiccall(i256 %abi_params, i256 %address, i256 %p0, i256 %p1, i256 %mimic) #2 personality i32 ()* @__personality {
 entry:
   %invoke_res = invoke i8 addrspace(3)* @__mimiccall_int_l(i256 %abi_params, i256 %address, i256 %p0, i256 %p1, i256 %mimic)
     to label %ok unwind label %err
@@ -415,7 +415,7 @@ err:
   ret {i8 addrspace(3)*, i1} %res.2f
 }
 
-define {i8 addrspace(3)*, i1} @__farcall_byref(i8 addrspace(3)* %abi_params.r, i256 %address) personality i32 ()* @__personality {
+define {i8 addrspace(3)*, i1} @__farcall_byref(i8 addrspace(3)* %abi_params.r, i256 %address) #2 personality i32 ()* @__personality {
 entry:
   %abi_params = ptrtoint i8 addrspace(3)* %abi_params.r to i256
   %invoke_res = invoke i8 addrspace(3)* @__farcall_int(i256 %abi_params, i256 %address)
@@ -431,7 +431,7 @@ err:
   ret {i8 addrspace(3)*, i1} %res.2f
 }
 
-define {i8 addrspace(3)*, i1} @__staticcall_byref(i8 addrspace(3)* %abi_params.r, i256 %address) personality i32 ()* @__personality {
+define {i8 addrspace(3)*, i1} @__staticcall_byref(i8 addrspace(3)* %abi_params.r, i256 %address) #2 personality i32 ()* @__personality {
 entry:
   %abi_params = ptrtoint i8 addrspace(3)* %abi_params.r to i256
   %invoke_res = invoke i8 addrspace(3)* @__staticcall_int(i256 %abi_params, i256 %address)
@@ -447,7 +447,7 @@ err:
   ret {i8 addrspace(3)*, i1} %res.2f
 }
 
-define {i8 addrspace(3)*, i1} @__delegatecall_byref(i8 addrspace(3)* %abi_params.r, i256 %address) personality i32 ()* @__personality {
+define {i8 addrspace(3)*, i1} @__delegatecall_byref(i8 addrspace(3)* %abi_params.r, i256 %address) #2 personality i32 ()* @__personality {
 entry:
   %abi_params = ptrtoint i8 addrspace(3)* %abi_params.r to i256
   %invoke_res = invoke i8 addrspace(3)* @__delegatecall_int(i256 %abi_params, i256 %address)
@@ -463,7 +463,7 @@ err:
   ret {i8 addrspace(3)*, i1} %res.2f
 }
 
-define {i8 addrspace(3)*, i1} @__mimiccall_byref(i8 addrspace(3)* %abi_params.r, i256 %address, i256 %mimic) personality i32 ()* @__personality {
+define {i8 addrspace(3)*, i1} @__mimiccall_byref(i8 addrspace(3)* %abi_params.r, i256 %address, i256 %mimic) #2 personality i32 ()* @__personality {
 entry:
   %abi_params = ptrtoint i8 addrspace(3)* %abi_params.r to i256
   %invoke_res = invoke i8 addrspace(3)* @__mimiccall_int(i256 %abi_params, i256 %address, i256 %mimic)
@@ -479,7 +479,7 @@ err:
   ret {i8 addrspace(3)*, i1} %res.2f
 }
 
-define {i8 addrspace(3)*, i1} @__system_call_byref(i8 addrspace(3)* %abi_params.r, i256 %address, i256 %p0, i256 %p1) personality i32 ()* @__personality {
+define {i8 addrspace(3)*, i1} @__system_call_byref(i8 addrspace(3)* %abi_params.r, i256 %address, i256 %p0, i256 %p1) #2 personality i32 ()* @__personality {
 entry:
   %abi_params = ptrtoint i8 addrspace(3)* %abi_params.r to i256
   %invoke_res = invoke i8 addrspace(3)* @__farcall_int_l(i256 %abi_params, i256 %address, i256 %p0, i256 %p1)
@@ -495,7 +495,7 @@ err:
   ret {i8 addrspace(3)*, i1} %res.2f
 }
 
-define {i8 addrspace(3)*, i1} @__system_staticcall_byref(i8 addrspace(3)* %abi_params.r, i256 %address, i256 %p0, i256 %p1) personality i32 ()* @__personality {
+define {i8 addrspace(3)*, i1} @__system_staticcall_byref(i8 addrspace(3)* %abi_params.r, i256 %address, i256 %p0, i256 %p1) #2 personality i32 ()* @__personality {
 entry:
   %abi_params = ptrtoint i8 addrspace(3)* %abi_params.r to i256
   %invoke_res = invoke i8 addrspace(3)* @__staticcall_int_l(i256 %abi_params, i256 %address, i256 %p0, i256 %p1)
@@ -511,7 +511,7 @@ err:
   ret {i8 addrspace(3)*, i1} %res.2f
 }
 
-define {i8 addrspace(3)*, i1} @__system_delegatecall_byref(i8 addrspace(3)* %abi_params.r, i256 %address, i256 %p0, i256 %p1) personality i32 ()* @__personality {
+define {i8 addrspace(3)*, i1} @__system_delegatecall_byref(i8 addrspace(3)* %abi_params.r, i256 %address, i256 %p0, i256 %p1) #2 personality i32 ()* @__personality {
 entry:
   %abi_params = ptrtoint i8 addrspace(3)* %abi_params.r to i256
   %invoke_res = invoke i8 addrspace(3)* @__delegatecall_int_l(i256 %abi_params, i256 %address, i256 %p0, i256 %p1)
@@ -527,7 +527,7 @@ err:
   ret {i8 addrspace(3)*, i1} %res.2f
 }
 
-define {i8 addrspace(3)*, i1} @__system_mimiccall_byref(i8 addrspace(3)* %abi_params.r, i256 %address, i256 %p0, i256 %p1, i256 %mimic) personality i32 ()* @__personality {
+define {i8 addrspace(3)*, i1} @__system_mimiccall_byref(i8 addrspace(3)* %abi_params.r, i256 %address, i256 %p0, i256 %p1, i256 %mimic) #2 personality i32 ()* @__personality {
 entry:
   %abi_params = ptrtoint i8 addrspace(3)* %abi_params.r to i256
   %invoke_res = invoke i8 addrspace(3)* @__mimiccall_int_l(i256 %abi_params, i256 %address, i256 %p0, i256 %p1, i256 %mimic)
@@ -543,17 +543,17 @@ err:
   ret {i8 addrspace(3)*, i1} %res.2f
 }
 
-define void @__sstore(i256 %val, i256 %key) {
+define void @__sstore(i256 %val, i256 %key) #1 {
   call void @llvm.syncvm.sstore(i256 %key, i256 %val)
   ret void
 }
 
-define i256 @__sload(i256 %key) {
+define i256 @__sload(i256 %key) #1 {
   %res = call i256 @llvm.syncvm.sload(i256 %key)
   ret i256 %res
 }
 
-define void @__small_store_as1(i256 %addr.i, i256 %value, i256 %size_in_bits) nounwind {
+define void @__small_store_as1(i256 %addr.i, i256 %value, i256 %size_in_bits) #3 {
   %addr = inttoptr i256 %addr.i to i256 addrspace(1)*
   %sizeinv = sub nsw nuw i256 256, %size_in_bits
   %maskload = lshr i256 -1, %size_in_bits
@@ -566,7 +566,7 @@ define void @__small_store_as1(i256 %addr.i, i256 %value, i256 %size_in_bits) no
   ret void
 }
 
-define void @__small_store_as2(i256 %addr.i, i256 %value, i256 %size_in_bits) nounwind {
+define void @__small_store_as2(i256 %addr.i, i256 %value, i256 %size_in_bits) #3 {
   %addr = inttoptr i256 %addr.i to i256 addrspace(2)*
   %sizeinv = sub nsw nuw i256 256, %size_in_bits
   %maskload = lshr i256 -1, %size_in_bits
@@ -579,7 +579,7 @@ define void @__small_store_as2(i256 %addr.i, i256 %value, i256 %size_in_bits) no
   ret void
 }
 
-define void @__memset_uma_as1(i256 addrspace(1)* %dest, i256 %val, i256 %size) nounwind {
+define void @__memset_uma_as1(i256 addrspace(1)* %dest, i256 %val, i256 %size) #3 {
 entry:
   %numcells = udiv i256 %size, 32
   %hascells = icmp ugt i256 %numcells, 0
@@ -607,7 +607,7 @@ return:
   ret void
 }
 
-define void @__memset_uma_as2(i256 addrspace(2)* %dest, i256 %val, i256 %size) nounwind {
+define void @__memset_uma_as2(i256 addrspace(2)* %dest, i256 %val, i256 %size) #3 {
 entry:
   %numcells = udiv i256 %size, 32
   %hascells = icmp ugt i256 %numcells, 0
@@ -650,5 +650,8 @@ declare i8 addrspace(3)* @__mimiccall_int(i256, i256, i256)
 declare i8 addrspace(3)* @__mimiccall_int_l(i256, i256, i256, i256, i256)
 declare i32 @__personality()
 
-attributes #0 = { nounwind readnone }
-attributes #1 = { mustprogress nounwind readnone willreturn }
+attributes #0 = { mustprogress nounwind readnone willreturn "internalize-early"}
+attributes #1 = {"internalize-early"}
+attributes #2 = { noinline nounwind willreturn "internalize-late" }
+attributes #3 = { nounwind "internalize-late"}
+attributes #4 = { noinline "internalize-late"}

--- a/llvm/lib/Transforms/IPO/CMakeLists.txt
+++ b/llvm/lib/Transforms/IPO/CMakeLists.txt
@@ -73,4 +73,8 @@ add_llvm_component_library(LLVMipo
   Vectorize
   Instrumentation
   Scalar
+  # SyncVM local begin
+  # Enable SyncVM-specific passes to be run in opt pipeline with old PM.
+  SyncVM
+  # SyncVM local end
   )

--- a/llvm/lib/Transforms/IPO/PassManagerBuilder.cpp
+++ b/llvm/lib/Transforms/IPO/PassManagerBuilder.cpp
@@ -164,6 +164,9 @@ cl::opt<AttributorRunOption> AttributorRun(
                           "disable attributor runs")));
 
 extern cl::opt<bool> EnableKnowledgeRetention;
+// SyncVM local begin
+extern ModulePass* createSyncVMLinkRuntimePass(bool);
+// SyncVM local end
 } // namespace llvm
 
 PassManagerBuilder::PassManagerBuilder() {
@@ -578,8 +581,12 @@ void PassManagerBuilder::addVectorPasses(legacy::PassManagerBase &PM,
     PM.add(createInstructionCombiningPass());
 }
 
+
 void PassManagerBuilder::populateModulePassManager(
     legacy::PassManagerBase &MPM) {
+  // SyncVM local begin
+  MPM.add(createSyncVMLinkRuntimePass(false /*InternalizeOnly*/));
+  // SyncVM local end
   MPM.add(createAnnotation2MetadataLegacyPass());
 
   // Allow forcing function attributes as a debugging and tuning aid.

--- a/llvm/test/CodeGen/Generic/2008-08-07-PtrToInt-SmallerInt.ll
+++ b/llvm/test/CodeGen/Generic/2008-08-07-PtrToInt-SmallerInt.ll
@@ -1,5 +1,3 @@
-; XFAIL: syncvm
-; TODO: CPR-920 Support operators in global constants.
 ; RUN: llc < %s
 ; PR2603
         %struct.A = type { i8 }

--- a/llvm/test/Transforms/LoopVersioningLICM/loopversioningLICM1.ll
+++ b/llvm/test/Transforms/LoopVersioningLICM/loopversioningLICM1.ll
@@ -1,4 +1,3 @@
-; RUN: opt < %s  -O1  -S -loop-versioning-licm -licm -debug-only=loop-versioning-licm -enable-new-pm=0 2>&1 | FileCheck %s
 ; RUN: opt < %s -S -passes='default<O1>,function(loop-versioning-licm,loop-mssa(licm))' -debug-only=loop-versioning-licm 2>&1 | FileCheck %s
 ; REQUIRES: asserts
 ;


### PR DESCRIPTION
* Inject runtime linkage to the beginning of optimization pipeline.
* Introduce internalize-early function attribute to internalize runtime functions just after the linkage.
* Introduce internalize-lately function attribute to internalize runtime functions in backend pipeline before final Global DCE.