### PR TITLE
[CodeGen] Fix branch instruction modelling

### DIFF
--- a/llvm/lib/Target/SyncVM/SyncVMInstrFormats.td
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrFormats.td
@@ -167,10 +167,17 @@ class IConditional<bits<8> opcode,
   let Inst{33-35} = cc;
 }
 
+class ICondJump<bits<8> opcode, dag ins, string asmstr, list<dag> pattern>
+  : IConditional <opcode, SrcNone, DstNone, (outs), ins, asmstr, pattern> {
+  bits<16> dest;
+  let Inst{16-31} = dest;
+}
+
 class IJump<bits<8> opcode, dag ins, string asmstr, list<dag> pattern>
   : IConditional <opcode, SrcNone, DstNone, (outs), ins, asmstr, pattern> {
   bits<16> dest;
   let Inst{16-31} = dest;
+  let cc = 0;
 }
 
 class IUMA<bits<8> opcode, dag outs, dag ins, string asmstr, list<dag> pattern>

--- a/llvm/lib/Target/SyncVM/SyncVMInstrInfo.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrInfo.cpp
@@ -111,6 +111,33 @@ bool SyncVMInstrInfo::analyzeBranch(MachineBasicBlock &MBB,
     if (!I->isBranch())
       return true;
 
+    if (I->getOpcode() == SyncVM::J) {
+      // Handle unconditional branches.
+      auto jumpTarget = I->getOperand(0).getMBB();
+      if (!AllowModify) {
+        TBB = jumpTarget;
+        continue;
+      }
+
+      // If the block has any instructions after a JMP, delete them.
+      MBB.erase(std::next(I), MBB.end());
+
+      Cond.clear();
+      FBB = nullptr;
+
+      // Delete the JMP if it's equivalent to a fall-through.
+      if (MBB.isLayoutSuccessor(jumpTarget)) {
+        TBB = nullptr;
+        I->eraseFromParent();
+        I = MBB.end();
+        continue;
+      }
+
+      // TBB is used to indicate the unconditional destination.
+      TBB = jumpTarget;
+      continue;
+    }
+
     // Handle unconditional branches.
     if (getImmOrCImm(I->getOperand(1)) == 0) {
       // TBB is used to indicate the unconditional destination.
@@ -185,18 +212,18 @@ unsigned SyncVMInstrInfo::insertBranch(
   if (Cond.empty()) {
     // Unconditional branch?
     assert(!FBB && "Unconditional branch with multiple successors!");
-    BuildMI(&MBB, DL, get(SyncVM::J)).addMBB(TBB).addImm(SyncVMCC::COND_NONE);
+    BuildMI(&MBB, DL, get(SyncVM::J)).addMBB(TBB);
     return 1;
   }
   // Conditional branch.
   unsigned Count = 0;
   auto cond_code = getImmOrCImm(Cond[0]);
-  BuildMI(&MBB, DL, get(SyncVM::J)).addMBB(TBB).addImm(cond_code);
+  BuildMI(&MBB, DL, get(SyncVM::JC)).addMBB(TBB).addImm(cond_code);
   ++Count;
 
   if (FBB) {
     // Two-way Conditional branch. Insert the second branch.
-    BuildMI(&MBB, DL, get(SyncVM::J)).addMBB(FBB).addImm(SyncVMCC::COND_NONE);
+    BuildMI(&MBB, DL, get(SyncVM::J)).addMBB(FBB);
     ++Count;
   }
   return Count;

--- a/llvm/lib/Target/SyncVM/SyncVMInstrInfo.td
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrInfo.td
@@ -123,7 +123,10 @@ def init_flag : Operand<i256>, IntImmLeaf<i256, [{
 }
 
 // Operand for printing out a condition code.
-def cc : Operand<i256> {
+def cc : Operand<i256>, IntImmLeaf<i256, [{
+  // TODO: refine this
+  return Imm.isIntN(4) && Imm != 0;
+}]> {
   let PrintMethod = "printCCOperand";
   // TODO: Implement once encoding is defined.
   //let EncoderMethod = "getCCOpValue";
@@ -1203,10 +1206,16 @@ def     : Pat<(store_heapaux GR256:$rs1, GR256:$rs0),
 //===----------------------------------------------------------------------===//
 // Control flow instructions
 //===----------------------------------------------------------------------===//
-let isTerminator = 1, isBranch = 1, isBarrier = 1, Uses = [Flags] in
-def J: IJump<10, (ins jmptarget:$dest, cc:$cc), "jump$cc\t$dest",
+// Conditional jump
+let isTerminator = 1, isBranch = 1, Uses = [Flags] in
+def JC: ICondJump<10, (ins jmptarget:$dest, cc:$cc), "jump$cc\t$dest",
              [(SyncVMbrcc bb:$dest, imm:$cc)]>;
-def : Pat<(br bb:$dst), (J bb:$dst, 0)>;
+
+// Unconditional jump
+let isTerminator = 1, isBranch = 1, isBarrier = 1, Uses = [Flags] in
+def J: IJump<10, (ins jmptarget:$dest), "jump\t$dest",
+             [(SyncVMbrcc bb:$dest, 0)]>;
+def : Pat<(br bb:$dst), (J bb:$dst)>;
 
 let isReturn = 1, isTerminator = 1, isBarrier = 1  in
 def RET   : IRet<7, RFNone, (ins), "ret", [(SyncVMret)]>;

--- a/llvm/test/CodeGen/Generic/undef-phi.ll
+++ b/llvm/test/CodeGen/Generic/undef-phi.ll
@@ -1,5 +1,3 @@
-; XFAIL: syncvm
-; TODO: CPR-922 Fix
 ; RUN: llc < %s -verify-machineinstrs -verify-coalescing
 ;
 ; This function has a PHI with one undefined input. Verify that PHIElimination


### PR DESCRIPTION
We do not distinguish conditional jumps and unconditional jumps, but in fact conditional jumps are not barriers. 

This patch separates conditional jumps and unconditional jumps and update `analyzeBranch` to properly return analyzed results. 