### PR TITLE
[Fix] CALLSTACK, and CALLs are not terminators

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetInstrInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetInstrInfo.h
@@ -236,9 +236,19 @@ public:
   /// prior to the pair.
   int64_t getFrameTotalSize(const MachineInstr &I) const {
     if (isFrameSetup(I)) {
-      assert(I.getOperand(1).getImm() >= 0 &&
+      // SyncVM local begin
+      int64_t frame_size = 0;
+      assert(I.getOperand(1).isImm() ||
+             I.getOperand(1).isCImm() && "Unexpected operand type");
+      if (I.getOperand(1).isImm()) {
+        frame_size = I.getOperand(1).getImm();
+      } else if (I.getOperand(1).isCImm()) {
+        frame_size = I.getOperand(1).getCImm()->getSExtValue();
+      }
+      assert(frame_size >= 0 &&
              "Frame size must not be negative");
-      return getFrameSize(I) + I.getOperand(1).getImm();
+      return getFrameSize(I) + frame_size;
+      // SyncVM Local end
     }
     return getFrameSize(I);
   }

--- a/llvm/lib/Target/SyncVM/SyncVMInstrInfo.td
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrInfo.td
@@ -1323,7 +1323,7 @@ let Defs = [R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15],
 }
 
 let Defs = [R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15],
-    isCall = 1, isTerminator = 1 in {
+    isCall = 1 in {
 def FAR_CALL  : ICall<8, CFNormal, (ins GR256:$abi, GR256:$address, jmptarget:$unwind),
                "far_call\t$abi, $address, $unwind", [(SyncVMfarcall GR256:$abi, GR256:$address, bb:$unwind)]>;
 def FAR_CALLL  : ICall<80, CFNormal, (ins GR256:$abi, GR256:$address, GR256:$op1, GR256:$op2, jmptarget:$unwind),

--- a/llvm/test/CodeGen/SyncVM/farcall-spill.ll
+++ b/llvm/test/CodeGen/SyncVM/farcall-spill.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s | FileCheck %s
+; RUN: llc --verify-coalescing < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "syncvm"


### PR DESCRIPTION
* in our backend, AJDCALLSTACK instructions have Cimm operand type instead of imm type.
* calls are not terminators
