### PR TITLE
Increase number of parameters in far calls to 12

### DIFF
--- a/llvm/lib/Target/SyncVM/SyncVM.h
+++ b/llvm/lib/Target/SyncVM/SyncVM.h
@@ -107,6 +107,6 @@ struct SyncVMLinkRuntimePass : PassInfoMixin<SyncVMLinkRuntimePass> {
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
 };
 
-} // end namespace llvm;
+} // namespace llvm
 
 #endif

--- a/llvm/lib/Target/SyncVM/SyncVMInstrInfo.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrInfo.cpp
@@ -333,13 +333,9 @@ unsigned SyncVMInstrInfo::getInstSizeInBytes(const MachineInstr &MI) const {
 bool SyncVMInstrInfo::isFarCall(const MachineInstr &MI) const {
   switch (MI.getOpcode()) {
   case SyncVM::FAR_CALL:
-  case SyncVM::FAR_CALLL:
   case SyncVM::STATIC_CALL:
-  case SyncVM::STATIC_CALLL:
   case SyncVM::DELEGATE_CALL:
-  case SyncVM::DELEGATE_CALLL:
   case SyncVM::MIMIC_CALL:
-  case SyncVM::MIMIC_CALLL:
     return true;
   }
   return false;

--- a/llvm/lib/Target/SyncVM/SyncVMInstrInfo.td
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrInfo.td
@@ -1369,26 +1369,19 @@ let Defs = [R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, Fl
                    "INVOKE\t$in1, $callee, $unwind", [(SyncVMinvoke GR256:$in1, tglobaladdr:$callee, bb:$unwind)]>;
    def NEAR_CALL : ICall<9, CFNormal, (ins GR256:$in1, imm16:$callee, jmptarget:$unwind),
                    "near_call\t$in1, $callee, $unwind", []>;
-}
 
-let Defs = [R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, Flags],
-    isCall = 1 in {
-def FAR_CALL  : ICall<8, CFNormal, (ins GR256:$abi, GR256:$address, jmptarget:$unwind),
-               "far_call\t$abi, $address, $unwind", [(SyncVMfarcall GR256:$abi, GR256:$address, bb:$unwind)]>;
-def FAR_CALLL  : ICall<80, CFNormal, (ins GR256:$abi, GR256:$address, GR256:$op1, GR256:$op2, jmptarget:$unwind),
-               "far_call\t$abi, $address, $unwind", [(SyncVMfarcall GR256:$abi, GR256:$address, GR256:$op1, GR256:$op2, bb:$unwind)]>;
-def STATIC_CALL  : ICall<10, CFNormal, (ins GR256:$abi, GR256:$address, jmptarget:$unwind),
-               "far_call.static\t$abi, $address, $unwind", [(SyncVMstaticcall GR256:$abi, GR256:$address, bb:$unwind)]>;
-def STATIC_CALLL  : ICall<100, CFNormal, (ins GR256:$abi, GR256:$address, GR256:$op1, GR256:$op2, jmptarget:$unwind),
-               "far_call.static\t$abi, $address, $unwind", [(SyncVMstaticcall GR256:$abi, GR256:$address, GR256:$op1, GR256:$op2, bb:$unwind)]>;
-def DELEGATE_CALL  : ICall<11, CFDelegate, (ins GR256:$abi, GR256:$address, jmptarget:$unwind),
-               "far_call.delegate\t$abi, $address, $unwind", [(SyncVMdelegatecall GR256:$abi, GR256:$address, bb:$unwind)]>;
-def DELEGATE_CALLL  : ICall<110, CFDelegate, (ins GR256:$abi, GR256:$address, GR256:$op1, GR256:$op2, jmptarget:$unwind),
-               "far_call.delegate\t$abi, $address, $unwind", [(SyncVMdelegatecall GR256:$abi, GR256:$address, GR256:$op1, GR256:$op2, bb:$unwind)]>;
-def MIMIC_CALL  : ICall<12, CFMimic, (ins GR256:$abi, GR256:$address, GR256:$mimic, jmptarget:$unwind),
-               "far_call.mimic\t$abi, $address, $unwind", [(SyncVMmimiccall GR256:$abi, GR256:$address, GR256:$mimic, bb:$unwind)]>;
-def MIMIC_CALLL  : ICall<120, CFMimic, (ins GR256:$abi, GR256:$address, GR256:$op1, GR256:$op2, GR256:$mimic, jmptarget:$unwind),
-               "far_call.mimic\t$abi, $address, $unwind", [(SyncVMmimiccall GR256:$abi, GR256:$address, GR256:$op1, GR256:$op2, GR256:$mimic, bb:$unwind)]>;
+  def FAR_CALL       : ICall<8, CFNormal, (ins jmptarget:$unwind),
+                             "far_call\tr1, r2, $unwind",
+                             [(SyncVMfarcall bb:$unwind)]>;
+  def STATIC_CALL    : ICall<10, CFNormal, (ins jmptarget:$unwind),
+                             "far_call.static\tr1, r2, $unwind",
+                             [(SyncVMstaticcall bb:$unwind)]>;
+  def DELEGATE_CALL  : ICall<11, CFDelegate, (ins jmptarget:$unwind),
+                             "far_call.delegate\tr1, r2, $unwind",
+                             [(SyncVMdelegatecall bb:$unwind)]>;
+  def MIMIC_CALL     : ICall<12, CFMimic, (ins jmptarget:$unwind),
+                             "far_call.mimic\tr1, r2, $unwind",
+                             [(SyncVMmimiccall bb:$unwind)]>;
 }
 
 def : Pat<(store_stack (add GR256:$rs0, neg_imm16:$imm), stackaddr:$dst0),

--- a/llvm/lib/Target/SyncVM/syncvm-runtime.ll
+++ b/llvm/lib/Target/SyncVM/syncvm-runtime.ll
@@ -295,9 +295,9 @@ define i256 @__signextend(i256 %numbyte, i256 %value) #0 {
   ret i256 %result
 }
 
-define {i8 addrspace(3)*, i1} @__farcall(i256 %abi_params, i256 %address) #2 personality i32 ()* @__personality {
+define {i8 addrspace(3)*, i1} @__farcall(i256 %abi_params, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12) #2 personality i32 ()* @__personality {
 entry:
-  %invoke_res = invoke i8 addrspace(3)* @__farcall_int(i256 %abi_params, i256 %address)
+  %invoke_res = invoke i8 addrspace(3)* @__farcall_int(i256 %abi_params, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12)
     to label %ok unwind label %err
 ok:
   %res.1u = insertvalue {i8 addrspace(3)*, i1} undef, i8 addrspace(3)* %invoke_res, 0
@@ -310,9 +310,9 @@ err:
   ret {i8 addrspace(3)*, i1} %res.2f
 }
 
-define {i8 addrspace(3)*, i1} @__staticcall(i256 %abi_params, i256 %address) #2 personality i32 ()* @__personality {
+define {i8 addrspace(3)*, i1} @__staticcall(i256 %abi_params, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12) #2 personality i32 ()* @__personality {
 entry:
-  %invoke_res = invoke i8 addrspace(3)* @__staticcall_int(i256 %abi_params, i256 %address)
+  %invoke_res = invoke i8 addrspace(3)* @__staticcall_int(i256 %abi_params, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12)
     to label %ok unwind label %err
 ok:
   %res.1u = insertvalue {i8 addrspace(3)*, i1} undef, i8 addrspace(3)* %invoke_res, 0
@@ -325,9 +325,9 @@ err:
   ret {i8 addrspace(3)*, i1} %res.2f
 }
 
-define {i8 addrspace(3)*, i1} @__delegatecall(i256 %abi_params, i256 %address) #2 personality i32 ()* @__personality {
+define {i8 addrspace(3)*, i1} @__delegatecall(i256 %abi_params, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12) #2 personality i32 ()* @__personality {
 entry:
-  %invoke_res = invoke i8 addrspace(3)* @__delegatecall_int(i256 %abi_params, i256 %address)
+  %invoke_res = invoke i8 addrspace(3)* @__delegatecall_int(i256 %abi_params, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12)
     to label %ok unwind label %err
 ok:
   %res.1u = insertvalue {i8 addrspace(3)*, i1} undef, i8 addrspace(3)* %invoke_res, 0
@@ -340,9 +340,9 @@ err:
   ret {i8 addrspace(3)*, i1} %res.2f
 }
 
-define {i8 addrspace(3)*, i1} @__mimiccall(i256 %abi_params, i256 %address, i256 %mimic) #2 personality i32 ()* @__personality {
+define {i8 addrspace(3)*, i1} @__mimiccall(i256 %abi_params, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12, i256 %mimic) #2 personality i32 ()* @__personality {
 entry:
-  %invoke_res = invoke i8 addrspace(3)* @__mimiccall_int(i256 %abi_params, i256 %address, i256 %mimic)
+  %invoke_res = invoke i8 addrspace(3)* @__mimiccall_int(i256 %abi_params, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12, i256 %mimic)
     to label %ok unwind label %err
 ok:
   %res.1u = insertvalue {i8 addrspace(3)*, i1} undef, i8 addrspace(3)* %invoke_res, 0
@@ -355,70 +355,10 @@ err:
   ret {i8 addrspace(3)*, i1} %res.2f
 }
 
-define {i8 addrspace(3)*, i1} @__system_call(i256 %abi_params, i256 %address, i256 %p0, i256 %p1) #2 personality i32 ()* @__personality {
-entry:
-  %invoke_res = invoke i8 addrspace(3)* @__farcall_int_l(i256 %abi_params, i256 %address, i256 %p0, i256 %p1)
-    to label %ok unwind label %err
-ok:
-  %res.1u = insertvalue {i8 addrspace(3)*, i1} undef, i8 addrspace(3)* %invoke_res, 0
-  %res.1f = insertvalue {i8 addrspace(3)*, i1} %res.1u, i1 1, 1
-  ret {i8 addrspace(3)*, i1} %res.1f
-
-err:
-  %res.2u = landingpad {i8 addrspace(3)*, i1} cleanup
-  %res.2f = insertvalue {i8 addrspace(3)*, i1} %res.2u, i1 0, 1
-  ret {i8 addrspace(3)*, i1} %res.2f
-}
-
-define {i8 addrspace(3)*, i1} @__system_staticcall(i256 %abi_params, i256 %address, i256 %p0, i256 %p1) #2 personality i32 ()* @__personality {
-entry:
-  %invoke_res = invoke i8 addrspace(3)* @__staticcall_int_l(i256 %abi_params, i256 %address, i256 %p0, i256 %p1)
-    to label %ok unwind label %err
-ok:
-  %res.1u = insertvalue {i8 addrspace(3)*, i1} undef, i8 addrspace(3)* %invoke_res, 0
-  %res.1f = insertvalue {i8 addrspace(3)*, i1} %res.1u, i1 1, 1
-  ret {i8 addrspace(3)*, i1} %res.1f
-
-err:
-  %res.2u = landingpad {i8 addrspace(3)*, i1} cleanup
-  %res.2f = insertvalue {i8 addrspace(3)*, i1} %res.2u, i1 0, 1
-  ret {i8 addrspace(3)*, i1} %res.2f
-}
-
-define {i8 addrspace(3)*, i1} @__system_delegatecall(i256 %abi_params, i256 %address, i256 %p0, i256 %p1) #2 personality i32 ()* @__personality {
-entry:
-  %invoke_res = invoke i8 addrspace(3)* @__delegatecall_int_l(i256 %abi_params, i256 %address, i256 %p0, i256 %p1)
-    to label %ok unwind label %err
-ok:
-  %res.1u = insertvalue {i8 addrspace(3)*, i1} undef, i8 addrspace(3)* %invoke_res, 0
-  %res.1f = insertvalue {i8 addrspace(3)*, i1} %res.1u, i1 1, 1
-  ret {i8 addrspace(3)*, i1} %res.1f
-
-err:
-  %res.2u = landingpad {i8 addrspace(3)*, i1} cleanup
-  %res.2f = insertvalue {i8 addrspace(3)*, i1} %res.2u, i1 0, 1
-  ret {i8 addrspace(3)*, i1} %res.2f
-}
-
-define {i8 addrspace(3)*, i1} @__system_mimiccall(i256 %abi_params, i256 %address, i256 %p0, i256 %p1, i256 %mimic) #2 personality i32 ()* @__personality {
-entry:
-  %invoke_res = invoke i8 addrspace(3)* @__mimiccall_int_l(i256 %abi_params, i256 %address, i256 %p0, i256 %p1, i256 %mimic)
-    to label %ok unwind label %err
-ok:
-  %res.1u = insertvalue {i8 addrspace(3)*, i1} undef, i8 addrspace(3)* %invoke_res, 0
-  %res.1f = insertvalue {i8 addrspace(3)*, i1} %res.1u, i1 1, 1
-  ret {i8 addrspace(3)*, i1} %res.1f
-
-err:
-  %res.2u = landingpad {i8 addrspace(3)*, i1} cleanup
-  %res.2f = insertvalue {i8 addrspace(3)*, i1} %res.2u, i1 0, 1
-  ret {i8 addrspace(3)*, i1} %res.2f
-}
-
-define {i8 addrspace(3)*, i1} @__farcall_byref(i8 addrspace(3)* %abi_params.r, i256 %address) #2 personality i32 ()* @__personality {
+define {i8 addrspace(3)*, i1} @__farcall_byref(i8 addrspace(3)* %abi_params.r, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12) #2 personality i32 ()* @__personality {
 entry:
   %abi_params = ptrtoint i8 addrspace(3)* %abi_params.r to i256
-  %invoke_res = invoke i8 addrspace(3)* @__farcall_int(i256 %abi_params, i256 %address)
+  %invoke_res = invoke i8 addrspace(3)* @__farcall_int(i256 %abi_params, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12)
     to label %ok unwind label %err
 ok:
   %res.1u = insertvalue {i8 addrspace(3)*, i1} undef, i8 addrspace(3)* %invoke_res, 0
@@ -431,10 +371,10 @@ err:
   ret {i8 addrspace(3)*, i1} %res.2f
 }
 
-define {i8 addrspace(3)*, i1} @__staticcall_byref(i8 addrspace(3)* %abi_params.r, i256 %address) #2 personality i32 ()* @__personality {
+define {i8 addrspace(3)*, i1} @__staticcall_byref(i8 addrspace(3)* %abi_params.r, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12) #2 personality i32 ()* @__personality {
 entry:
   %abi_params = ptrtoint i8 addrspace(3)* %abi_params.r to i256
-  %invoke_res = invoke i8 addrspace(3)* @__staticcall_int(i256 %abi_params, i256 %address)
+  %invoke_res = invoke i8 addrspace(3)* @__staticcall_int(i256 %abi_params, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12)
     to label %ok unwind label %err
 ok:
   %res.1u = insertvalue {i8 addrspace(3)*, i1} undef, i8 addrspace(3)* %invoke_res, 0
@@ -447,10 +387,10 @@ err:
   ret {i8 addrspace(3)*, i1} %res.2f
 }
 
-define {i8 addrspace(3)*, i1} @__delegatecall_byref(i8 addrspace(3)* %abi_params.r, i256 %address) #2 personality i32 ()* @__personality {
+define {i8 addrspace(3)*, i1} @__delegatecall_byref(i8 addrspace(3)* %abi_params.r, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12) #2 personality i32 ()* @__personality {
 entry:
   %abi_params = ptrtoint i8 addrspace(3)* %abi_params.r to i256
-  %invoke_res = invoke i8 addrspace(3)* @__delegatecall_int(i256 %abi_params, i256 %address)
+  %invoke_res = invoke i8 addrspace(3)* @__delegatecall_int(i256 %abi_params, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12)
     to label %ok unwind label %err
 ok:
   %res.1u = insertvalue {i8 addrspace(3)*, i1} undef, i8 addrspace(3)* %invoke_res, 0
@@ -463,74 +403,10 @@ err:
   ret {i8 addrspace(3)*, i1} %res.2f
 }
 
-define {i8 addrspace(3)*, i1} @__mimiccall_byref(i8 addrspace(3)* %abi_params.r, i256 %address, i256 %mimic) #2 personality i32 ()* @__personality {
+define {i8 addrspace(3)*, i1} @__mimiccall_byref(i8 addrspace(3)* %abi_params.r, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12, i256 %mimic) #2 personality i32 ()* @__personality {
 entry:
   %abi_params = ptrtoint i8 addrspace(3)* %abi_params.r to i256
-  %invoke_res = invoke i8 addrspace(3)* @__mimiccall_int(i256 %abi_params, i256 %address, i256 %mimic)
-    to label %ok unwind label %err
-ok:
-  %res.1u = insertvalue {i8 addrspace(3)*, i1} undef, i8 addrspace(3)* %invoke_res, 0
-  %res.1f = insertvalue {i8 addrspace(3)*, i1} %res.1u, i1 1, 1
-  ret {i8 addrspace(3)*, i1} %res.1f
-
-err:
-  %res.2u = landingpad {i8 addrspace(3)*, i1} cleanup
-  %res.2f = insertvalue {i8 addrspace(3)*, i1} %res.2u, i1 0, 1
-  ret {i8 addrspace(3)*, i1} %res.2f
-}
-
-define {i8 addrspace(3)*, i1} @__system_call_byref(i8 addrspace(3)* %abi_params.r, i256 %address, i256 %p0, i256 %p1) #2 personality i32 ()* @__personality {
-entry:
-  %abi_params = ptrtoint i8 addrspace(3)* %abi_params.r to i256
-  %invoke_res = invoke i8 addrspace(3)* @__farcall_int_l(i256 %abi_params, i256 %address, i256 %p0, i256 %p1)
-    to label %ok unwind label %err
-ok:
-  %res.1u = insertvalue {i8 addrspace(3)*, i1} undef, i8 addrspace(3)* %invoke_res, 0
-  %res.1f = insertvalue {i8 addrspace(3)*, i1} %res.1u, i1 1, 1
-  ret {i8 addrspace(3)*, i1} %res.1f
-
-err:
-  %res.2u = landingpad {i8 addrspace(3)*, i1} cleanup
-  %res.2f = insertvalue {i8 addrspace(3)*, i1} %res.2u, i1 0, 1
-  ret {i8 addrspace(3)*, i1} %res.2f
-}
-
-define {i8 addrspace(3)*, i1} @__system_staticcall_byref(i8 addrspace(3)* %abi_params.r, i256 %address, i256 %p0, i256 %p1) #2 personality i32 ()* @__personality {
-entry:
-  %abi_params = ptrtoint i8 addrspace(3)* %abi_params.r to i256
-  %invoke_res = invoke i8 addrspace(3)* @__staticcall_int_l(i256 %abi_params, i256 %address, i256 %p0, i256 %p1)
-    to label %ok unwind label %err
-ok:
-  %res.1u = insertvalue {i8 addrspace(3)*, i1} undef, i8 addrspace(3)* %invoke_res, 0
-  %res.1f = insertvalue {i8 addrspace(3)*, i1} %res.1u, i1 1, 1
-  ret {i8 addrspace(3)*, i1} %res.1f
-
-err:
-  %res.2u = landingpad {i8 addrspace(3)*, i1} cleanup
-  %res.2f = insertvalue {i8 addrspace(3)*, i1} %res.2u, i1 0, 1
-  ret {i8 addrspace(3)*, i1} %res.2f
-}
-
-define {i8 addrspace(3)*, i1} @__system_delegatecall_byref(i8 addrspace(3)* %abi_params.r, i256 %address, i256 %p0, i256 %p1) #2 personality i32 ()* @__personality {
-entry:
-  %abi_params = ptrtoint i8 addrspace(3)* %abi_params.r to i256
-  %invoke_res = invoke i8 addrspace(3)* @__delegatecall_int_l(i256 %abi_params, i256 %address, i256 %p0, i256 %p1)
-    to label %ok unwind label %err
-ok:
-  %res.1u = insertvalue {i8 addrspace(3)*, i1} undef, i8 addrspace(3)* %invoke_res, 0
-  %res.1f = insertvalue {i8 addrspace(3)*, i1} %res.1u, i1 1, 1
-  ret {i8 addrspace(3)*, i1} %res.1f
-
-err:
-  %res.2u = landingpad {i8 addrspace(3)*, i1} cleanup
-  %res.2f = insertvalue {i8 addrspace(3)*, i1} %res.2u, i1 0, 1
-  ret {i8 addrspace(3)*, i1} %res.2f
-}
-
-define {i8 addrspace(3)*, i1} @__system_mimiccall_byref(i8 addrspace(3)* %abi_params.r, i256 %address, i256 %p0, i256 %p1, i256 %mimic) #2 personality i32 ()* @__personality {
-entry:
-  %abi_params = ptrtoint i8 addrspace(3)* %abi_params.r to i256
-  %invoke_res = invoke i8 addrspace(3)* @__mimiccall_int_l(i256 %abi_params, i256 %address, i256 %p0, i256 %p1, i256 %mimic)
+  %invoke_res = invoke i8 addrspace(3)* @__mimiccall_int(i256 %abi_params, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12, i256 %mimic)
     to label %ok unwind label %err
 ok:
   %res.1u = insertvalue {i8 addrspace(3)*, i1} undef, i8 addrspace(3)* %invoke_res, 0
@@ -640,14 +516,10 @@ declare void @llvm.syncvm.throw(i256)
 declare void @llvm.syncvm.sstore(i256 %key, i256 %val)
 declare i256 @llvm.syncvm.sload(i256 %key)
 declare i256 @llvm.syncvm.iflt(i256, i256)
-declare i8 addrspace(3)* @__farcall_int(i256, i256)
-declare i8 addrspace(3)* @__farcall_int_l(i256, i256, i256, i256)
-declare i8 addrspace(3)* @__staticcall_int(i256, i256)
-declare i8 addrspace(3)* @__staticcall_int_l(i256, i256, i256, i256)
-declare i8 addrspace(3)* @__delegatecall_int(i256, i256)
-declare i8 addrspace(3)* @__delegatecall_int_l(i256, i256, i256, i256)
-declare i8 addrspace(3)* @__mimiccall_int(i256, i256, i256)
-declare i8 addrspace(3)* @__mimiccall_int_l(i256, i256, i256, i256, i256)
+declare i8 addrspace(3)* @__farcall_int(i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256)
+declare i8 addrspace(3)* @__staticcall_int(i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256)
+declare i8 addrspace(3)* @__delegatecall_int(i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256)
+declare i8 addrspace(3)* @__mimiccall_int(i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256)
 declare i32 @__personality()
 
 attributes #0 = { mustprogress nounwind readnone willreturn "internalize-early"}

--- a/llvm/test/CodeGen/SyncVM/farcall-spill.ll
+++ b/llvm/test/CodeGen/SyncVM/farcall-spill.ll
@@ -7,9 +7,9 @@ target triple = "syncvm"
 
 ; CHECK-LABEL: test1
 define void @test1() personality i32 ()* @__personality {
-  %fptr = invoke i8 addrspace(3)* @__farcall_int(i256 0, i256 1)
+  %fptr = invoke i8 addrspace(3)* @__farcall_int(i256 0, i256 1, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef)
     to label %ok unwind label %fail
-  ; CHECK: far_call	r0, r1, @.BB0_2
+  ; CHECK: far_call	r1, r2, @.BB0_2
   ; CHECK: ptr.add r1, r0, stack-[1]
 ok:
   call void @spill()
@@ -25,14 +25,14 @@ fail:
 define void @test2(i1 %cond) personality i32 ()* @__personality {
   br i1 %cond, label %staticcall, label %delegatecall
 staticcall:
-  %fptrs = invoke i8 addrspace(3)* @__staticcall_int(i256 0, i256 1)
+  %fptrs = invoke i8 addrspace(3)* @__staticcall_int(i256 0, i256 1, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef)
     to label %ok unwind label %fail
-  ; CHECK: far_call.static r0, r1, @.BB1_4
+  ; CHECK: far_call.static r1, r2, @.BB1_4
   ; CHECK: ptr.add r1, r0, stack-[1]
 delegatecall:
-  %fptrd = invoke i8 addrspace(3)* @__delegatecall_int(i256 0, i256 1)
+  %fptrd = invoke i8 addrspace(3)* @__delegatecall_int(i256 0, i256 1, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef)
     to label %ok unwind label %fail
-  ; CHECK: far_call.delegate r0, r1, @.BB1_4
+  ; CHECK: far_call.delegate r1, r2, @.BB1_4
   ; CHECK: ptr.add r1, r0, stack-[1]
 ok:
   %fptr = phi i8 addrspace(3)* [%fptrs, %staticcall], [%fptrd, %delegatecall]
@@ -46,8 +46,8 @@ fail:
 }
 
 
-declare i8 addrspace(3)* @__farcall_int(i256, i256)
-declare i8 addrspace(3)* @__staticcall_int(i256, i256)
-declare i8 addrspace(3)* @__delegatecall_int(i256, i256)
+declare i8 addrspace(3)* @__farcall_int(i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256)
+declare i8 addrspace(3)* @__staticcall_int(i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256)
+declare i8 addrspace(3)* @__delegatecall_int(i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256)
 declare void @spill()
 declare i32 @__personality()

--- a/llvm/test/CodeGen/SyncVM/intrinsic.ll
+++ b/llvm/test/CodeGen/SyncVM/intrinsic.ll
@@ -217,7 +217,7 @@ define i256 @ifgtii() {
 define {i8 addrspace(3)*, i1} @invoke.farcall() {
   ; CHECK: near_call r0, @__farcall, @DEFAULT_UNWIND
   ; CHECK-NEXT: ret
-  %res = call {i8 addrspace(3)*, i1} @__farcall(i256 0, i256 0)
+  %res = call {i8 addrspace(3)*, i1} @__farcall(i256 0, i256 0, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef)
   ret {i8 addrspace(3)*, i1} %res
 }
 
@@ -225,7 +225,7 @@ define {i8 addrspace(3)*, i1} @invoke.farcall() {
 define {i8 addrspace(3)*, i1} @invoke.staticcall() {
   ; CHECK: near_call r0, @__staticcall, @DEFAULT_UNWIND
   ; CHECK-NEXT: ret
-  %res = call {i8 addrspace(3)*, i1} @__staticcall(i256 0, i256 0)
+  %res = call {i8 addrspace(3)*, i1} @__staticcall(i256 0, i256 0, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef)
   ret {i8 addrspace(3)*, i1} %res
 }
 
@@ -233,7 +233,7 @@ define {i8 addrspace(3)*, i1} @invoke.staticcall() {
 define {i8 addrspace(3)*, i1} @invoke.delegatecall() {
   ; CHECK: near_call r0, @__delegatecall, @DEFAULT_UNWIND
   ; CHECK-NEXT: ret
-  %res = call {i8 addrspace(3)*, i1} @__delegatecall(i256 0, i256 0)
+  %res = call {i8 addrspace(3)*, i1} @__delegatecall(i256 0, i256 0, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef)
   ret {i8 addrspace(3)*, i1} %res
 }
 
@@ -241,39 +241,39 @@ define {i8 addrspace(3)*, i1} @invoke.delegatecall() {
 define {i8 addrspace(3)*, i1} @invoke.mimiccall() {
   ; CHECK: near_call r0, @__mimiccall, @DEFAULT_UNWIND
   ; CHECK-NEXT: ret
-  %res = call {i8 addrspace(3)*, i1} @__mimiccall(i256 0, i256 0, i256 0)
+  %res = call {i8 addrspace(3)*, i1} @__mimiccall(i256 0, i256 0, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 42)
   ret {i8 addrspace(3)*, i1} %res
 }
 
 ; CHECK-LABEL: invoke.system_call
 define {i8 addrspace(3)*, i1} @invoke.system_call() {
-  ; CHECK: near_call r0, @__system_call, @DEFAULT_UNWIND
+  ; CHECK: near_call r0, @__farcall, @DEFAULT_UNWIND
   ; CHECK-NEXT: ret
-  %res = call {i8 addrspace(3)*, i1} @__system_call(i256 0, i256 1, i256 2, i256 3)
+  %res = call {i8 addrspace(3)*, i1} @__farcall(i256 0, i256 1, i256 2, i256 3, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef)
   ret {i8 addrspace(3)*, i1} %res
 }
 
 ; CHECK-LABEL: invoke.system_staticcall
 define {i8 addrspace(3)*, i1} @invoke.system_staticcall() {
-  ; CHECK: near_call r0, @__system_staticcall, @DEFAULT_UNWIND
+  ; CHECK: near_call r0, @__staticcall, @DEFAULT_UNWIND
   ; CHECK-NEXT: ret
-  %res = call {i8 addrspace(3)*, i1} @__system_staticcall(i256 0, i256 1, i256 2, i256 3)
+  %res = call {i8 addrspace(3)*, i1} @__staticcall(i256 0, i256 1, i256 2, i256 3, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef)
   ret {i8 addrspace(3)*, i1} %res
 }
 
 ; CHECK-LABEL: invoke.system_delegatecall
 define {i8 addrspace(3)*, i1} @invoke.system_delegatecall() {
-  ; CHECK: near_call r0, @__system_delegatecall, @DEFAULT_UNWIND
+  ; CHECK: near_call r0, @__delegatecall, @DEFAULT_UNWIND
   ; CHECK-NEXT: ret
-  %res = call {i8 addrspace(3)*, i1} @__system_delegatecall(i256 0, i256 1, i256 2, i256 3)
+  %res = call {i8 addrspace(3)*, i1} @__delegatecall(i256 0, i256 1, i256 2, i256 3, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef)
   ret {i8 addrspace(3)*, i1} %res
 }
 
 ; CHECK-LABEL: invoke.system_mimiccall
 define {i8 addrspace(3)*, i1} @invoke.system_mimiccall() {
-  ; CHECK: near_call r0, @__system_mimiccall, @DEFAULT_UNWIND
+  ; CHECK: near_call r0, @__mimiccall, @DEFAULT_UNWIND
   ; CHECK-NEXT: ret
-  %res = call {i8 addrspace(3)*, i1} @__system_mimiccall(i256 0, i256 1, i256 2, i256 3, i256 4)
+  %res = call {i8 addrspace(3)*, i1} @__mimiccall(i256 0, i256 1, i256 2, i256 3, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 4)
   ret {i8 addrspace(3)*, i1} %res
 }
 
@@ -281,7 +281,7 @@ define {i8 addrspace(3)*, i1} @invoke.system_mimiccall() {
 define {i8 addrspace(3)*, i1} @invoke.farcall_byref(i8 addrspace(3)* %a1) {
   ; CHECK: near_call r0, @__farcall_byref, @DEFAULT_UNWIND
   ; CHECK-NEXT: ret
-  %res = call {i8 addrspace(3)*, i1} @__farcall_byref(i8 addrspace(3)* %a1, i256 0)
+  %res = call {i8 addrspace(3)*, i1} @__farcall_byref(i8 addrspace(3)* %a1, i256 0, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef)
   ret {i8 addrspace(3)*, i1} %res
 }
 
@@ -289,7 +289,7 @@ define {i8 addrspace(3)*, i1} @invoke.farcall_byref(i8 addrspace(3)* %a1) {
 define {i8 addrspace(3)*, i1} @invoke.staticcall_byref(i8 addrspace(3)* %a1) {
   ; CHECK: near_call r0, @__staticcall_byref, @DEFAULT_UNWIND
   ; CHECK-NEXT: ret
-  %res = call {i8 addrspace(3)*, i1} @__staticcall_byref(i8 addrspace(3)* %a1, i256 0)
+  %res = call {i8 addrspace(3)*, i1} @__staticcall_byref(i8 addrspace(3)* %a1, i256 0, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef)
   ret {i8 addrspace(3)*, i1} %res
 }
 
@@ -297,7 +297,7 @@ define {i8 addrspace(3)*, i1} @invoke.staticcall_byref(i8 addrspace(3)* %a1) {
 define {i8 addrspace(3)*, i1} @invoke.delegatecall_byref(i8 addrspace(3)* %a1) {
   ; CHECK: near_call r0, @__delegatecall_byref, @DEFAULT_UNWIND
   ; CHECK-NEXT: ret
-  %res = call {i8 addrspace(3)*, i1} @__delegatecall_byref(i8 addrspace(3)* %a1, i256 0)
+  %res = call {i8 addrspace(3)*, i1} @__delegatecall_byref(i8 addrspace(3)* %a1, i256 0, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef)
   ret {i8 addrspace(3)*, i1} %res
 }
 
@@ -305,39 +305,39 @@ define {i8 addrspace(3)*, i1} @invoke.delegatecall_byref(i8 addrspace(3)* %a1) {
 define {i8 addrspace(3)*, i1} @invoke.mimiccall_byref(i8 addrspace(3)* %a1) {
   ; CHECK: near_call r0, @__mimiccall_byref, @DEFAULT_UNWIND
   ; CHECK-NEXT: ret
-  %res = call {i8 addrspace(3)*, i1} @__mimiccall_byref(i8 addrspace(3)* %a1, i256 0, i256 0)
+  %res = call {i8 addrspace(3)*, i1} @__mimiccall_byref(i8 addrspace(3)* %a1, i256 0, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 42)
   ret {i8 addrspace(3)*, i1} %res
 }
 
 ; CHECK-LABEL: invoke.system_call_byref
 define {i8 addrspace(3)*, i1} @invoke.system_call_byref(i8 addrspace(3)* %a1) {
-  ; CHECK: near_call r0, @__system_call_byref, @DEFAULT_UNWIND
+  ; CHECK: near_call r0, @__farcall_byref, @DEFAULT_UNWIND
   ; CHECK-NEXT: ret
-  %res = call {i8 addrspace(3)*, i1} @__system_call_byref(i8 addrspace(3)* %a1, i256 1, i256 2, i256 3)
+  %res = call {i8 addrspace(3)*, i1} @__farcall_byref(i8 addrspace(3)* %a1, i256 1, i256 2, i256 3, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef)
   ret {i8 addrspace(3)*, i1} %res
 }
 
 ; CHECK-LABEL: invoke.system_staticcall_byref
 define {i8 addrspace(3)*, i1} @invoke.system_staticcall_byref(i8 addrspace(3)* %a1) {
-  ; CHECK: near_call r0, @__system_staticcall_byref, @DEFAULT_UNWIND
+  ; CHECK: near_call r0, @__staticcall_byref, @DEFAULT_UNWIND
   ; CHECK-NEXT: ret
-  %res = call {i8 addrspace(3)*, i1} @__system_staticcall_byref(i8 addrspace(3)* %a1, i256 1, i256 2, i256 3)
+  %res = call {i8 addrspace(3)*, i1} @__staticcall_byref(i8 addrspace(3)* %a1, i256 1, i256 2, i256 3, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef)
   ret {i8 addrspace(3)*, i1} %res
 }
 
 ; CHECK-LABEL: invoke.system_delegatecall_byref
 define {i8 addrspace(3)*, i1} @invoke.system_delegatecall_byref(i8 addrspace(3)* %a1) {
-  ; CHECK: near_call r0, @__system_delegatecall_byref, @DEFAULT_UNWIND
+  ; CHECK: near_call r0, @__delegatecall_byref, @DEFAULT_UNWIND
   ; CHECK-NEXT: ret
-  %res = call {i8 addrspace(3)*, i1} @__system_delegatecall_byref(i8 addrspace(3)* %a1, i256 1, i256 2, i256 3)
+  %res = call {i8 addrspace(3)*, i1} @__delegatecall_byref(i8 addrspace(3)* %a1, i256 1, i256 2, i256 3, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef)
   ret {i8 addrspace(3)*, i1} %res
 }
 
 ; CHECK-LABEL: invoke.system_mimiccall_byref
 define {i8 addrspace(3)*, i1} @invoke.system_mimiccall_byref(i8 addrspace(3)* %a1) {
-  ; CHECK: near_call r0, @__system_mimiccall_byref, @DEFAULT_UNWIND
+  ; CHECK: near_call r0, @__mimiccall_byref, @DEFAULT_UNWIND
   ; CHECK-NEXT: ret
-  %res = call {i8 addrspace(3)*, i1} @__system_mimiccall_byref(i8 addrspace(3)* %a1, i256 1, i256 2, i256 3, i256 4)
+  %res = call {i8 addrspace(3)*, i1} @__mimiccall_byref(i8 addrspace(3)* %a1, i256 1, i256 2, i256 3, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 4)
   ret {i8 addrspace(3)*, i1} %res
 }
 
@@ -363,35 +363,7 @@ define {i8 addrspace(3)*, i1} @invoke.system_mimiccall_byref(i8 addrspace(3)* %a
 ; CHECK-NOT: r1
 ; CHECK-NOT: r2
 ; CHECK-NOT: r3
-; CHECK: far_call.mimic r1, r2
-
-; CHECK-LABEL: __system_call
-; CHECK-NOT: r1
-; CHECK-NOT: r2
-; CHECK-NOT: r3
-; CHECK-NOT: r4
-; CHECK: far_call r1, r2
-
-; CHECK-LABEL: __system_staticcall
-; CHECK-NOT: r1
-; CHECK-NOT: r2
-; CHECK-NOT: r3
-; CHECK-NOT: r4
-; CHECK: far_call.static r1, r2
-
-; CHECK-LABEL: __system_delegatecall
-; CHECK-NOT: r1
-; CHECK-NOT: r2
-; CHECK-NOT: r3
-; CHECK-NOT: r4
-; CHECK: far_call.delegate r1, r2
-
-; CHECK-LABEL: __system_mimiccall
-; CHECK-NOT: r1
-; CHECK-NOT: r2
-; CHECK-NOT: r3
-; CHECK-NOT: r4
-; CHECK-NOT: r5
+; CHECK: add r13, r0, r15
 ; CHECK: far_call.mimic r1, r2
 
 ; CHECK-LABEL: __farcall_byref
@@ -413,35 +385,7 @@ define {i8 addrspace(3)*, i1} @invoke.system_mimiccall_byref(i8 addrspace(3)* %a
 ; CHECK-NOT: r1
 ; CHECK-NOT: r2
 ; CHECK-NOT: r3
-; CHECK: far_call.mimic r1, r2
-
-; CHECK-LABEL: __system_call_byref
-; CHECK-NOT: r1
-; CHECK-NOT: r2
-; CHECK-NOT: r3
-; CHECK-NOT: r4
-; CHECK: far_call r1, r2
-
-; CHECK-LABEL: __system_staticcall_byref
-; CHECK-NOT: r1
-; CHECK-NOT: r2
-; CHECK-NOT: r3
-; CHECK-NOT: r4
-; CHECK: far_call.static r1, r2
-
-; CHECK-LABEL: __system_delegatecall_byref
-; CHECK-NOT: r1
-; CHECK-NOT: r2
-; CHECK-NOT: r3
-; CHECK-NOT: r4
-; CHECK: far_call.delegate r1, r2
-
-; CHECK-LABEL: __system_mimiccall_byref
-; CHECK-NOT: r1
-; CHECK-NOT: r2
-; CHECK-NOT: r3
-; CHECK-NOT: r4
-; CHECK-NOT: r5
+; CHECK: add r13, r0, r15
 ; CHECK: far_call.mimic r1, r2
 
 declare i8* @llvm.stacksave()
@@ -469,20 +413,12 @@ declare i256 @llvm.syncvm.ifeq(i256, i256)
 declare i256 @llvm.syncvm.iflt(i256, i256)
 declare i256 @llvm.syncvm.ifgt(i256, i256)
 
-declare {i8 addrspace(3)*, i1} @__farcall(i256, i256)
-declare {i8 addrspace(3)*, i1} @__staticcall(i256, i256)
-declare {i8 addrspace(3)*, i1} @__delegatecall(i256, i256)
-declare {i8 addrspace(3)*, i1} @__mimiccall(i256, i256, i256)
-declare {i8 addrspace(3)*, i1} @__system_call(i256, i256, i256, i256)
-declare {i8 addrspace(3)*, i1} @__system_staticcall(i256, i256, i256, i256)
-declare {i8 addrspace(3)*, i1} @__system_delegatecall(i256, i256, i256, i256)
-declare {i8 addrspace(3)*, i1} @__system_mimiccall(i256, i256, i256, i256, i256)
+declare {i8 addrspace(3)*, i1} @__farcall(i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256)
+declare {i8 addrspace(3)*, i1} @__staticcall(i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256)
+declare {i8 addrspace(3)*, i1} @__delegatecall(i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256)
+declare {i8 addrspace(3)*, i1} @__mimiccall(i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256)
 
-declare {i8 addrspace(3)*, i1} @__farcall_byref(i8 addrspace(3)*, i256)
-declare {i8 addrspace(3)*, i1} @__staticcall_byref(i8 addrspace(3)*, i256)
-declare {i8 addrspace(3)*, i1} @__delegatecall_byref(i8 addrspace(3)*, i256)
-declare {i8 addrspace(3)*, i1} @__mimiccall_byref(i8 addrspace(3)*, i256, i256)
-declare {i8 addrspace(3)*, i1} @__system_call_byref(i8 addrspace(3)*, i256, i256, i256)
-declare {i8 addrspace(3)*, i1} @__system_staticcall_byref(i8 addrspace(3)*, i256, i256, i256)
-declare {i8 addrspace(3)*, i1} @__system_delegatecall_byref(i8 addrspace(3)*, i256, i256, i256)
-declare {i8 addrspace(3)*, i1} @__system_mimiccall_byref(i8 addrspace(3)*, i256, i256, i256, i256)
+declare {i8 addrspace(3)*, i1} @__farcall_byref(i8 addrspace(3)*, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256)
+declare {i8 addrspace(3)*, i1} @__staticcall_byref(i8 addrspace(3)*, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256)
+declare {i8 addrspace(3)*, i1} @__delegatecall_byref(i8 addrspace(3)*, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256)
+declare {i8 addrspace(3)*, i1} @__mimiccall_byref(i8 addrspace(3)*, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256)


### PR DESCRIPTION
All far calls but mimic call now have 12 parameters, mimic call has 13 with whom to mimic comes last. The wrapper puts it to r15 before a mimic call instruction.
