### PR TITLE
Disable AssertAlign for intrinsics in DAG builder

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -115,7 +115,11 @@ using namespace SwitchCG;
 static unsigned LimitFloatPrecision;
 
 static cl::opt<bool>
-    InsertAssertAlign("insert-assert-align", cl::init(true),
+// SyncVM local begin
+// We can't assert alignment for fat pointers which are not numerical.
+// TODO: Move it to the compiler's driver to pass as option.
+    InsertAssertAlign("insert-assert-align", cl::init(false),
+// SyncVM local end
                       cl::desc("Insert the experimental `assertalign` node."),
                       cl::ReallyHidden);
 

--- a/llvm/test/CodeGen/SyncVM/fatpointer-align-assert.ll
+++ b/llvm/test/CodeGen/SyncVM/fatpointer-align-assert.ll
@@ -1,0 +1,16 @@
+; RUN: llc < %s
+target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
+target triple = "syncvm-unknown-unknown"
+
+declare ptr addrspace(3) @llvm.syncvm.ptr.shrink(ptr addrspace(3), i256)
+
+define i256 @__entry() {
+  call void @__runtime()
+  unreachable
+}
+
+define private void @__runtime() {
+entry:
+  %active_pointer_shrunken = call align 32 ptr addrspace(3) @llvm.syncvm.ptr.shrink(ptr addrspace(3) align 32 undef, i256 65535)
+  unreachable
+}


### PR DESCRIPTION
Because fat pointers are not numeric, LLVM doesn't know how to assert alignment, so trust the FE on that respect.
