### PR TITLE
[CI] CPR-942: Automate Lit tests with extra verification options

### DIFF
--- a/.github/workflows/compiler-integration-tests.yml
+++ b/.github/workflows/compiler-integration-tests.yml
@@ -15,6 +15,7 @@ on:
         required: true
         default: "main"
 
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -82,6 +83,59 @@ jobs:
           ${DOCKER_CMD} sh -c 'cd compiler-llvm && \
           ./build_gnu.sh ${{ env.LLVM_BUILD_TYPE }}'
 
+      - name: Testing with LLVM Lit default options.
+        run: ${DOCKER_CMD} sh -c 'cd compiler-llvm && ninja -C build-target check-llvm'
+
+      - name: Running Lit SyncVM tests with llc verification options.
+        env:
+            LLC_OPTS: >
+              --cgp-verify-bfi-updates
+              --compile-twice
+              --earlycse-debug-hash
+              --loop-distribute-verify
+              --machine-combiner-verify-pattern-order
+              --phicse-debug-hash
+              --reassociate-geps-verify-no-dead-code
+              --safepoint-ir-verifier-print-only
+              --scev-verify-ir
+              --tail-dup-verify
+              --unroll-verify-domtree
+              --vplan-verify-hcfg
+            XFAILS:
+              "CodeGen/SyncVM/memcpy-expansion.ll"
+        run: ${DOCKER_CMD} sh -c 'cd compiler-llvm && build-target/bin/llvm-lit -s --xfail "${XFAILS}"  "-Dllc=llc ${LLC_OPTS}"  llvm/test/CodeGen/SyncVM/'
+
+      - name: Running Lit tests with opt verification options.
+        env:
+            OPT_OPTS: >
+              --cgp-verify-bfi-updates
+              --earlycse-debug-hash
+              --loop-distribute-verify
+              --machine-combiner-verify-pattern-order
+              --phicse-debug-hash
+              --scev-verify-ir
+              --tail-dup-verify
+              --unroll-verify-domtree
+              --verify-assumption-cache
+              --verify-cfg-preserved
+              --verify-cfiinstrs
+              --verify-coalescing
+              --verify-dom-info
+              --verify-loop-info
+              --verify-loop-lcssa
+              --verify-machine-dom-info
+              --verify-machineinstrs
+              --verify-memoryssa
+              --verify-misched
+              --verify-regalloc
+              --verify-scev-strict
+              --vplan-verify-hcfg
+            XFAILS:
+              "Transforms/LoopVectorize/vplan_hcfg_stress_test.ll;\
+              Transforms/LoopFlatten/widen-iv2.ll;\
+              Transforms/LoopFusion/simple.ll"
+        run: ${DOCKER_CMD} sh -c 'cd compiler-llvm && build-target/bin/llvm-lit -s --xfail "${XFAILS}" "-Dopt=opt ${OPT_OPTS}"  llvm/test/CodeGen/'
+
       - name: Testing. Building and running compiler tester.
         id: compiler_tester_run
         run: |
@@ -99,10 +153,8 @@ jobs:
 
       - name: Testing. Running segfault.sh.
         if: always() && steps.compiler_tester_run.outcome == 'failure' && env.RUN_SEGFAULT_STEP == 'true'
-        run: ${DOCKER_CMD} sh -c 'cd compiler-tester && ./segfault.sh'
-
-      - name: Testing with LLVM Lit.
-        run: ${DOCKER_CMD} sh -c 'cd compiler-llvm && ninja -C build-target check-llvm'
+        run: |
+          ${DOCKER_CMD} sh -c 'cd compiler-tester && ./segfault.sh'
 
       - uses: 8398a7/action-slack@v3
         with:


### PR DESCRIPTION
- GitHub Action runs for our target-specific LLVM Lit tests with additional verification options for `llc`.  To do: 
  - Also add `--verify-machineinstrs` when CPR-917 is fixed
  - `--verify-regalloc`: CPR-927 
  - `--compile-twice`: CPR-928
- Extra `opt` verification options on all tests, with xfails for a few which fail.  To do:
  - `--verify-safepoint-ir`: CPR-935
- GitHub UI checkbox for skipping the slower tests, mainly for me while developing 
  - Negative test: [runs/3789380641](https://github.com/matter-labs/compiler-llvm/actions/runs/3789380641) 
  - Positive test: [runs/3790403282](https://github.com/matter-labs/compiler-llvm/actions/runs/3790403282)