### PR TITLE
[Asm] clear constant pool after emitting asm file

### DIFF
--- a/llvm/lib/Target/SyncVM/SyncVMAsmPrinter.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMAsmPrinter.cpp
@@ -158,6 +158,10 @@ void SyncVMAsmPrinter::emitEndOfAsmFile(Module &) {
     // then print constant:
     emitGlobalConstant(getDataLayout(), C);
   }
+
+  // after emitting all the things, we also need to clear symbol cache
+  UniqueConstants.clear();
+  ConstantPoolMap.clear();
 }
 
 void SyncVMAsmPrinter::emitConstantPool() {

--- a/llvm/test/CodeGen/SyncVM/icmp.ll
+++ b/llvm/test/CodeGen/SyncVM/icmp.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s | FileCheck %s
+; RUN: llc --compile-twice < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
 target triple = "syncvm"


### PR DESCRIPTION
This is needed to fix the `--verify-twice` option, as it will run the compilation pipeline twice.
