### PR TITLE
[RegInfo] Do not use imm 0 to represent R0

### DIFF
--- a/llvm/lib/Target/SyncVM/SyncVMInstrInfo.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrInfo.cpp
@@ -290,7 +290,7 @@ void SyncVMInstrInfo::loadRegFromStackSlot(
         .addFrameIndex(FrameIdx)
         .addImm(32)
         .addImm(0)
-        .addImm(0)
+        .addReg(SyncVM::R0)
         .addImm(0)
         .addMemOperand(MMO);
   } else if (RC == &SyncVM::GRPTRRegClass) {
@@ -299,7 +299,7 @@ void SyncVMInstrInfo::loadRegFromStackSlot(
         .addFrameIndex(FrameIdx)
         .addImm(32)
         .addImm(0)
-        .addImm(0)
+        .addReg(SyncVM::R0)
         .addImm(0)
         .addMemOperand(MMO);
   } else {

--- a/llvm/test/CodeGen/SyncVM/calling-convensions.ll
+++ b/llvm/test/CodeGen/SyncVM/calling-convensions.ll
@@ -144,45 +144,45 @@ define i256 @caller_argtypes(i1 %a1, i8 %a2, i16 %a3, i32 %a4, i64 %a5, i128 %a6
 
 	; CHECK: near_call r0, @i1.arg, @DEFAULT_UNWIND
   %1 = call i256 @i1.arg(i1 %a1)
-	; CHECK: add stack-[2], 0, r1
+	; CHECK: add stack-[2], r0, r1
 	; CHECK: near_call r0, @i8.arg, @DEFAULT_UNWIND
   %2 = call i256 @i8.arg(i8 %a2)
-	; CHECK: add stack-[3], 0, r1
+	; CHECK: add stack-[3], r0, r1
 	; CHECK: near_call r0, @i16.arg, @DEFAULT_UNWIND
   %3 = call i256 @i16.arg(i16 %a3)
-	; CHECK: add stack-[4], 0, r1
+	; CHECK: add stack-[4], r0, r1
 	; CHECK: near_call r0, @i32.arg, @DEFAULT_UNWIND
   %4 = call i256 @i32.arg(i32 %a4)
-	; CHECK: add stack-[5], 0, r1
+	; CHECK: add stack-[5], r0, r1
 	; CHECK: near_call r0, @i64.arg, @DEFAULT_UNWIND
   %5 = call i256 @i64.arg(i64 %a5)
-	; CHECK: add stack-[6], 0, r1
+	; CHECK: add stack-[6], r0, r1
 	; CHECK: near_call r0, @i128.arg, @DEFAULT_UNWIND
   %6 = call i256 @i128.arg(i128 %a6)
 
 	; CHECK: add 42, r0, r15
 	; CHECK: add r15, r0, stack-[7]
-	; CHECK: add stack-[1], 0, r1
+	; CHECK: add stack-[1], r0, r1
 	; CHECK: near_call r15, @i1.arg, @DEFAULT_UNWIND
   %7 = call i256(i256*, i256, ...) @llvm.syncvm.nearcall(i256* %ptr1, i256 42, i1 %a1)
-	; CHECK: add stack-[2], 0, r1
-	; CHECK: add stack-[7], 0, r15
+	; CHECK: add stack-[2], r0, r1
+	; CHECK: add stack-[7], r0, r15
 	; CHECK: near_call r15, @i8.arg, @DEFAULT_UNWIND
   %8 = call i256(i256*, i256, ...) @llvm.syncvm.nearcall(i256* %ptr8, i256 42, i8 %a2)
-	; CHECK: add stack-[3], 0, r1
-	; CHECK: add stack-[7], 0, r15
+	; CHECK: add stack-[3], r0, r1
+	; CHECK: add stack-[7], r0, r15
 	; CHECK: near_call r15, @i16.arg, @DEFAULT_UNWIND
   %9 = call i256(i256*, i256, ...) @llvm.syncvm.nearcall(i256* %ptr16, i256 42, i16 %a3)
-	; CHECK: add stack-[4], 0, r1
-	; CHECK: add stack-[7], 0, r15
+	; CHECK: add stack-[4], r0, r1
+	; CHECK: add stack-[7], r0, r15
 	; CHECK: near_call r15, @i32.arg, @DEFAULT_UNWIND
   %10 = call i256(i256*, i256, ...) @llvm.syncvm.nearcall(i256* %ptr32, i256 42, i32 %a4)
-	; CHECK: add stack-[5], 0, r1
-	; CHECK: add stack-[7], 0, r15
+	; CHECK: add stack-[5], r0, r1
+	; CHECK: add stack-[7], r0, r15
 	; CHECK: near_call r15, @i64.arg, @DEFAULT_UNWIND
   %11 = call i256(i256*, i256, ...) @llvm.syncvm.nearcall(i256* %ptr64, i256 42, i64 %a5)
-	; CHECK: add stack-[6], 0, r1
-	; CHECK: add stack-[7], 0, r15
+	; CHECK: add stack-[6], r0, r1
+	; CHECK: add stack-[7], r0, r15
 	; CHECK: near_call r15, @i128.arg, @DEFAULT_UNWIND
   %12 = call i256(i256*, i256, ...) @llvm.syncvm.nearcall(i256* %ptr128, i256 42, i128 %a6)
 

--- a/llvm/test/CodeGen/SyncVM/farcall-spill.ll
+++ b/llvm/test/CodeGen/SyncVM/farcall-spill.ll
@@ -13,7 +13,7 @@ define void @test1() personality i32 ()* @__personality {
   ; CHECK: ptr.add r1, r0, stack-[1]
 ok:
   call void @spill()
-  ; CHECK: ptr.add stack-[1], 0, r1
+  ; CHECK: ptr.add stack-[1], r0, r1
   store i8 addrspace(3)* %fptr, i8 addrspace(3)** @ptr
   ret void
 fail:
@@ -37,7 +37,7 @@ delegatecall:
 ok:
   %fptr = phi i8 addrspace(3)* [%fptrs, %staticcall], [%fptrd, %delegatecall]
   call void @spill()
-  ; CHECK: ptr.add stack-[1], 0, r1
+  ; CHECK: ptr.add stack-[1], r0, r1
   store i8 addrspace(3)* %fptr, i8 addrspace(3)** @ptr
   ret void
 fail:


### PR DESCRIPTION
Which will cause `--verify-regalloc` to fail due to incompatible type of operand. Use `SyncVM::R0` instead of `0`.
