### PR TITLE
[ISel] Optimize storing sequence for extend stores

### DIFF
--- a/llvm/test/CodeGen/SyncVM/zeroinitializer.ll
+++ b/llvm/test/CodeGen/SyncVM/zeroinitializer.ll
@@ -8,7 +8,7 @@ define void @zeroinit_fatptr() {
 entry:
   ; CHECK: nop stack+=[2]
   %ptr = alloca { i8 addrspace(3)*, i1 }
-  ; TODO: CPR-888 Codegen for store to stack-[1] is incorrect
+  ; CHECK: add 0, r0, stack-[1]
   ; CHECK: add 0, r0, stack-[2]
   store { i8 addrspace(3)*, i1 } zeroinitializer, { i8 addrspace(3)*, i1 }* %ptr, align 32
   ret void


### PR DESCRIPTION
In the case of storing smaller-typed values to a 256bit, semantically we do not need to mask the original memory value with the to-be-stored value. Instead we can extend the storing value to the pointer type and use fewer instructions.

