### PR TITLE
[Fix] INVOKE is not a terminator

### DIFF
--- a/llvm/lib/Target/SyncVM/SyncVMInstrInfo.td
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrInfo.td
@@ -1319,10 +1319,8 @@ let Defs = [R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15],
     Uses = [SP], isCall = 1 in {
    def CALL : Pseudo<(outs), (ins GR256:$in1, imm16:$callee),
                    "CALL\t$in1, $callee", [(SyncVMcall GR256:$in1, tglobaladdr:$callee)]>;
-   let isTerminator = 1 in
    def INVOKE : Pseudo<(outs), (ins GR256:$in1, imm16:$callee, jmptarget:$unwind),
                    "INVOKE\t$in1, $callee, $unwind", [(SyncVMinvoke GR256:$in1, tglobaladdr:$callee, bb:$unwind)]>;
-
    def NEAR_CALL : ICall<9, CFNormal, (ins GR256:$in1, imm16:$callee, jmptarget:$unwind),
                    "near_call\t$in1, $callee, $unwind", []>;
 }


### PR DESCRIPTION
INVOKE is eventually converted to a near call, which should not be a terminator by itself. The throwing and error handling is already done in other parts.

This patch fix the following test:
```
build-target/bin/llc   --verify-regalloc  --verify-machineinstrs llvm/test/CodeGen/SyncVM/cxa_throw.ll
```

