### PR TITLE
[Fix] Silence verifier's complain about stack register

### DIFF
--- a/llvm/lib/Target/SyncVM/SyncVMInstrInfo.td
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrInfo.td
@@ -169,7 +169,7 @@ def memop : Operand<i256> {
 
 def stackop : Operand<i256> {
   let PrintMethod = "printStackOperand";
-  let MIOperandInfo = (ops GR256, GR256, i16imm);
+  let MIOperandInfo = (ops GRStack, GR256, i16imm);
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/SyncVM/SyncVMRegisterInfo.td
+++ b/llvm/lib/Target/SyncVM/SyncVMRegisterInfo.td
@@ -42,7 +42,6 @@ def GRPTR : RegisterClass<"SyncVM", [fatptr], 256, (add R0, R1, R2, R3, R4, R5, 
                                                       R7, R8, R9, R10, R11, R12,
                                                       R13, R14, R15)>;
 
-
 //===----------------------------------------------------------------------===//
 // Special registers
 //===----------------------------------------------------------------------===//
@@ -64,3 +63,6 @@ def Flags : SyncVMRegister<18, "#BAD#">;
 
 let isAllocatable = 0 in
 def SPR256 : RegisterClass<"SyncVM", [i256], 256, (add PC, SP, Flags)>;
+
+// Registers that could be used for stack addressing.
+def GRStack : RegisterClass<"SyncVM", [i256], 256, (add R0, SP)>;


### PR DESCRIPTION
In stack addressing mode, we sometimes need to use $SP for designating relative stack addresses. Previously machine verifier would complain that `$SP` should not be part of a stack operand.

This patch simply add `$SP` to be part of the legal stackop so verifier will not complain anymore.

This should fix the machine verifier complain about illegal machine operand. To reproduce the issue, use the following:
```
llc  --verify-machineinstrs tests/Codegen/SyncVM/add.ll
```

