### PR TITLE
Track commit id as part of the version

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -1110,6 +1110,16 @@ if(LLVM_INCLUDE_TESTS)
   umbrella_lit_testsuite_begin(check-all)
 endif()
 
+# SyncVM local begin
+find_package(Git REQUIRED)
+execute_process(COMMAND "${GIT_EXECUTABLE}" rev-parse HEAD
+                WORKING_DIRECTORY "${LLVM_MAIN_SRC_DIR}"
+                OUTPUT_VARIABLE COMMIT_ID
+                RESULT_VARIABLE RES_ID
+                OUTPUT_STRIP_TRAILING_WHITESPACE)
+add_compile_definitions(SYNCVM_LLVM_COMMIT_ID="${COMMIT_ID}")
+# SyncVM local end
+
 # Put this before tblgen. Else we have a circular dependence.
 add_subdirectory(lib/Demangle)
 add_subdirectory(lib/Support)

--- a/llvm/include/llvm-c/Support.h
+++ b/llvm/include/llvm-c/Support.h
@@ -63,6 +63,14 @@ void *LLVMSearchForAddressOfSymbol(const char *symbolName);
  */
 void LLVMAddSymbol(const char *symbolName, void *symbolValue);
 
+// SyncVM local begin
+/**
+ * Print git commit id to Buf.
+ * Return sprintf exit code.
+ */
+int LLVMPrintCommitIDTo(char* Buf);
+// SyncVM local end
+
 /**
  * @}
  */

--- a/llvm/lib/Support/CommandLine.cpp
+++ b/llvm/lib/Support/CommandLine.cpp
@@ -2471,6 +2471,11 @@ public:
     OS << "LLVM (http://llvm.org/):\n  ";
 #endif
     OS << PACKAGE_NAME << " version " << PACKAGE_VERSION << "\n  ";
+// SyncVM local begin
+#ifdef SYNCVM_LLVM_COMMIT_ID
+    OS << "Git: " << SYNCVM_LLVM_COMMIT_ID << "\n  ";
+#endif
+// SyncVM local end
 #if LLVM_IS_DEBUG_BUILD
     OS << "DEBUG build";
 #else
@@ -2739,3 +2744,9 @@ void LLVMParseCommandLineOptions(int argc, const char *const *argv,
   llvm::cl::ParseCommandLineOptions(argc, argv, StringRef(Overview),
                                     &llvm::nulls());
 }
+
+// SyncVM local begin
+int LLVMPrintCommitIDTo(char* Buf) {
+  return sprintf(Buf, "%s", SYNCVM_LLVM_COMMIT_ID);
+}
+// SyncVM local end


### PR DESCRIPTION
* Export commit ID getting API as LLVMPrintCommitIDTo.
* Print commit id in LLVM tool --version message.