### PR TITLE
[CI] Add --verify-regalloc to LLC_OPTS

### DIFF
--- a/.github/workflows/compiler-integration-tests.yml
+++ b/.github/workflows/compiler-integration-tests.yml
@@ -97,6 +97,7 @@ jobs:
               --scev-verify-ir
               --tail-dup-verify
               --unroll-verify-domtree
+              --verify-regalloc
               --vplan-verify-hcfg
             XFAILS:
               "CodeGen/SyncVM/memcpy-expansion.ll"


### PR DESCRIPTION
(as well as to OPT_OPTS, which was 7272213d6e80) now that CPR-927 is fixed.