### PR TITLE
[UnitTest] Adding flag setting map unit tests

### DIFF
--- a/llvm/lib/Target/SyncVM/SyncVMInstrFormats.td
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrFormats.td
@@ -46,7 +46,7 @@ def ToStackReg     : DestAddrModeValue<4>;
 
 def getPseudoMapOpcode : InstrMapping {
   let FilterClass = "PseudoRel";
-  let RowFields = ["BaseOpcode", "OperandAddrMode", "DestAddrMode", "ReverseOperand"];
+  let RowFields = ["BaseOpcode", "OperandAddrMode", "DestAddrMode", "ReverseOperand", "isCommutable"];
   let ColFields = ["IsPseudoArith"];
   let KeyCol = ["1"];
   let ValueCols = [["0"]];

--- a/llvm/lib/Target/SyncVM/SyncVMInstrInfo.td
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrInfo.td
@@ -806,7 +806,7 @@ multiclass PtrInstr<bits<8> opcode, string asmstring, SDPatternOperator node> {
   def xrr_v : Iirr<opcode, 1, 0,
                        (outs GRPTR:$rd0), (ins imm16:$imm, GRPTR:$rs1, cc:$cc),
                        !strconcat(!strconcat(asmstring, ".s"),
-                                  "$cc!\t$imm, $rs1, $rd0"), []>;
+                                  "$cc!\t$imm, $rs1, $rd0"), []>, FlagRel;
   let mayLoad = 1 in {
   let isPseudo = 1, isCodeGenOnly = 1 in
   def yrr_p : Pseudo<(outs GRPTR:$rd0), (ins memop:$src0, GRPTR:$rs1),
@@ -967,24 +967,40 @@ multiclass Arith2<bits<8> opcode, string asmstring, SDPatternOperator node, bit 
   }
 
   let mayStore = 1 in {
+  def rrsr_p : Pseudo<(outs GR256:$rd1), (ins GR256:$rs0, GR256:$rs1, stackop:$dst0),
+                      !strconcat(asmstring, "\t$rs0, $rs1, $dst0, $rd1"), []> {
+                        let DestAddrMode = ToStackReg.Value;
+                        let OperandAddrMode = OpndRR.Value;
+                      }
   def rrsr_s : Irrsr<opcode, 0, 1,
                      (outs GR256:$rd1), (ins GR256:$rs0, GR256:$rs1, stackop:$dst0, cc:$cc),
-                     !strconcat(asmstring, "$cc\t$rs0, $rs1, $dst0, $rd1"), []>, FlagRel;
+                     !strconcat(asmstring, "$cc\t$rs0, $rs1, $dst0, $rd1"), []>, PseudoRel, FlagRel;
   let Defs = [Flags] in
   def rrsr_v : Irrsr<opcode, 0, 0,
                      (outs GR256:$rd1), (ins GR256:$rs0, GR256:$rs1, stackop:$dst0, cc:$cc),
                      !strconcat(asmstring, "$cc!\t$rs0, $rs1, $dst0, $rd1"), []>, FlagRel;
   let mayLoad = 1 in {
+  def crsr_p : Pseudo<(outs GR256:$rd1), (ins memop:$src0, GR256:$rs1, stackop:$dst0),
+                      !strconcat(asmstring, "\t$src0[0], $rs1, $dst0, $rd1"), []> {
+                        let DestAddrMode = ToStackReg.Value;
+                        let OperandAddrMode = OpndCR.Value;
+                      }
   def crsr_s : Imrsr<opcode, SrcCode, 0, 1,
                      (outs GR256:$rd1), (ins memop:$src0, GR256:$rs1, stackop:$dst0, cc:$cc),
-                     !strconcat(asmstring, "$cc\t$src0[0], $rs1, $dst0, $rd1"), []>, FlagRel;
+                     !strconcat(asmstring, "$cc\t$src0[0], $rs1, $dst0, $rd1"), []>, PseudoRel, FlagRel;
   let Defs = [Flags] in
   def crsr_v : Imrsr<opcode, SrcCode, 0, 0,
                      (outs GR256:$rd1), (ins memop:$src0, GR256:$rs1, stackop:$dst0, cc:$cc),
                      !strconcat(asmstring, "$cc!\t$src0[0], $rs1, $dst0, $rd1"), []>, FlagRel;
+  def srsr_p : Pseudo<(outs GR256:$rd1), (ins stackop:$src0, GR256:$rs1, stackop:$dst0),
+                      !strconcat(asmstring, "\t$src0, $rs1, $dst0, $rd1"), []> {
+                        let DestAddrMode = ToStackReg.Value;
+                        let OperandAddrMode = OpndSR.Value;
+                        let ReverseOperand = 0;
+                      }
   def srsr_s : Isrsr<opcode, SrcStack, 0, 1,
                      (outs GR256:$rd1), (ins stackop:$src0, GR256:$rs1, stackop:$dst0, cc:$cc),
-                     !strconcat(asmstring, "$cc\t$src0, $rs1, $dst0, $rd1"), []>, FlagRel;
+                     !strconcat(asmstring, "$cc\t$src0, $rs1, $dst0, $rd1"), []>, PseudoRel, FlagRel;
   let Defs = [Flags] in
   def srsr_v : Isrsr<opcode, SrcStack, 0, 0,
                      (outs GR256:$rd1), (ins stackop:$src0, GR256:$rs1, stackop:$dst0, cc:$cc),
@@ -997,7 +1013,6 @@ multiclass Arith2<bits<8> opcode, string asmstring, SDPatternOperator node, bit 
 multiclass Arith2ICommutable<bits<8> opcode, string asmstring, SDPatternOperator node>
          : Arith2<opcode, asmstring, node, 1> {
   let BaseOpcode = asmstring, isCommutable = 1 in {
-  let isPseudo = 1, isCodeGenOnly = 1 in
   def irrr_p : Pseudo<(outs GR256:$rd0, GR256:$rd1), (ins imm16:$imm, GR256:$rs1),
                       !strconcat(asmstring, "\t$imm, $rs1, $rd0, $rd1"),
                       [(set GR256:$rd0, GR256:$rd1, (node GR256:$rs1, imm16:$imm))]> {
@@ -1012,9 +1027,14 @@ multiclass Arith2ICommutable<bits<8> opcode, string asmstring, SDPatternOperator
                      (outs GR256:$rd0, GR256:$rd1), (ins imm16:$imm, GR256:$rs1, cc:$cc),
                      !strconcat(asmstring, "$cc!\t$imm, $rs1, $rd0, $rd1"), []>, FlagRel;
   let mayStore = 1 in {
+  def irsr_p : Pseudo<(outs GR256:$rd1), (ins imm16:$imm, GR256:$rs1, stackop:$dst0),
+                      !strconcat(asmstring, "\t$imm, $rs1, $dst0, $rd1"), []> {
+                        let DestAddrMode = ToStackReg.Value;
+                        let OperandAddrMode = OpndIR.Value;
+                      }
   def irsr_s : Iirsr<opcode, 0, 1,
                      (outs GR256:$rd1), (ins imm16:$imm, GR256:$rs1, stackop:$dst0, cc:$cc),
-                     !strconcat(asmstring, "$cc\t$imm, $rs1, $dst0, $rd1"), []>, FlagRel;
+                     !strconcat(asmstring, "$cc\t$imm, $rs1, $dst0, $rd1"), []>, PseudoRel, FlagRel;
   let Defs = [Flags] in
   def irsr_v : Iirsr<opcode, 0, 0,
                      (outs GR256:$rd1), (ins imm16:$imm, GR256:$rs1, stackop:$dst0, cc:$cc),
@@ -1075,7 +1095,7 @@ multiclass Arith2INonCommutable<bits<8> opcode, string asmstring, SDPatternOpera
   def yrrr_v : Imrrr<opcode, SrcCode, 1, 0,
                      (outs GR256:$rd0, GR256:$rd1), (ins memop:$src0, GR256:$rs1, cc:$cc),
                      !strconcat(asmstring, ".s$cc!\t$src0[0], $rs1, $rd0, $rd1"), []>, FlagRel;
-  let isPseudo = 1 in
+  let isPseudo = 1, isCodeGenOnly = 1 in
   def zrrr_p : Pseudo<(outs GR256:$rd0, GR256:$rd1), (ins stackop:$src0, GR256:$rs1),
                       !strconcat(asmstring, ".s\t$src0, $rs1, $rd0, $rd1"),
                       [(set GR256:$rd0, GR256:$rd1, (node GR256:$rs1, (load_stack stackaddr:$src0)))]> {
@@ -1092,11 +1112,20 @@ multiclass Arith2INonCommutable<bits<8> opcode, string asmstring, SDPatternOpera
                    !strconcat(asmstring, ".s$cc!\t$src0, $rs1, $rd0, $rd1"), []>, FlagRel;
   }
   let mayStore = 1 in {
-  foreach swap = ["i", "x"] in
+  foreach swap = ["i", "x"] in {
+  let isPseudo = 1, isCodeGenOnly = 1 in
+  def swap#rsr_p : Pseudo<(outs GR256:$rd1), (ins imm16:$imm, GR256:$rs1, stackop:$dst0), 
+                          !strconcat(!strconcat(asmstring, !if(!eq(swap, "i"), "", ".s")),
+                                    "\t$imm, $rs1, $dst0, $rd1"), []> {
+      let DestAddrMode = ToStackReg.Value;
+      let OperandAddrMode = OpndIR.Value;
+      let ReverseOperand = !if(!eq(swap, "i"), 0, 1);
+    }
   def swap#rsr_s : Iirsr<opcode, !if(!eq(swap, "i"), 0, 1), 1,
                          (outs GR256:$rd1), (ins imm16:$imm, GR256:$rs1, stackop:$dst0, cc:$cc),
                          !strconcat(!strconcat(asmstring, !if(!eq(swap, "i"), "", ".s")),
                                     "$cc\t$imm, $rs1, $dst0, $rd1"), []>, PseudoRel, FlagRel;
+  }
   foreach swap = ["i", "x"] in
   let Defs = [Flags] in
   def swap#rsr_v : Iirsr<opcode, !if(!eq(swap, "i"), 0, 1), 0,
@@ -1104,6 +1133,13 @@ multiclass Arith2INonCommutable<bits<8> opcode, string asmstring, SDPatternOpera
                          !strconcat(!strconcat(asmstring, !if(!eq(swap, "i"), "", ".s")),
                                     "$cc!\t$imm, $rs1, $dst0, $rd1"), []>, FlagRel;
   let mayLoad = 1 in {
+  let isPseudo = 1, isCodeGenOnly = 1 in
+  def yrsr_p : Pseudo<(outs GR256:$rd0), (ins memop:$src0, GR256:$rs1, stackop:$dst0),
+                      !strconcat(asmstring, ".s\t$src0[0], $rs1, $dst0, $rd0"), []> {
+                        let DestAddrMode = ToStackReg.Value;
+                        let OperandAddrMode = OpndCR.Value;
+                        let ReverseOperand = 1;
+                      }
   def yrsr_s : Imrsr<opcode, SrcCode, 1, 1,
                      (outs GR256:$rd0), (ins memop:$src0, GR256:$rs1, stackop:$dst0, cc:$cc),
                      !strconcat(asmstring, ".s$cc\t$src0[0], $rs1, $dst0, $rd0"), []>, PseudoRel, FlagRel;
@@ -1111,6 +1147,13 @@ multiclass Arith2INonCommutable<bits<8> opcode, string asmstring, SDPatternOpera
   def yrsr_v : Imrsr<opcode, SrcCode, 1, 0,
                      (outs GR256:$rd0), (ins memop:$src0, GR256:$rs1, stackop:$dst0, cc:$cc),
                      !strconcat(asmstring, ".s$cc!\t$src0[0], $rs1, $dst0, $rd0"), []>, FlagRel;
+  let isPseudo = 1, isCodeGenOnly = 1 in
+  def zrsr_p : Pseudo<(outs GR256:$rd0), (ins stackop:$src0, GR256:$rs1, stackop:$dst0),
+                      !strconcat(asmstring, ".s\t$src0, $rs1, $dst0, $rd0"), []> {
+                        let DestAddrMode = ToStackReg.Value;
+                        let OperandAddrMode = OpndSR.Value;
+                        let ReverseOperand = 1;
+                      }
   def zrsr_s : Isrsr<opcode, SrcStack, 1, 1,
                      (outs GR256:$rd0), (ins stackop:$src0, GR256:$rs1, stackop:$dst0, cc:$cc),
                      !strconcat(asmstring, ".s$cc\t$src0, $rs1, $dst0, $rd0"), []>, PseudoRel, FlagRel;

--- a/llvm/unittests/Target/SyncVM/CMakeLists.txt
+++ b/llvm/unittests/Target/SyncVM/CMakeLists.txt
@@ -1,0 +1,23 @@
+include_directories(
+  ${LLVM_MAIN_SRC_DIR}/lib/Target/SyncVM
+  ${LLVM_BINARY_DIR}/lib/Target/SyncVM
+  )
+
+set(LLVM_LINK_COMPONENTS
+  SyncVMCodeGen
+  SyncVMDesc
+  SyncVMInfo
+  CodeGen
+  Core
+  MC
+  MIRParser
+  SelectionDAG
+  Support
+  Target
+)
+
+add_llvm_target_unittest(SyncVMTests
+  InstrMappingTest.cpp
+  )
+
+set_property(TARGET SyncVMTests PROPERTY FOLDER "Tests/UnitTests/TargetTests")

--- a/llvm/unittests/Target/SyncVM/InstrMappingTest.cpp
+++ b/llvm/unittests/Target/SyncVM/InstrMappingTest.cpp
@@ -1,0 +1,99 @@
+//===------------ llvm/unittests/Target/SyncVM/InstrMapping.cpp -----------===//
+//
+// Coverage tests for SyncVM's Tablegen InstrMapping implementations.
+//
+//===----------------------------------------------------------------------===//
+
+#include "Utils.h"
+
+#define EXPECT_MAP_BASE(OpcodeName, S1, S2)                                    \
+  EXPECT_MAP_EQ_OPCODE_BASE(OpcodeName##rrr_, S1, S2);                         \
+  EXPECT_MAP_EQ_OPCODE_BASE(OpcodeName##rrs_, S1, S2);                         \
+  EXPECT_MAP_EQ_OPCODE_BASE(OpcodeName##srr_, S1, S2);                         \
+  EXPECT_MAP_EQ_OPCODE_BASE(OpcodeName##srs_, S1, S2)
+
+#define EXPECT_MAP_COMMUTABLE(OpcodeName, S1, S2)                              \
+  EXPECT_MAP_BASE(OpcodeName, S1, S2);                                         \
+  EXPECT_MAP_EQ_OPCODE_BASE(OpcodeName##irr_, S1, S2);                         \
+  EXPECT_MAP_EQ_OPCODE_BASE(OpcodeName##irs_, S1, S2);                         \
+  EXPECT_MAP_EQ_OPCODE_BASE(OpcodeName##crr_, S1, S2);                         \
+  EXPECT_MAP_EQ_OPCODE_BASE(OpcodeName##crs_, S1, S2)
+
+#define EXPECT_MAP_NONCOMMUTABLE(OpcodeName, S1, S2)                           \
+  EXPECT_MAP_COMMUTABLE(OpcodeName, S1, S2);                                   \
+  EXPECT_MAP_EQ_OPCODE_BASE(OpcodeName##xrr_, S1, S2);                         \
+  EXPECT_MAP_EQ_OPCODE_BASE(OpcodeName##xrs_, S1, S2);                         \
+  EXPECT_MAP_EQ_OPCODE_BASE(OpcodeName##yrr_, S1, S2);                         \
+  EXPECT_MAP_EQ_OPCODE_BASE(OpcodeName##yrs_, S1, S2);                         \
+  EXPECT_MAP_EQ_OPCODE_BASE(OpcodeName##zrr_, S1, S2);                         \
+  EXPECT_MAP_EQ_OPCODE_BASE(OpcodeName##zrs_, S1, S2)
+
+#define EXPECT_MAP_ARITH2(Opcode, S1, S2)                                      \
+  EXPECT_MAP_EQ_OPCODE_BASE(Opcode##rrrr_, S1, S2);                            \
+  EXPECT_MAP_EQ_OPCODE_BASE(Opcode##irrr_, S1, S2);                            \
+  EXPECT_MAP_EQ_OPCODE_BASE(Opcode##irsr_, S1, S2);                            \
+  EXPECT_MAP_EQ_OPCODE_BASE(Opcode##crrr_, S1, S2);                            \
+  EXPECT_MAP_EQ_OPCODE_BASE(Opcode##srrr_, S1, S2);                            \
+  EXPECT_MAP_EQ_OPCODE_BASE(Opcode##rrsr_, S1, S2);                            \
+  EXPECT_MAP_EQ_OPCODE_BASE(Opcode##crsr_, S1, S2);                            \
+  EXPECT_MAP_EQ_OPCODE_BASE(Opcode##srsr_, S1, S2)
+
+#define EXPECT_MAP_ARITH2_EXTEND(Opcode, S1, S2)                               \
+  EXPECT_MAP_ARITH2(Opcode, S1, S2);                                           \
+  EXPECT_MAP_EQ_OPCODE_BASE(Opcode##xrrr_, S1, S2);                            \
+  EXPECT_MAP_EQ_OPCODE_BASE(Opcode##yrrr_, S1, S2);                            \
+  EXPECT_MAP_EQ_OPCODE_BASE(Opcode##zrrr_, S1, S2);                            \
+  EXPECT_MAP_EQ_OPCODE_BASE(Opcode##xrsr_, S1, S2);                            \
+  EXPECT_MAP_EQ_OPCODE_BASE(Opcode##yrsr_, S1, S2);                            \
+  EXPECT_MAP_EQ_OPCODE_BASE(Opcode##zrsr_, S1, S2)
+
+#define EXPECT_MAP_PTR(Opcode, S1, S2)                                         \
+  EXPECT_MAP_EQ_OPCODE_BASE(Opcode##rrr_, S1, S2);                             \
+  EXPECT_MAP_EQ_OPCODE_BASE(Opcode##srr_, S1, S2);                             \
+  EXPECT_MAP_EQ_OPCODE_BASE(Opcode##xrr_, S1, S2);                             \
+  EXPECT_MAP_EQ_OPCODE_BASE(Opcode##yrr_, S1, S2);                             \
+  EXPECT_MAP_EQ_OPCODE_BASE(Opcode##zrr_, S1, S2);                             \
+  EXPECT_MAP_EQ_OPCODE_BASE(Opcode##rrs_, S1, S2);                             \
+  EXPECT_MAP_EQ_OPCODE_BASE(Opcode##xrs_, S1, S2);                             \
+  EXPECT_MAP_EQ_OPCODE_BASE(Opcode##yrs_, S1, S2);                             \
+  EXPECT_MAP_EQ_OPCODE_BASE(Opcode##zrs_, S1, S2)
+
+#define TEST_INSTR_MAPS(S1, S2)                                                \
+  EXPECT_MAP_COMMUTABLE(SyncVM::ADD, S1, S2);                                  \
+  EXPECT_MAP_COMMUTABLE(SyncVM::AND, S1, S2);                                  \
+  EXPECT_MAP_COMMUTABLE(SyncVM::OR, S1, S2);                                   \
+  EXPECT_MAP_COMMUTABLE(SyncVM::XOR, S1, S2);                                  \
+  EXPECT_MAP_NONCOMMUTABLE(SyncVM::SUB, S1, S2);                               \
+  EXPECT_MAP_NONCOMMUTABLE(SyncVM::SHL, S1, S2);                               \
+  EXPECT_MAP_NONCOMMUTABLE(SyncVM::SHR, S1, S2);                               \
+  EXPECT_MAP_NONCOMMUTABLE(SyncVM::ROL, S1, S2);                               \
+  EXPECT_MAP_NONCOMMUTABLE(SyncVM::ROR, S1, S2);                               \
+  EXPECT_MAP_PTR(SyncVM::PTR_ADD, S1, S2);                                     \
+  EXPECT_MAP_PTR(SyncVM::PTR_PACK, S1, S2);                                    \
+  EXPECT_MAP_PTR(SyncVM::PTR_SHRINK, S1, S2);                                  \
+  EXPECT_MAP_ARITH2(SyncVM::MUL, S1, S2);                                      \
+  EXPECT_MAP_ARITH2_EXTEND(SyncVM::DIV, S1, S2)
+
+TEST(GetFlagSettingOpcode, TheTest) {
+#undef EXPECT_MAP_EQ_OPCODE_BASE
+#define EXPECT_MAP_EQ_OPCODE_BASE(Opcode, Subfix1, Subfix2)                    \
+  EXPECT_EQ(SyncVM::getFlagSettingOpcode(Opcode##Subfix1), Opcode##Subfix2)
+
+  TEST_INSTR_MAPS(s, v);
+}
+
+TEST(GetNonFlagSettingOpcode, TheTest) {
+#undef EXPECT_MAP_EQ_OPCODE_BASE
+#define EXPECT_MAP_EQ_OPCODE_BASE(Opcode, Subfix1, Subfix2)                    \
+  EXPECT_EQ(SyncVM::getNonFlagSettingOpcode(Opcode##Subfix1), Opcode##Subfix2)
+
+  TEST_INSTR_MAPS(v, s);
+}
+
+TEST(GetPseudoMapOpcode, TheTest) {
+#undef EXPECT_MAP_EQ_OPCODE_BASE
+#define EXPECT_MAP_EQ_OPCODE_BASE(Opcode, Subfix1, Subfix2)                    \
+  EXPECT_EQ(SyncVM::getPseudoMapOpcode(Opcode##Subfix1), Opcode##Subfix2)
+
+  TEST_INSTR_MAPS(p, s);
+}

--- a/llvm/unittests/Target/SyncVM/Utils.h
+++ b/llvm/unittests/Target/SyncVM/Utils.h
@@ -1,0 +1,44 @@
+//===---------------- llvm/unittests/Target/SyncVM/Utils.h ----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "SyncVMTargetMachine.h"
+#include "SyncVMSubtarget.h"
+
+#include "MCTargetDesc/SyncVMMCTargetDesc.h"
+#include "llvm/CodeGen/TargetSubtargetInfo.h"
+#include "llvm/MC/MCTargetOptions.h"
+#include "llvm/MC/TargetRegistry.h"
+#include "llvm/Support/TargetSelect.h"
+#include "llvm/Target/TargetMachine.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+static std::once_flag flag;
+
+static void InitializeSyncVMTarget() {
+  std::call_once(flag, []() {
+    LLVMInitializeSyncVMTargetInfo();
+    LLVMInitializeSyncVMTarget();
+    LLVMInitializeSyncVMTargetMC();
+  });
+}
+
+[[maybe_unused]]
+std::unique_ptr<const SyncVMTargetMachine>
+createSyncVMTargetMachine() {
+  InitializeSyncVMTarget();
+
+  std::string Error;
+  const Target *T = TargetRegistry::lookupTarget("syncvm", Error);
+  if (!T)
+    return nullptr;
+
+  TargetOptions Options;
+  return std::unique_ptr<SyncVMTargetMachine>(static_cast<SyncVMTargetMachine *>(
+      T->createTargetMachine("syncvm", "", "", Options, None, None)));
+}


### PR DESCRIPTION
Adds a new CMake target: `SyncVMTests`, which is a gunit test suite.

Also added a `Utils.h` for easier unit test writing in the future.

