### PR TITLE
Fix MIR format THROW instruction to quench verifier's complain

### DIFF
--- a/llvm/lib/Target/SyncVM/SyncVMExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMExpandPseudoInsts.cpp
@@ -270,7 +270,7 @@ bool SyncVMExpandPseudo::runOnMachineFunction(MachineFunction &MF) {
         auto func_name = func_opnd->getName();
         if (func_name == "__cxa_throw") {
           BuildMI(*MI.getParent(), &MI, MI.getDebugLoc(),
-                  TII->get(SyncVM::THROW));
+                  TII->get(SyncVM::THROW)).addReg(SyncVM::R1);
         } else {
           // One of the problem: the backend cannot restrict frontend to not
           // emit calls (Should we reinforce it?) so this route is needed. If a

--- a/llvm/lib/Target/SyncVM/SyncVMInstrInfo.td
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrInfo.td
@@ -1268,8 +1268,11 @@ def RET   : IRet<7, RFNone, (ins), "ret", [(SyncVMret)]>;
 def PANIC : IRet<7, RFPanic, (ins GR256:$rs0), "ret.panic\t$rs0", []>;
 }
 let isTerminator = 1, isBarrier = 1, isTrap = 1 in
-def THROW : IRet<7, RFErr, (ins GR256:$rs0), "revert",
+def THROW : IRet<7, RFErr, (ins GR256:$rs0), "ret.error\t$rs0",
                  [(SyncVMthrow GR256:$rs0)]>;
+
+def : InstAlias<"revert", (THROW R1)>;
+def : InstAlias<"panic", (PANIC R1)>;
 
 let isTerminator = 1, isBarrier = 1 in {
 def RETURN : IRet<52, RFErr, (ins GR256:$rs0), "ret.ok.to_label\t$rs0, @DEFAULT_FAR_RETURN",


### PR DESCRIPTION
This should fix one of the problem in the following run:
```
llc --verify-machineinstrs cxa_throw.ll
```
