### PR TITLE
[ISEL] directly materialize constants on stack

### DIFF
--- a/llvm/lib/Target/SyncVM/SyncVMInstrInfo.td
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrInfo.td
@@ -1180,6 +1180,9 @@ defm PTR_ADD    : PtrInstr<159, "ptr.add", SyncVMptr_add>;
 defm PTR_PACK   : PtrInstr<160, "ptr.pack", SyncVMptr_pack>;
 defm PTR_SHRINK : PtrInstr<161, "ptr.shrink", SyncVMptr_shrink>;
 
+// Materialization of constants on stack
+def : Pat<(store_stack imm16:$imm, stackaddr:$dst),  (ADDirs_p imm16:$imm, R0, stackaddr:$dst)>;
+
 // MOV patterns
 def : Pat<(store_stack (load_code memaddr:$src), stackaddr:$dst),  (ADDcrs_p memaddr:$src, R0, stackaddr:$dst)>;
 def : Pat<(store_stack (load_stack stackaddr:$src), stackaddr:$dst),  (ADDsrs_p stackaddr:$src, R0, stackaddr:$dst)>;

--- a/llvm/test/CodeGen/SyncVM/add.ll
+++ b/llvm/test/CodeGen/SyncVM/add.ll
@@ -78,7 +78,15 @@ define void @addsrs(i256 %rs1) nounwind {
 ; CHECK-LABEL: addneg
 define i256 @addneg(i256 %rs1) nounwind {
   %res = add i256 %rs1, -65535
-; CHECK; sub.s   65535, r1, r1
+; CHECK: sub.s   65535, r1, r1
   ret i256 %res
+}
+
+; CHECK-LABEL: addstack
+define void @addstack() nounwind {
+  %valptr = alloca i256
+; CHECK: add 1024, r0, stack-[1]
+  store i256 1024, i256 * %valptr
+  ret void
 }
 


### PR DESCRIPTION
Adding an instruction selection pattern to materialize constants directly on stack.

