### PR TITLE
Update some root files for open-sourcing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,9 @@
-# Contributing to LLVM
+# Contribution Guidelines
 
-Thank you for your interest in contributing to LLVM! There are many ways to
-contribute, and we appreciate all contributions.
+Thank you for considering helping out with the source code! We are extremely grateful for any consideration of
+contributions to this repository. However, at this time, we generally do not accept external contributions. This policy
+will change in the future, so please check back regularly for updates.
 
-To get started with contributing, please take a look at the
-[Contributing to LLVM](https://llvm.org/docs/Contributing.html) guide. It
-describes how to get involved, raise issues and submit patches. Please note
-that at the moment the LLVM project does not use GitHub pull requests.
+For security issues, please contact us at [security@matterlabs.dev](mailto:security@matterlabs.dev).
+
+Thank you for your support in accelerating the mass adoption of crypto for personal sovereignty!

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,0 @@
-# Reporting LLVM Security Issues
-
-To report security issues in LLVM, please follow the steps outlined on the
-[LLVM Security Group](https://llvm.org/docs/Security.html#how-to-report-a-security-issue)
-page.


### PR DESCRIPTION
Updated the root files according to our open-sourcing guide.

We consulted with lawyers and decided not to change any LICENSEs here.

READMEs are ok too, since building LLVM without our `zkevm-llvm` tool and the enclosing compiler isn't of much use for users. We'll be able to update the README in the future on request though.