### PR TITLE
[ISEL] Wrap all global symbols

### DIFF
--- a/llvm/lib/Target/SyncVM/SyncVMISelLowering.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMISelLowering.cpp
@@ -33,24 +33,47 @@ using namespace llvm;
 
 #define DEBUG_TYPE "syncvm-lower"
 
-/// Wrap global address with GAStack or GACode nodes.
+/// Helper function: wrap symbols according to their address space.
 /// Precondition:
-/// \p ValueToWrap is SDValue containing a GlobalAddressSDNode.
-/// The nodes are to lower CopyToReg GlobalAddress to
-/// 1. Materialize GlobalAddress in a virtual register
-/// 2. Copy it to a physical one.
-/// TODO: CPR-921 Should be removed after a proper wrapping is implemented.
-static SDValue wrappedGlobalAddress(const SDValue &ValueToWrap,
-                                    SelectionDAG &DAG, const SDLoc &DL) {
-  auto *GANode = cast<GlobalAddressSDNode>(ValueToWrap.getNode());
-  switch (GANode->getAddressSpace()) {
+/// \p ValueToWrap is SDValue containing a symbol value (global address,
+/// external symbol or block address)
+SDValue SyncVMTargetLowering::wrapSymbol(const SDValue &ValueToWrap,
+                                         SelectionDAG &DAG, const SDLoc &DL,
+                                         unsigned addrspace) const {
+  auto VT = getPointerTy(DAG.getDataLayout());
+  switch (addrspace) {
   case SyncVMAS::AS_STACK:
-    return DAG.getNode(SyncVMISD::GAStack, DL, MVT::i256, ValueToWrap);
+    return DAG.getNode(SyncVMISD::GAStack, DL, VT, ValueToWrap);
   case SyncVMAS::AS_CODE:
-    return DAG.getNode(SyncVMISD::GACode, DL, MVT::i256, ValueToWrap);
+    return DAG.getNode(SyncVMISD::GACode, DL, VT, ValueToWrap);
+  default:
+    llvm_unreachable("Global symbol in unexpected addr space");
   }
-  llvm_unreachable("Global symbol in unexpected addr space");
   return {};
+}
+
+/// Wrap a global address and lower to TargetGlobalAddress.
+/// The \p ValueToWrap must be a GlobalAddressSDNode.
+SDValue SyncVMTargetLowering::wrapGlobalAddress(const SDValue &ValueToWrap,
+                                                SelectionDAG &DAG,
+                                                const SDLoc &DL) const {
+  // convert to TargetGlobalAddress
+  auto *GANode = dyn_cast<GlobalAddressSDNode>(ValueToWrap.getNode());
+  auto TGA = DAG.getTargetGlobalAddress(
+      GANode->getGlobal(), DL, ValueToWrap.getValueType(), GANode->getOffset());
+  return wrapSymbol(TGA, DAG, DL, GANode->getAddressSpace());
+}
+
+/// Wrap a external symbol and lower to TargetExternalSymbol.
+/// The \p ValueToWrap must be a ExternalSymbolSDNode.
+SDValue SyncVMTargetLowering::wrapExternalSymbol(const SDValue &ValueToWrap,
+                                                 SelectionDAG &DAG,
+                                                 const SDLoc &DL) const {
+  // convert to TargetExternalSymbol
+  auto *ESNode = dyn_cast<ExternalSymbolSDNode>(ValueToWrap.getNode());
+  auto TES = DAG.getTargetExternalSymbol(ESNode->getSymbol(),
+                                         ValueToWrap.getValueType());
+  return wrapSymbol(TES, DAG, DL, SyncVMAS::AS_CODE);
 }
 
 SyncVMTargetLowering::SyncVMTargetLowering(const TargetMachine &TM,
@@ -208,7 +231,7 @@ SyncVMTargetLowering::LowerReturn(SDValue Chain, CallingConv::ID CallConv,
 
     const SDValue &CurVal = OutVals[i];
     auto Val = isa<GlobalAddressSDNode>(CurVal.getNode())
-                   ? wrappedGlobalAddress(CurVal, DAG, DL)
+                   ? wrapGlobalAddress(CurVal, DAG, DL)
                    : CurVal;
     Chain = DAG.getCopyToReg(Chain, DL, VA.getLocReg(), Val, Flag);
 
@@ -465,16 +488,18 @@ SyncVMTargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
   // If the callee is a GlobalAddress node (quite common, every direct call is)
   // turn it into a TargetGlobalAddress node so that legalize doesn't hack it.
   // Likewise ExternalSymbol -> TargetExternalSymbol.
-  if (GlobalAddressSDNode *G = dyn_cast<GlobalAddressSDNode>(Callee))
-    Callee = DAG.getTargetGlobalAddress(G->getGlobal(), DL, MVT::i256);
-  else if (ExternalSymbolSDNode *E = dyn_cast<ExternalSymbolSDNode>(Callee))
-    Callee = DAG.getTargetExternalSymbol(E->getSymbol(), MVT::i256);
+  if (GlobalAddressSDNode *G = dyn_cast<GlobalAddressSDNode>(Callee)) {
+    Callee = wrapGlobalAddress(Callee, DAG, DL);
+  }
+  else if (ExternalSymbolSDNode *E = dyn_cast<ExternalSymbolSDNode>(Callee)) {
+    Callee = wrapExternalSymbol(Callee, DAG, DL);
+  }
 
   for (unsigned i = 0, e = Outs.size(); i != e; ++i) {
     if (ArgLocs[i].isRegLoc()) {
       SDValue &CurVal = OutVals[i];
       auto Val = isa<GlobalAddressSDNode>(CurVal.getNode())
-                     ? wrappedGlobalAddress(CurVal, DAG, DL)
+                     ? wrapGlobalAddress(CurVal, DAG, DL)
                      : CurVal;
 
       Chain = DAG.getCopyToReg(Chain, DL, ArgLocs[i].getLocReg(), Val, InFlag);
@@ -870,14 +895,7 @@ SDValue SyncVMTargetLowering::LowerSREM(SDValue Op, SelectionDAG &DAG) const {
 
 SDValue SyncVMTargetLowering::LowerGlobalAddress(SDValue Op,
                                                  SelectionDAG &DAG) const {
-  auto *GANode = cast<GlobalAddressSDNode>(Op);
-  const GlobalValue *GV = GANode->getGlobal();
-  int64_t Offset = cast<GlobalAddressSDNode>(Op)->getOffset();
-  auto PtrVT = getPointerTy(DAG.getDataLayout());
-
-  // Create the TargetGlobalAddress node, folding in the constant offset.
-  SDValue Result = DAG.getTargetGlobalAddress(GV, SDLoc(Op), PtrVT, Offset);
-  return Result;
+  return wrapGlobalAddress(Op, DAG, SDLoc(Op));
 }
 
 SDValue SyncVMTargetLowering::LowerExternalSymbol(SDValue Op,

--- a/llvm/lib/Target/SyncVM/SyncVMISelLowering.h
+++ b/llvm/lib/Target/SyncVM/SyncVMISelLowering.h
@@ -245,6 +245,13 @@ private:
 
   Register getRegisterByName(const char *RegName, LLT VT,
                              const MachineFunction &MF) const override;
+
+  SDValue wrapGlobalAddress(const SDValue &ValueToWrap, SelectionDAG &DAG,
+                            const SDLoc &DL) const;
+  SDValue wrapExternalSymbol(const SDValue &ValueToWrap, SelectionDAG &DAG,
+                             const SDLoc &DL) const;
+  SDValue wrapSymbol(const SDValue &ValueToWrap, SelectionDAG &DAG,
+                     const SDLoc &DL, unsigned addrspace) const;
 };
 } // namespace llvm
 

--- a/llvm/lib/Target/SyncVM/SyncVMInstrInfo.td
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrInfo.td
@@ -192,7 +192,6 @@ def constant_pool : SDNodeXForm<imm, [{
 // Complex Pattern Definitions.
 //===----------------------------------------------------------------------===//
 
-def inreg_memaddr: ComplexPattern<iPTR, 1, "SelectInRegMemAddr", [], []>;
 def memaddr      : ComplexPattern<iPTR, 2, "SelectMemAddr", [], []>;
 def stackaddr    : ComplexPattern<iPTR, 3, "SelectStackAddr", [], []>;
 def adjstackaddr : ComplexPattern<iPTR, 3, "SelectAdjStackAddr", [], []>;
@@ -1188,6 +1187,7 @@ def : Pat<(load_code memaddr:$addr),  (ADDcrr_p memaddr:$addr, R0)>;
 def : Pat<(load_stack stackaddr:$addr),  (ADDsrr_p stackaddr:$addr, R0)>;
 def : Pat<(store_stack GR256:$src, stackaddr:$dst),  (ADDrrs_p GR256:$src, R0, stackaddr:$dst)>;
 def : Pat<(store_stack imm16:$src, stackaddr:$dst),  (ADDirs_p imm16:$src, R0, stackaddr:$dst)>;
+
 // fat pointer move patterns
 def : Pat<(fatptr (load_stack stackaddr:$addr)),  (PTR_ADDsrr_p stackaddr:$addr, R0)>;
 def : Pat<(store_stack GRPTR:$src, stackaddr:$dst),  (PTR_ADDrrs_p GRPTR:$src, R0, stackaddr:$dst)>;
@@ -1364,9 +1364,9 @@ def : Pat<(int_syncvm_precompile GR256:$rs0, GR256:$rs1),
 let Defs = [R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, Flags],
     Uses = [SP], isCall = 1 in {
    def CALL : Pseudo<(outs), (ins GR256:$in1, imm16:$callee),
-                   "CALL\t$in1, $callee", [(SyncVMcall GR256:$in1, tglobaladdr:$callee)]>;
+                   "CALL\t$in1, $callee", [(SyncVMcall GR256:$in1, (SyncVMGAStack tglobaladdr:$callee))]>;
    def INVOKE : Pseudo<(outs), (ins GR256:$in1, imm16:$callee, jmptarget:$unwind),
-                   "INVOKE\t$in1, $callee, $unwind", [(SyncVMinvoke GR256:$in1, tglobaladdr:$callee, bb:$unwind)]>;
+                   "INVOKE\t$in1, $callee, $unwind", [(SyncVMinvoke GR256:$in1, (SyncVMGAStack tglobaladdr:$callee), bb:$unwind)]>;
    def NEAR_CALL : ICall<9, CFNormal, (ins GR256:$in1, imm16:$callee, jmptarget:$unwind),
                    "near_call\t$in1, $callee, $unwind", []>;
 

--- a/llvm/test/CodeGen/Generic/2003-05-30-BadPreselectPhi.ll
+++ b/llvm/test/CodeGen/Generic/2003-05-30-BadPreselectPhi.ll
@@ -1,5 +1,3 @@
-; XFAIL: syncvm
-; TODO: CPR-921 Needs proger GA wrapping to be implemented.
 ; RUN: llc < %s
 
 ;; Date:     May 28, 2003.

--- a/llvm/test/CodeGen/Generic/print-mul.ll
+++ b/llvm/test/CodeGen/Generic/print-mul.ll
@@ -1,5 +1,3 @@
-; XFAIL: syncvm
-; TODO: CPR-921 Needs proger GA wrapping to be implemented.
 ; RUN: llc < %s
 
 @a_str = internal constant [8 x i8] c"a = %d\0A\00"		; <[8 x i8]*> [#uses=1]

--- a/llvm/test/CodeGen/Generic/print-shift.ll
+++ b/llvm/test/CodeGen/Generic/print-shift.ll
@@ -1,5 +1,3 @@
-; XFAIL: syncvm
-; TODO: CPR-921 Needs proger GA wrapping to be implemented.
 ; RUN: llc < %s
 
 @a_str = internal constant [8 x i8] c"a = %d\0A\00"             ; <[8 x i8]*> [#uses=1]


### PR DESCRIPTION
The goal is to apply wrappers to all global addresses in lowering and change selection accordingly. 

This patch fixes a few XFAILed generic tests.