### PR TITLE
General fix for code quality

### DIFF
--- a/llvm/lib/Support/CommandLine.cpp
+++ b/llvm/lib/Support/CommandLine.cpp
@@ -2747,6 +2747,7 @@ void LLVMParseCommandLineOptions(int argc, const char *const *argv,
 
 // SyncVM local begin
 int LLVMPrintCommitIDTo(char* Buf) {
-  return sprintf(Buf, "%s", SYNCVM_LLVM_COMMIT_ID);
+  return snprintf(Buf, sizeof(SYNCVM_LLVM_COMMIT_ID), "%s",
+                  SYNCVM_LLVM_COMMIT_ID);
 }
 // SyncVM local end

--- a/llvm/lib/Target/SyncVM/SyncVM.td
+++ b/llvm/lib/Target/SyncVM/SyncVM.td
@@ -12,6 +12,9 @@
 
 include "llvm/Target/Target.td"
 
+class Proc<string Name, list<SubtargetFeature> Features>
+ : Processor<Name, NoItineraries, Features>;
+def : Proc<"generic",         []>;
 
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/SyncVM/SyncVMISelLowering.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMISelLowering.cpp
@@ -50,9 +50,9 @@ SDValue SyncVMTargetLowering::wrapSymbol(const SDValue &ValueToWrap,
   case SyncVMAS::AS_CODE:
     return DAG.getNode(SyncVMISD::GACode, DL, VT, ValueToWrap);
   default:
-    llvm_unreachable("Global symbol in unexpected addr space");
+    break;
   }
-  return {};
+  llvm_unreachable("Global symbol in unexpected addr space");
 }
 
 /// Wrap a global address and lower to TargetGlobalAddress.
@@ -61,7 +61,7 @@ SDValue SyncVMTargetLowering::wrapGlobalAddress(const SDValue &ValueToWrap,
                                                 SelectionDAG &DAG,
                                                 const SDLoc &DL) const {
   // convert to TargetGlobalAddress
-  auto *GANode = dyn_cast<GlobalAddressSDNode>(ValueToWrap.getNode());
+  auto *GANode = cast<GlobalAddressSDNode>(ValueToWrap.getNode());
   auto TGA = DAG.getTargetGlobalAddress(
       GANode->getGlobal(), DL, ValueToWrap.getValueType(), GANode->getOffset());
   return wrapSymbol(TGA, DAG, DL, GANode->getAddressSpace());
@@ -73,7 +73,7 @@ SDValue SyncVMTargetLowering::wrapExternalSymbol(const SDValue &ValueToWrap,
                                                  SelectionDAG &DAG,
                                                  const SDLoc &DL) const {
   // convert to TargetExternalSymbol
-  auto *ESNode = dyn_cast<ExternalSymbolSDNode>(ValueToWrap.getNode());
+  auto *ESNode = cast<ExternalSymbolSDNode>(ValueToWrap.getNode());
   auto TES = DAG.getTargetExternalSymbol(ESNode->getSymbol(),
                                          ValueToWrap.getValueType());
   return wrapSymbol(TES, DAG, DL, SyncVMAS::AS_CODE);
@@ -704,16 +704,14 @@ SDValue SyncVMTargetLowering::LowerANY_EXTEND(SDValue Op,
 SDValue SyncVMTargetLowering::LowerZERO_EXTEND(SDValue Op,
                                                SelectionDAG &DAG) const {
   SDLoc DL(Op);
-  SDValue extending_value = Op.getOperand(0);
-  if (extending_value.getValueType() == Op.getValueType()) {
-    return extending_value;
-  } else {
-    // eliminate zext
-    SDValue new_value = DAG.getNode(extending_value->getOpcode(), DL,
-                                    Op.getValueType(), extending_value->ops());
-    return new_value;
-  }
-  return {};
+  SDValue ExtendingValue = Op.getOperand(0);
+  if (ExtendingValue.getValueType() == Op.getValueType())
+    return ExtendingValue;
+
+  // eliminate zext
+  SDValue NewValue = DAG.getNode(ExtendingValue->getOpcode(), DL,
+                                 Op.getValueType(), ExtendingValue->ops());
+  return NewValue;
 }
 
 SDValue SyncVMTargetLowering::LowerSTORE(SDValue Op, SelectionDAG &DAG) const {

--- a/llvm/lib/Target/SyncVM/SyncVMRegisterInfo.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMRegisterInfo.cpp
@@ -68,7 +68,7 @@ void SyncVMRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator II,
 
   if (MI.getOpcode() == SyncVM::ADDframe) {
     auto SPInst = BuildMI(MBB, II, DL, TII.get(SyncVM::CTXr_se))
-                      .add(MI.getOperand(0))
+                      .addDef(MI.getOperand(0).getReg())
                       .addImm(SyncVMCTX::SP)
                       .addImm(SyncVMCC::COND_NONE)
                       .getInstr();
@@ -76,7 +76,7 @@ void SyncVMRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator II,
     SPInst = BuildMI(MBB, II, DL, TII.get(SyncVM::SUBxrr_s))
                  .addDef(MI.getOperand(0).getReg())
                  .addImm(-Offset / 32)
-                 .add(SPInst->getOperand(0))
+                 .addReg(SPInst->getOperand(0).getReg())
                  .addImm(SyncVMCC::COND_NONE)
                  .getInstr();
 
@@ -87,7 +87,7 @@ void SyncVMRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator II,
         .addDef(MI.getOperand(0).getReg())
         .addDef(SyncVM::R0)
         .addImm(32)
-        .add(SPInst->getOperand(0))
+        .addReg(SPInst->getOperand(0).getReg())
         .addImm(SyncVMCC::COND_NONE);
     MI.eraseFromParent();
     return;


### PR DESCRIPTION
Using this PR to generally improve code quality at places we have found.

* Addressing CPR-1196, CPR-1205
* quenching compiler warnings, such as using `sprintf` and defining zero-length arrays
* assigning def property to input operands
* preserving implicitly defined registers after a call
* Use RegMasks for calls