### PR TITLE
Do not optimize memcpy of size is bigger than i64

### DIFF
--- a/llvm/lib/Analysis/MemoryLocation.cpp
+++ b/llvm/lib/Analysis/MemoryLocation.cpp
@@ -14,6 +14,9 @@
 #include "llvm/IR/IntrinsicsARM.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Type.h"
+// SyncVM local begin
+#include "llvm/ADT/Triple.h"
+// SyncVM local end
 using namespace llvm;
 
 void LocationSize::print(raw_ostream &OS) const {
@@ -164,6 +167,33 @@ MemoryLocation MemoryLocation::getForArgument(const CallBase *Call,
   // We may be able to produce an exact size for known intrinsics.
   if (const IntrinsicInst *II = dyn_cast<IntrinsicInst>(Call)) {
     const DataLayout &DL = II->getModule()->getDataLayout();
+
+    // SyncVM local begin
+    // check if the length is within i64 range. If not, return imprecise
+    // location
+    auto T = Call->getModule()->getTargetTriple();
+    if (Triple(T).isSyncVM()) {
+      switch (II->getIntrinsicID()) {
+      case Intrinsic::memcpy:
+      case Intrinsic::memcpy_inline:
+      case Intrinsic::memmove:
+      case Intrinsic::memset:
+        if (ConstantInt *LenCI = dyn_cast<ConstantInt>(II->getArgOperand(2)))
+          if (LenCI->getValue().getActiveBits() > 64) {
+            return MemoryLocation::getBeforeOrAfter(Call->getArgOperand(ArgIdx),
+                                                    AATags);
+          }
+        break;
+      case Intrinsic::lifetime_start:
+      case Intrinsic::lifetime_end:
+        // it is okay to have lifetime intrinsic
+        break;
+      default:
+        llvm_unreachable("Unexpected intrinsic for SyncVM target");
+        break;
+      }
+    }
+    // SyncVM local end
 
     switch (II->getIntrinsicID()) {
     default:

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGAddressAnalysis.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGAddressAnalysis.cpp
@@ -220,6 +220,10 @@ static BaseIndexOffset matchLSNode(const LSBaseSDNode *N,
       // Only consider ORs which act as adds.
       if (auto *C = dyn_cast<ConstantSDNode>(Base->getOperand(1)))
         if (DAG.MaskedValueIsZero(Base->getOperand(0), C->getAPIntValue())) {
+          // SyncVM local begin
+          if (C->getAPIntValue().getActiveBits() > 64)
+            return BaseIndexOffset();
+          // SyncVM local end
           Offset += C->getSExtValue();
           Base = DAG.getTargetLoweringInfo().unwrapAddress(Base->getOperand(0));
           continue;
@@ -227,6 +231,10 @@ static BaseIndexOffset matchLSNode(const LSBaseSDNode *N,
       break;
     case ISD::ADD:
       if (auto *C = dyn_cast<ConstantSDNode>(Base->getOperand(1))) {
+        // SyncVM local begin
+        if (C->getAPIntValue().getActiveBits() > 64)
+          return BaseIndexOffset();
+        // SyncVM local end
         Offset += C->getSExtValue();
         Base = DAG.getTargetLoweringInfo().unwrapAddress(Base->getOperand(0));
         continue;
@@ -238,6 +246,10 @@ static BaseIndexOffset matchLSNode(const LSBaseSDNode *N,
       unsigned int IndexResNo = (Base->getOpcode() == ISD::LOAD) ? 1 : 0;
       if (LSBase->isIndexed() && Base.getResNo() == IndexResNo)
         if (auto *C = dyn_cast<ConstantSDNode>(LSBase->getOffset())) {
+          // SyncVM local begin
+          if (C->getAPIntValue().getActiveBits() > 64)
+            return BaseIndexOffset();
+          // SyncVM local end
           auto Off = C->getSExtValue();
           if (LSBase->getAddressingMode() == ISD::PRE_DEC ||
               LSBase->getAddressingMode() == ISD::POST_DEC)
@@ -281,6 +293,12 @@ static BaseIndexOffset matchLSNode(const LSBaseSDNode *N,
         !isa<ConstantSDNode>(Index->getOperand(1)))
       return BaseIndexOffset(PotentialBase, Index, Offset, IsIndexSignExt);
 
+    // SyncVM local begin
+    if (cast<ConstantSDNode>(Index->getOperand(1))
+            ->getAPIntValue()
+            .getActiveBits() > 64)
+      return BaseIndexOffset();
+    // SyncVM local end
     Offset += cast<ConstantSDNode>(Index->getOperand(1))->getSExtValue();
     Index = Index->getOperand(0);
     if (Index->getOpcode() == ISD::SIGN_EXTEND) {

--- a/llvm/test/CodeGen/SyncVM/memcpy-expansion.ll
+++ b/llvm/test/CodeGen/SyncVM/memcpy-expansion.ll
@@ -4,6 +4,7 @@ target triple = "syncvm-unknown-unknown"
 
 ; Function Attrs: argmemonly mustprogress nofree nounwind willreturn
 declare void @llvm.memcpy.p1i256.p3i256.i256(i256 addrspace(1)* noalias nocapture writeonly, i256 addrspace(3)* noalias nocapture readonly, i256, i1 immarg)
+declare void @llvm.memcpy.p1i256.p1i256.i256(i256 addrspace(1)* noalias nocapture writeonly, i256 addrspace(1)* noalias nocapture readonly, i256, i1 immarg)
 
 ; CHECK-LABEL: expand-known
 define fastcc void @expand-known(i256 addrspace(1)* %dest, i256 addrspace(3)* %src) {

--- a/llvm/test/CodeGen/SyncVM/memintrinsics-opt.ll
+++ b/llvm/test/CodeGen/SyncVM/memintrinsics-opt.ll
@@ -1,0 +1,29 @@
+; RUN: opt -O3 -S < %s | FileCheck %s
+target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
+target triple = "syncvm"
+
+declare void @llvm.memcpy.p0i256.p0i256.i256(i256 addrspace(0)* noalias nocapture writeonly, i256 addrspace(0)* noalias nocapture readonly, i256, i1 immarg)
+declare void @llvm.memcpy.p1i256.p1i256.i256(i256 addrspace(1)* noalias nocapture writeonly, i256 addrspace(1)* noalias nocapture readonly, i256, i1 immarg)
+declare void @llvm.memcpy.p2i256.p2i256.i256(i256 addrspace(2)* noalias nocapture writeonly, i256 addrspace(2)* noalias nocapture readonly, i256, i1 immarg)
+
+; SimplifyLibCall has this assumption that the size will not exceed i64 datatype.
+; CHECK-LABEL: huge-copysize0
+define fastcc void @huge-copysize0(i256 addrspace(0)* %dest, i256 addrspace(0)* %src) {
+  ; CHECK: tail call void @llvm.memcpy.p0i256.p0i256.i256(i256* align 1 %dest, i256* align 1 %src, i256 81129638414606681695789005144064, i1 false)
+  call void @llvm.memcpy.p0i256.p0i256.i256(i256 addrspace(0)* %dest, i256 addrspace(0)* %src, i256 81129638414606681695789005144064, i1 false)
+  ret void
+}
+
+; CHECK-LABEL: huge-copysize1
+define fastcc void @huge-copysize1(i256 addrspace(1)* %dest, i256 addrspace(1)* %src) {
+  ; CHECK: tail call void @llvm.memcpy.p1i256.p1i256.i256(i256 addrspace(1)* align 1 %dest, i256 addrspace(1)* align 1 %src, i256 81129638414606681695789005144064, i1 false)
+  call void @llvm.memcpy.p1i256.p1i256.i256(i256 addrspace(1)* %dest, i256 addrspace(1)* %src, i256 81129638414606681695789005144064, i1 false)
+  ret void
+}
+
+; CHECK-LABEL: huge-copysize2
+define fastcc void @huge-copysize2(i256 addrspace(2)* %dest, i256 addrspace(2)* %src) {
+  ; CHECK: tail call void @llvm.memcpy.p2i256.p2i256.i256(i256 addrspace(2)* align 1 %dest, i256 addrspace(2)* align 1 %src, i256 81129638414606681695789005144064, i1 false)
+  call void @llvm.memcpy.p2i256.p2i256.i256(i256 addrspace(2)* %dest, i256 addrspace(2)* %src, i256 81129638414606681695789005144064, i1 false)
+  ret void
+}

--- a/llvm/test/CodeGen/SyncVM/memintrinsics.ll
+++ b/llvm/test/CodeGen/SyncVM/memintrinsics.ll
@@ -1,0 +1,144 @@
+; RUN: llc -O3 < %s | FileCheck %s
+target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
+target triple = "syncvm"
+
+declare void @llvm.memcpy.p0i256.p0i256.i256(i256 addrspace(0)* noalias nocapture writeonly, i256 addrspace(0)* noalias nocapture readonly, i256, i1 immarg)
+declare void @llvm.memcpy.p1i256.p1i256.i256(i256 addrspace(1)* noalias nocapture writeonly, i256 addrspace(1)* noalias nocapture readonly, i256, i1 immarg)
+declare void @llvm.memcpy.p2i256.p2i256.i256(i256 addrspace(2)* noalias nocapture writeonly, i256 addrspace(2)* noalias nocapture readonly, i256, i1 immarg)
+
+
+; CHECK-LABEL: huge-copysize0
+define fastcc void @huge-copysize0(i256 addrspace(0)* %dest, i256 addrspace(0)* %src) {
+; CHECK:   add     r0, r0, [[INDEX0:r[0-9]+]]
+; CHECK: .BB0_1:
+; CHECK:   shl.s   5, [[INDEX0]], [[SHIFTED_OFFSET0_SRC:r[0-9]+]]
+; CHECK:   add     r1, [[SHIFTED_OFFSET0_SRC]], [[SHIFTED_OFFSET0_DST:r[0-9]+]]
+; CHECK:   add     r2, [[SHIFTED_OFFSET0_SRC]], [[SHIFTED_OFFSET0_SRC]]
+; CHECK:   div.s   32, [[SHIFTED_OFFSET0_SRC]], [[SHIFTED_OFFSET0_SRC]], r0
+; CHECK:   add     stack[[[SHIFTED_OFFSET0_SRC]] - 0], r0, [[LOADED_VALUE0:r[0-9]+]]
+; CHECK:   div.s   32, [[SHIFTED_OFFSET0_DST]], [[SHIFTED_OFFSET0_DST]], r0
+; CHECK:   add     [[LOADED_VALUE0]], r0, stack[[[SHIFTED_OFFSET0_DST]] - 0]
+; CHECK:   add     1, [[INDEX0]], [[INDEX0]]
+; CHECK:   sub.s!  @CPI0_0[0], [[INDEX0]], r4
+; CHECK:   jump.lt @.BB0_1
+; CHECK:   ret
+  call void @llvm.memcpy.p0i256.p0i256.i256(i256 addrspace(0)* %dest, i256 addrspace(0)* %src, i256 81129638414606681695789005144064, i1 false)
+  ret void
+}
+
+; CHECK-LABEL: huge-copysize1
+define fastcc void @huge-copysize1(i256 addrspace(1)* %dest, i256 addrspace(1)* %src) {
+; CHECK:  add     r0, r0, [[INDEX1:r[0-9]+]]
+; CHECK:.BB1_1:
+; CHECK:  shl.s   5, [[INDEX1]], [[SHIFTED_OFFSET1_SRC:r[0-9]+]]
+; CHECK:  add     r1, [[SHIFTED_OFFSET1_SRC]], [[SHIFTED_OFFSET1_DST:r[0-9]+]]
+; CHECK:  add     r2, [[SHIFTED_OFFSET1_SRC]], [[SHIFTED_OFFSET1_SRC]]
+; CHECK:  ld.1    [[SHIFTED_OFFSET1_SRC]], [[LOADED_VALUE1:r[0-9]+]]
+; CHECK:  st.1    [[SHIFTED_OFFSET1_DST]], [[LOADED_VALUE1]]
+; CHECK:  add     1, [[INDEX1]], [[INDEX1]]
+; CHECK:  sub.s!  @CPI1_0[0], [[INDEX1]], r{{[0-9]+}}
+; CHECK:  jump.lt @.BB1_1
+  
+; trailing part:
+; CHECK:  add     @CPI1_1[0], r1, r1
+; CHECK:  ld.1    r1, [[TRAILING_PART1:r[0-9]+]]
+; CHECK:  and     @CPI1_2[0], [[TRAILING_DST1:r[0-9]+]], [[TRAILING_DST1]]
+; CHECK:  add     @CPI1_1[0], r2, r2
+; CHECK:  ld.1    r2, [[TRAILING_SRC1:r[0-9]+]]
+; CHECK:  and     @CPI1_3[0], [[TRAILING_SRC1]], [[TRAILING_SRC1]]
+; CHECK:  or      [[TRAILING_SRC1]], [[TRAILING_DST1]], [[MERGED1:r[0-9]+]]
+; CHECK:  st.1    r1, [[MERGED1:r[0-9]+]]
+; CHECK:  ret
+
+  ; the test explicitly has some trailing part to be copied.
+  call void @llvm.memcpy.p1i256.p1i256.i256(i256 addrspace(1)* %dest, i256 addrspace(1)* %src, i256 81129638414606681695789005144065, i1 false)
+  ret void
+}
+
+; CHECK-LABEL: huge-copysize2
+define fastcc void @huge-copysize2(i256 addrspace(2)* %dest, i256 addrspace(2)* %src) {
+; CHECK:  add     r0, r0, [[INDEX2:r[0-9]+]]
+; CHECK:.BB2_1:
+; CHECK:  shl.s   5, [[INDEX2]], [[SHIFTED_OFFSET2_SRC:r[0-9]+]]
+; CHECK:  add     r1, [[SHIFTED_OFFSET2_SRC]], [[SHIFTED_OFFSET2_DST:r[0-9]+]]
+; CHECK:  add     r2, [[SHIFTED_OFFSET2_SRC]], [[SHIFTED_OFFSET2_SRC]]
+; CHECK:  ld.2    [[SHIFTED_OFFSET2_SRC]], [[LOADED_VALUE2:r[0-9]+]]
+; CHECK:  st.2    [[SHIFTED_OFFSET2_DST]], [[LOADED_VALUE2]]
+; CHECK:  add     1, [[INDEX2]], [[INDEX2]]
+; CHECK:  sub.s!  @CPI2_0[0], [[INDEX2]], r{{[0-9]+}}
+; CHECK:  jump.lt @.BB2_1
+
+; trailing part:
+; CHECK:  add     @CPI2_1[0], r1, r1
+; CHECK:  ld.2    r1, [[TRAILING_PART2:r[0-9]+]]
+; CHECK:  and     @CPI2_2[0], [[TRAILING_DST2:r[0-9]+]], [[TRAILING_DST2]]
+; CHECK:  add     @CPI2_1[0], r2, r2
+; CHECK:  ld.2    r2, [[TRAILING_SRC2:r[0-9]+]]
+; CHECK:  and     @CPI2_3[0], [[TRAILING_SRC2]], [[TRAILING_SRC2]]
+; CHECK:  or      [[TRAILING_SRC2]], [[TRAILING_DST2]], [[MERGED2:r[0-9]+]]
+; CHECK:  st.2    r1, [[MERGED2:r[0-9]+]]
+; CHECK:  ret
+
+  ; the test explicitly has some trailing part to be copied.
+  call void @llvm.memcpy.p2i256.p2i256.i256(i256 addrspace(2)* %dest, i256 addrspace(2)* %src, i256 81129638414606681695789005144065, i1 false)
+  ret void
+}
+
+; CHECK-LABEL: normal-known-size
+define fastcc void @normal-known-size(i256* %dest, i256* %src) {
+; CHECK:   add     r0, r0, [[INDEX3:r[3-9]+]]
+; CHECK: .BB3_1:
+; CHECK:   shl.s   5, [[INDEX3]], [[SHIFTED_OFFSET3_SRC:r[3-9]+]]
+; CHECK:   add     r1, [[SHIFTED_OFFSET3_SRC]], [[SHIFTED_OFFSET3_DST:r[3-9]+]]
+; CHECK:   add     r2, [[SHIFTED_OFFSET3_SRC]], [[SHIFTED_OFFSET3_SRC]]
+; CHECK:   div.s   32, [[SHIFTED_OFFSET3_SRC]], [[SHIFTED_OFFSET3_SRC]], r0
+; CHECK:   add     stack[[[SHIFTED_OFFSET3_SRC]] - 0], r0, [[LOADED_VALUE3:r[3-9]+]]
+; CHECK:   div.s   32, [[SHIFTED_OFFSET3_DST]], [[SHIFTED_OFFSET3_DST]], r0
+; CHECK:   add     [[LOADED_VALUE3]], r0, stack[[[SHIFTED_OFFSET3_DST]] - 0]
+; CHECK:   add     1, [[INDEX3]], [[INDEX3]]
+; CHECK:   sub.s!  32, [[INDEX3]], r{{[0-9]+}}
+; CHECK:   jump.lt @.BB3_1
+; CHECK:   ret
+  call void @llvm.memcpy.p0i256.p0i256.i256(i256* %dest, i256* %src, i256 1024, i1 false)
+  ret void
+}
+
+; CHECK-LABEL: normal-known-size-2
+define fastcc void @normal-known-size-2(i256* %dest, i256* %src) {
+; CHECK:   add     r0, r0, [[INDEX4:r[3-9]+]]
+; CHECK: .BB4_1:
+; CHECK:   shl.s   5, [[INDEX4]], [[SHIFTED_OFFSET4_SRC:r[3-9]+]]
+; CHECK:   add     r1, [[SHIFTED_OFFSET4_SRC]], [[SHIFTED_OFFSET4_DST:r[3-9]+]]
+; CHECK:   add     r2, [[SHIFTED_OFFSET4_SRC]], [[SHIFTED_OFFSET4_SRC]]
+; CHECK:   div.s   32, [[SHIFTED_OFFSET4_SRC]], [[SHIFTED_OFFSET4_SRC]], r0
+; CHECK:   add     stack[[[SHIFTED_OFFSET4_SRC]] - 0], r0, [[LOADED_VALUE4:r[3-9]+]]
+; CHECK:   div.s   32, [[SHIFTED_OFFSET4_DST]], [[SHIFTED_OFFSET4_DST]], r0
+; CHECK:   add     [[LOADED_VALUE4]], r0, stack[[[SHIFTED_OFFSET4_DST]] - 0]
+; CHECK:   add     1, [[INDEX4]], [[INDEX4]]
+; CHECK:   sub.s!  33, [[INDEX4]], r{{[0-9]+}}
+; CHECK:   jump.lt @.BB4_1
+; CHECK:   add     @CPI4_0[0], r0, [[SRCMASK4:r[0-9]+]]
+; CHECK:   div.s   32, r2, r2, r0
+; CHECK:   and     stack[r2 + 33], [[SRCMASK4]], [[SRCMASKED_VALUE4:r[0-9]+]]
+; CHECK:   add     @CPI4_1[0], r0, [[DSTMASK4:r[0-9]+]]
+; CHECK:   div.s   32, r1, r1, r0
+; CHECK:   and     stack[r1 + 33], [[DSTMASK4]], [[DSTMASKED_VALUE4:r[0-9]+]]
+; CHECK:   or      [[SRCMASKED_VALUE4]], [[DSTMASKED_VALUE4]], stack[r1 + 33]
+  call void @llvm.memcpy.p0i256.p0i256.i256(i256* %dest, i256* %src, i256 1060, i1 false)
+  ret void
+}
+
+; check that the big size copy has correct number of iterations (size / 32)
+; CHECK: CPI0_0:
+; CHECK: CPI1_0:
+; CHECK: CPI2_0:
+; CHECK:        .cell 2535301200456458802993406410752
+
+
+; check that in the trailing part, the mask is correct
+; CHECK: CPI1_1:
+; CHECK: CPI2_1:
+; CHECK:  .cell 452312848583266388373324160190187140051835877600158453279131187530910662655
+; CHECK: CPI1_3:
+; CHECK: CPI2_3:
+; CHECK:  .cell -452312848583266388373324160190187140051835877600158453279131187530910662656


### PR DESCRIPTION
Just a quick fix to avoid crashing in LLVM, regardless of the correctness of frontend emitted IR.

