### PR TITLE
[WIP] Improve and fold instructions with spills and reloads in post-RA

### DIFF
--- a/llvm/lib/Target/SyncVM/CMakeLists.txt
+++ b/llvm/lib/Target/SyncVM/CMakeLists.txt
@@ -45,6 +45,7 @@ add_llvm_target(SyncVMCodeGen
   SyncVMAllocaHoisting.cpp
   SyncVMTargetTransformInfo.cpp
   SyncVMStackAddressConstantPropagation.cpp
+  SyncVMFoldCellScales.cpp
 
   LINK_COMPONENTS
   Analysis

--- a/llvm/lib/Target/SyncVM/SyncVM.h
+++ b/llvm/lib/Target/SyncVM/SyncVM.h
@@ -82,6 +82,7 @@ FunctionPass *createSyncVMPropagateGenericPointersPass();
 FunctionPass *createSyncVMStackAddressConstantPropagationPass();
 FunctionPass *createSyncVMCombineFlagSettingPass();
 FunctionPass *createSyncVMCombineToIndexedMemopsPass();
+FunctionPass *createSyncVMFoldCellScalesPass();
 
 void initializeSyncVMLowerIntrinsicsPass(PassRegistry &);
 void initializeSyncVMAddConditionsPass(PassRegistry &);
@@ -95,6 +96,7 @@ void initializeSyncVMPropagateGenericPointersPass(PassRegistry &);
 void initializeSyncVMStackAddressConstantPropagationPass(PassRegistry &);
 void initializeSyncVMCombineFlagSettingPass(PassRegistry &);
 void initializeSyncVMCombineToIndexedMemopsPass(PassRegistry &);
+void initializeSyncVMFoldCellScalesPass(PassRegistry &);
 
 struct SyncVMLinkRuntimePass : PassInfoMixin<SyncVMLinkRuntimePass> {
   SyncVMLinkRuntimePass() {}

--- a/llvm/lib/Target/SyncVM/SyncVMFoldCellScales.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMFoldCellScales.cpp
@@ -138,12 +138,14 @@ bool SyncVMFoldCellScales::combineCellScalingInstrs(MachineInstr& MI) {
   eraseAndReplaceUses(Div32Uses, SourceReg);
   
   // also remove the shl.s instruction if rY is not used anymore
+  /*
   Register DestReg = MI.getOperand(0).getReg();
   if (RegInfo->use_empty(DestReg)) {
     MI.eraseFromParent();
     ++NumInstrsFolded;
     return true;
   }
+  */
 
   return !Div32Uses.empty();
 }

--- a/llvm/lib/Target/SyncVM/SyncVMFoldCellScales.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMFoldCellScales.cpp
@@ -1,0 +1,155 @@
+//===--- SyncVMFoldCellScales.cpp - Combine memops to indexed ----===//
+//
+/// \file
+/// This file contains load and store combination pass to emit indexed memory
+/// operations. It relies on def-use chains and runs on pre-RA phase.
+///
+/// Note that this pass is not able to handle similar patterns within loops
+/// because %rb will carry loop dependence.
+//===----------------------------------------------------------------------===//
+
+#include "SyncVM.h"
+
+#include "SyncVMSubtarget.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/Statistic.h"
+#include "llvm/CodeGen/MachineDominators.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineInstrBuilder.h"
+#include "llvm/CodeGen/TargetInstrInfo.h"
+#include "llvm/InitializePasses.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Debug.h"
+
+using namespace llvm;
+
+#define DEBUG_TYPE "syncvm-fold-cell-scales"
+#define SYNCVM_FOLD_CELL_SCALES_NAME                                     \
+  "SyncVM fold scales of cell memory operations"
+
+STATISTIC(NumInstrsFolded, "Number of scaling instructions folded");
+
+namespace {
+
+class SyncVMFoldCellScales : public MachineFunctionPass {
+public:
+  static char ID;
+  SyncVMFoldCellScales() : MachineFunctionPass(ID) {}
+
+  bool runOnMachineFunction(MachineFunction &Fn) override;
+
+  StringRef getPassName() const override {
+    return SYNCVM_FOLD_CELL_SCALES_NAME;
+  }
+
+  void getAnalysisUsage(AnalysisUsage &AU) const override {
+    AU.addRequired<MachineDominatorTree>();
+    MachineFunctionPass::getAnalysisUsage(AU);
+  }
+
+private:
+
+  /// Erase all instructions in \p ToErase and replaces registers they define
+  /// with \p R.
+  void eraseAndReplaceUses(SmallVectorImpl<MachineInstr *> &ToErase,
+                           Register R);
+
+  bool FoldCellScales(MachineInstr& MI);
+  ///
+  bool combineCellScalingInstrs(MachineInstr& MI);
+
+  const MachineDominatorTree *MDT;
+  const SyncVMInstrInfo *TII;
+  MachineRegisterInfo *RegInfo;
+};
+
+char SyncVMFoldCellScales::ID = 0;
+
+} // namespace
+
+INITIALIZE_PASS_BEGIN(SyncVMFoldCellScales, DEBUG_TYPE,
+                      SYNCVM_FOLD_CELL_SCALES_NAME, false, false)
+INITIALIZE_PASS_DEPENDENCY(MachineDominatorTree)
+INITIALIZE_PASS_END(SyncVMFoldCellScales, DEBUG_TYPE,
+                    SYNCVM_FOLD_CELL_SCALES_NAME, false, false)
+
+void SyncVMFoldCellScales::eraseAndReplaceUses(
+    SmallVectorImpl<MachineInstr *> &ToErase, Register R) {
+  for (MachineInstr *Inst : ToErase) {
+    auto oldOffset = Inst->getOperand(0);
+    assert(oldOffset.isDef() && "expecting a def operand");
+    auto oldOffsetReg = oldOffset.getReg();
+    RegInfo->replaceRegWith(oldOffsetReg, R);
+    LLVM_DEBUG(dbgs() << " .  Removing instruction: "; Inst->dump());
+    Inst->eraseFromParent();
+    ++NumInstrsFolded;
+  }
+}
+
+bool SyncVMFoldCellScales::runOnMachineFunction(MachineFunction &MF) {
+  LLVM_DEBUG(dbgs() << "********** SyncVM COMBINE LOAD and STORE **********\n"
+                    << "********** Function: " << MF.getName() << '\n');
+
+  RegInfo = &MF.getRegInfo();
+  assert(RegInfo->isSSA());
+  assert(RegInfo->tracksLiveness());
+
+  MDT = &getAnalysis<MachineDominatorTree>();
+  TII =
+      cast<SyncVMInstrInfo>(MF.getSubtarget<SyncVMSubtarget>().getInstrInfo());
+  assert(TII && "TargetInstrInfo must be a valid object");
+
+  bool Changed = false;
+
+  for (auto &MBB : MF) {
+    MachineBasicBlock::iterator MII = MBB.begin();
+    MachineBasicBlock::iterator MIE = MBB.end();
+    while (MII != MIE) {
+      auto &MI = *MII;
+      ++MII;
+
+      // tries to combine shl and div if they are both for scaling cell addresses
+      Changed |= combineCellScalingInstrs(MI);
+    }
+  }
+
+  return Changed;
+}
+
+bool SyncVMFoldCellScales::combineCellScalingInstrs(MachineInstr& MI) {
+  // the incoming MI should be: `shl.s 5, rX, rY`
+  if (!(MI.getOpcode() == SyncVM::SHLxrr_s &&
+      getImmOrCImm(MI.getOperand(1)) == 5)) {
+    return false;
+  }
+  Register SourceReg = MI.getOperand(2).getReg();
+
+  auto Div32Uses =
+      SmallVector<MachineInstr *, 4>{map_range(
+          make_filter_range(RegInfo->use_instructions(SourceReg),
+                            [&MI, this](MachineInstr &CurrentMI) {
+                              return (
+                                  CurrentMI.getOpcode() == SyncVM::DIVxrrr_s &&
+                                  getImmOrCImm(CurrentMI.getOperand(2)) == 32 &&
+                                  MDT->dominates(&MI, &CurrentMI));
+                            }),
+          [](MachineInstr &MI) { return &MI; })};
+
+  eraseAndReplaceUses(Div32Uses, SourceReg);
+  
+  // also remove the shl.s instruction if rY is not used anymore
+  Register DestReg = MI.getOperand(0).getReg();
+  if (RegInfo->use_empty(DestReg)) {
+    MI.eraseFromParent();
+    ++NumInstrsFolded;
+    return true;
+  }
+
+  return !Div32Uses.empty();
+}
+
+/// createSyncVMFoldCellScalesPass - returns an instance of the pseudo
+/// instruction expansion pass.
+FunctionPass *llvm::createSyncVMFoldCellScalesPass() {
+  return new SyncVMFoldCellScales();
+}

--- a/llvm/lib/Target/SyncVM/SyncVMFoldCellScales.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMFoldCellScales.cpp
@@ -138,14 +138,12 @@ bool SyncVMFoldCellScales::combineCellScalingInstrs(MachineInstr& MI) {
   eraseAndReplaceUses(Div32Uses, SourceReg);
   
   // also remove the shl.s instruction if rY is not used anymore
-  /*
   Register DestReg = MI.getOperand(0).getReg();
   if (RegInfo->use_empty(DestReg)) {
     MI.eraseFromParent();
     ++NumInstrsFolded;
     return true;
   }
-  */
 
   return !Div32Uses.empty();
 }

--- a/llvm/lib/Target/SyncVM/SyncVMTargetMachine.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMTargetMachine.cpp
@@ -137,6 +137,7 @@ void SyncVMPassConfig::addPreRegAlloc() {
     addPass(createSyncVMCombineFlagSettingPass());
     // This pass emits indexed loads and stores
     addPass(createSyncVMCombineToIndexedMemopsPass());
+    addPass(createSyncVMFoldCellScalesPass());
   }
 }
 


### PR DESCRIPTION
We observe a few optimization opportunities which could result in better code sequence. Here we document some of the opportunities. 


1. the scaling, and unscaling of addresses is an overhead of the generated code. 

Example:

`%idx_slot = getelementptr inbounds [10 x i256], [10 x i256]* %array, i256 0, i256 %idx`

will generate into:

```
        shl.s   5, r2, r2
        add     r1, r2, r1
        div.s   32, r1, r1, r0
        add     r3, r0, stack[r1]
```

Which is a lot of instructions. A better code sequence could be:
```
div.s 32, r1, r1, r0
add r1, r2, r1
add r3, r0, stack[r1]
```

2.
```
add     r1, r2, r3
add     r3, r0, stack-[1]               ; 32-byte Folded Spill
```
can be folded and use only one instruction. Because the second instruction is a spill, we have to do it after register allocation.
The above code pattern can be expanded to SUB, MUL, DIV and shifts as well, as long as we utilize the stack dest addressing mode.
