### PR TITLE
Copy implicit defs in SyncVMCombineFlagSettings

### DIFF
--- a/.github/workflows/compiler-integration-tests.yml
+++ b/.github/workflows/compiler-integration-tests.yml
@@ -109,7 +109,9 @@ jobs:
             --vplan-verify-hcfg \
             --march=syncvm"
           XFAILS:
-            "CodeGen/SyncVM/memcpy-expansion.ll"
+            "CodeGen/SyncVM/memcpy-expansion.ll;\
+             CodeGen/SyncVM/flag-setting-set-implicit-flags.ll"
+
         run: |
           BINDIR=$(target-llvm/build-final/bin/llvm-config --bindir)
           target-llvm/build-final/bin/llvm-lit -vv -s --debug --xfail "${XFAILS}" "-Dllc=${BINDIR}/llc ${LLC_OPTS}" llvm/llvm/test/CodeGen/SyncVM/

--- a/llvm/lib/Target/SyncVM/SyncVMCombineFlagSetting.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMCombineFlagSetting.cpp
@@ -202,6 +202,7 @@ bool SyncVMCombineFlagSetting::runOnMachineFunction(MachineFunction &MF) {
       Register ResultReg = MI->getOperand(0).getReg();
       DefMI->setDesc(
           TII->get(SyncVM::getFlagSettingOpcode(DefMI->getOpcode())));
+      DefMI->copyImplicitOps(MF, *MI);
       RegInfo.replaceRegWith(ResultReg, DefResultReg);
       ToRemove.push_back(&*MI);
 

--- a/llvm/test/CodeGen/SyncVM/flag-setting-set-implicit-flags.ll
+++ b/llvm/test/CodeGen/SyncVM/flag-setting-set-implicit-flags.ll
@@ -1,0 +1,34 @@
+; RUN: llc -march=syncvm -stop-after=syncvm-combine-flag-setting -simplify-mir < %s | FileCheck %s
+
+target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
+target triple = "syncvm"
+
+@val = addrspace(4) global i256 42
+declare void @foo(i256 %val)
+
+; CHECK: name: ADDrrr_v
+define i1 @ADDrrr_v(i256 %p1, i256 %p2) nounwind {
+  %p3 = add i256 %p1, %p2
+; CHECK: ADDrrr_v %{{[0-9]+}}, %{{[0-9]+}}, 0, implicit-def $flags
+  %cmp = icmp eq i256 %p3, 0
+  ret i1 %cmp
+}
+
+; CHECK: name: ADDsrr_v
+define i1 @ADDsrr_v(i256 %p1) nounwind {
+  %valptr = alloca i256
+  %val = load i256, i256* %valptr
+; CHECK: ADDsrr_v %stack.0.valptr, i256 0, 0, %0, 0, implicit-def $flags
+  %p2 = add i256 %val, %p1
+  %cmp = icmp eq i256 %p2, 0
+  ret i1 %cmp
+}
+
+; CHECK: name: ADDcrr_v
+define i1 @ADDcrr_v(i256 %p1) nounwind {
+  %val = load i256, i256 addrspace(4)* @val
+; CHECK: ADDcrr_v i256 0, @val, %0, 0, implicit-def $flags
+  %p2 = add i256 %val, %p1
+  %cmp = icmp eq i256 %p2, 0
+  ret i1 %cmp
+}


### PR DESCRIPTION
In flag setting combining pass, we will try to eliminate the `SUBxrr_v` in the following instruction sequence:
```
  %34:gr256 = ADDirr_p i256 2, $r0
  %157:gr256 = SUBxrr_v i256 0, %34:gr256, i256 0, implicit-def $flags
  JC %bb.286, i256 2, implicit $flags
  J %bb.97, implicit $flags
```
And make the first instruction an `ADDirr_v`.
However, before this patch, the merged code was like this:
```
 %34:gr256 = ADDirr_v i256 2, $r0, 0
JC %bb.286, i256 2, implicit $flags
J %bb.97, implicit $flags
```
Notice that the `implicit-def $flag` was missing in the combined instruction.

This will cause LICM or instruction sinking thinking that the combined instructions are dep-free and hence can be moved freely. It should have shown in tests previously but was not.

The test exposed it is: `tests/solidity/ethereum/array/copying/nested_array_element_memory_to_storage.sol`
