### PR TITLE
Replace imm 0 with r0 for sub!, select

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
@@ -2601,7 +2601,9 @@ CheckInteger(const unsigned char *MatcherTable, unsigned &MatcherIndex,
   Val = decodeSignRotatedValue(Val);
 
   ConstantSDNode *C = dyn_cast<ConstantSDNode>(N);
-  return C && C->getSExtValue() == Val;
+  // SyncVM local begin
+  return C && C->getAPIntValue() == Val;
+  // SyncVM local end
 }
 
 LLVM_ATTRIBUTE_ALWAYS_INLINE static bool

--- a/llvm/lib/Target/SyncVM/SyncVMCombineFlagSetting.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMCombineFlagSetting.cpp
@@ -2,12 +2,12 @@
 //
 /// \file
 ///
-/// The pass attempts to combine `sub.s! 0, x, y` with the definition of x:
+/// The pass attempts to combine `sub! x, r0, y` with the definition of x:
 /// '''
 /// def = op x, y
 /// ; No flags def or use in between
 /// ; ... ...
-/// result = sub.s! 0, def
+/// result = sub! def, r0
 /// '''
 ///
 /// can be folded into:
@@ -84,7 +84,7 @@ char SyncVMCombineFlagSetting::ID = 0;
 INITIALIZE_PASS(SyncVMCombineFlagSetting, DEBUG_TYPE,
                 SYNCVM_COMBINE_FLAG_SETTING_NAME, false, false)
 
-/// Given sub.s! 0, x, y or equivalent \p MI return the register for x.
+/// Given sub! x, r0, y or equivalent \p MI return the register for x.
 /// Return R0 if precondition is not met.
 /// TODO: CPR-965 It might worth canonicalizing instead of checking different
 /// forms, but there is a chance that the proper layering of CPR-965 is post-RA.
@@ -92,9 +92,6 @@ static Register getValueRegister(const MachineInstr &MI) {
   if (MI.getOpcode() == SyncVM::SUBrrr_v && MI.getOperand(1).isReg() &&
       MI.getOperand(2).isReg() && MI.getOperand(2).getReg() == SyncVM::R0)
     return MI.getOperand(1).getReg();
-  if (MI.getOpcode() == SyncVM::SUBxrr_v && MI.getOperand(2).isReg() &&
-      MI.getOperand(1).getCImm()->isZero())
-    return MI.getOperand(2).getReg();
   return SyncVM::R0;
 }
 
@@ -140,7 +137,7 @@ bool SyncVMCombineFlagSetting::runOnMachineFunction(MachineFunction &MF) {
   for (MachineBasicBlock &MBB : MF)
     for (auto MI = MBB.begin(); MI != MBB.end(); ++MI) {
       Register ValReg = getValueRegister(*MI);
-      // MI is not sub.s! 0, x, y or equivalent.
+      // MI is not sub! x, r0, y.
       if (ValReg == SyncVM::R0)
         continue;
 
@@ -152,7 +149,7 @@ bool SyncVMCombineFlagSetting::runOnMachineFunction(MachineFunction &MF) {
       MachineInstr *DefMI = &*RegInfo.def_instructions(ValReg).begin();
 
       // There must be no flag def or use between the value definition and
-      // sub.s! 0, x, y.
+      // sub! x, r0, y.
       if (hasFlagsDefOrUseBetween(DefMI->getIterator(), MI))
         continue;
 
@@ -198,7 +195,7 @@ bool SyncVMCombineFlagSetting::runOnMachineFunction(MachineFunction &MF) {
                  dbgs() << "        And instruction:"; MI->dump(););
       ++NumFlagsFolded;
 
-      // Fold sub.s! 0, (op x, y) to op! x, y
+      // Fold sub! (op x, y), r0 to op! x, y
       Register ResultReg = MI->getOperand(0).getReg();
       DefMI->setDesc(
           TII->get(SyncVM::getFlagSettingOpcode(DefMI->getOpcode())));

--- a/llvm/lib/Target/SyncVM/SyncVMInstrInfo.td
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrInfo.td
@@ -325,6 +325,11 @@ let mayLoad = 1 in {
 }
 }
 
+// To be able to fold (op in0, (select.cc x, y)) to (op in0, y) + (op.cc in0, y) for
+// non-register in0 reduce immediate 0 to r0 in select.
+def : Pat<(SyncVMselectcc 0, GR256:$src2, imm:$cc), (SELrrr R0, GR256:$src2, imm:$cc)>;
+def : Pat<(SyncVMselectcc GR256:$src1, 0, imm:$cc), (SELrrr GR256:$src1, R0, imm:$cc)>;
+
 /*
 def : Pat<(store_stack (load_stack(SyncVMselectcc stackaddr:$addr1, stackaddr:$addr2, imm:$cc)), stackaddr:$addr3),
           (SELsss stackaddr:$addr1, stackaddr:$addr2, imm:$cc, stackaddr:$addr3)>;
@@ -1108,6 +1113,8 @@ def : Pat<(SyncVMcopy_from_ptrreg GRPTR:$src), (PTR_ADDrrr_p GRPTR:$src, R0)>;
 
 // SelecCC, BR_CC supplement
 def : Pat<(SyncVMcmp GR256:$lhs, GR256:$rhs), (SUBrrr_v GR256:$lhs, GR256:$rhs, 0)>;
+// r0 is more profitable than imm 0 because it makes sub! x, r0 combinable with x = load y.
+def : Pat<(SyncVMcmp GR256:$lhs, 0), (SUBrrr_v GR256:$lhs, R0, 0)>;
 def : Pat<(SyncVMcmp GR256:$lhs, imm16:$rhs), (SUBxrr_v imm:$rhs, GR256:$lhs, 0)>;
 def : Pat<(SyncVMcmp GR256:$lhs, large_imm:$rhs), (SUByrr_v (constant_pool imm:$rhs), 0, GR256:$lhs, 0)>;
 

--- a/llvm/test/CodeGen/SyncVM/frame_memory.ll
+++ b/llvm/test/CodeGen/SyncVM/frame_memory.ll
@@ -36,7 +36,7 @@ define void @store_to_frame_select(i256 %par, i1 %flag) nounwind {
 ; CHECK: sub.s 2, r4, r4
 ; CHECK: mul 32, r4, r4, r0
 ; the select part
-; CHECK: sub.s! 0, r2, r2
+; CHECK: sub! r2, r0, r2
 ; CHECK: add r3, r0, r2
 ; CHECK: add.ne r4, r0, r2
 ; store 

--- a/llvm/test/CodeGen/SyncVM/ra_regress.ll
+++ b/llvm/test/CodeGen/SyncVM/ra_regress.ll
@@ -9,18 +9,18 @@ target triple = "syncvm"
 define i256 @test_length(i256 %arg1) {
 entry:
 ; CHECK:      sub.s!  36, r{{[0-9]+}}, r{{[[0-9]+}}
-; CHECK-NEXT: add     0, r{{[0-9]+}}, r{{[[0-9]+}}
+; CHECK-NEXT: add     r0, r{{[0-9]+}}, r{{[[0-9]+}}
 ; CHECK-NEXT: add.lt  r{{[0-9]+}}, r{{[0-9]+}}, r{{[0-9]+}}
   %comparison_result24 = icmp slt i256 35, %arg1
   %comparison_result_extended25 = zext i1 %comparison_result24 to i256
 
-; CHECK:      and  @CPI0_0[0], r{{[0-9]+}}, r{{[[0-9]+}}
-; CHECK-NEXT: sub.s!  0, r{{[0-9]+}}, r{{[[0-9]+}}
-; CHECK-NEXT: add.le  0, r{{[0-9]+}}, r{{[[0-9]+}}
+; CHECK:      and     @CPI0_0[0], r{{[0-9]+}}, r{{[[0-9]+}}
+; CHECK-NEXT: sub!    r{{[0-9]+}}, r0, r{{[[0-9]+}}
+; CHECK-NEXT: add.le  r0, r{{[0-9]+}}, r{{[[0-9]+}}
   %comparison_result26 = icmp eq i256 %comparison_result_extended25, 0
   %comparison_result_extended27 = zext i1 %comparison_result26 to i256
 
-; CHECK:      sub.s!  0, r{{[0-9]+}}, r{{[[0-9]+}}
+; CHECK:      sub!    r{{[0-9]+}}, r0, r{{[[0-9]+}}
 ; CHECK-NEXT: add     0, r{{[0-9]+}}, r{{[[0-9]+}}
 ; CHECK-NEXT: add.ne  1, r{{[0-9]+}}, r{{[[0-9]+}}
 ; CHECK-NOT:  and     1, r{{[0-9]+}}, r{{[[0-9]+}}


### PR DESCRIPTION
It makes sub! combinable with reload of its argument and allows to fold (op (select.cc x, y), z) into (op y, z) + (op.cc x, z). The patch only makes preliminary work and doesn't perform transformations themselves.