### PR TITLE
Do no try to analyze vector type parts in legalization

### DIFF
--- a/llvm/lib/Target/SyncVM/SyncVMTargetTransformInfo.h
+++ b/llvm/lib/Target/SyncVM/SyncVMTargetTransformInfo.h
@@ -106,6 +106,8 @@ public:
   // TODO: The value is copied from AMDGPU, needs to be configured.
   unsigned getInliningThresholdMultiplier() const { return 11; }
 
+  unsigned getNumberOfParts(Type *Tp) const { return 0; }
+
   /// @}
 };
 


### PR DESCRIPTION
When it tries to legalize a vector element type, if no vector-specific type is available, it will try to extend it with a scalar type.

It is related to the use vector datatypes. Since we do not have vector datatypes anyway, just by default return unanalyzable at the beginning of the lowering to break up a vector type into using default scalar types.