### PR TITLE
Add missing register information to SyncVM TTI

### DIFF
--- a/llvm/lib/Target/SyncVM/SyncVMTargetTransformInfo.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMTargetTransformInfo.cpp
@@ -51,15 +51,6 @@ InstructionCost SyncVMTTIImpl::getIntImmCost(const APInt &Imm, Type *Ty,
   return TTI::TCC_Expensive;
 }
 
-unsigned SyncVMTTIImpl::getNumberOfRegisters(unsigned ClassID) const {
-  unsigned Result = BaseT::getNumberOfRegisters(ClassID);
-  return Result;
-}
-
-TypeSize SyncVMTTIImpl::getRegisterBitWidth(bool) const {
-  return TypeSize::Fixed(256);
-}
-
 InstructionCost
 SyncVMTTIImpl::getIntrinsicInstrCost(const IntrinsicCostAttributes &ICA,
                                      TTI::TargetCostKind CostKind) {

--- a/llvm/test/Transforms/SLPVectorizer/dont-vectorize-for-syncvm.ll
+++ b/llvm/test/Transforms/SLPVectorizer/dont-vectorize-for-syncvm.ll
@@ -1,0 +1,21 @@
+; RUN: opt -slp-vectorizer < %s
+
+target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
+target triple = "syncvm-unknown-unknown"
+
+; Function Attrs: null_pointer_is_valid
+define void @function_main() unnamed_addr {
+entry:
+  br i1 undef, label %bb2, label %bb3
+
+bb1:
+  %calldata_pointer384 = phi ptr addrspace(3) [ undef, %bb2 ], [ undef, %bb3 ]
+  %stack_var_005.0.in = phi ptr addrspace(3) [ undef, %bb2 ], [ undef, %bb3 ]
+  unreachable
+
+bb2:                              ; preds = %entry
+  br label %bb1
+
+bb3:                 ; preds = %entry
+  br label %bb1
+}


### PR DESCRIPTION
Thus SLP vectorizer no longer attempts to vectorize for the target.