### PR TITLE
[DAGISel] CheckInteger: Fix comparison APInt vs int64_t.

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
@@ -2602,7 +2602,12 @@ CheckInteger(const unsigned char *MatcherTable, unsigned &MatcherIndex,
 
   ConstantSDNode *C = dyn_cast<ConstantSDNode>(N);
   // SyncVM local begin
-  return C && C->getAPIntValue() == Val;
+  if (C) {
+    const APInt &CVal = C->getAPIntValue();
+    if (CVal == APInt(CVal.getBitWidth(), Val, /*isSigned=*/true))
+      return true;
+  }
+  return false;
   // SyncVM local end
 }
 


### PR DESCRIPTION
[DAGISel] CheckInteger: Fix comparison APInt vs int64_t.

Perform conversion of int64_t value to APInt value before comparison.
otherwise APInt::operator==(uint64_t) is called that return false if LHS value takes  >64 bits.
This may lead to wrong results. For example: 
`С:  i256 Constant<-1>,  Val: (int64_t) -1`
then 
` C->getAPIntValue() == Val`
 returns false. 
 