### PR TITLE
Instruction mappings for addr modes and argument swap

### DIFF
--- a/llvm/lib/Target/SyncVM/SyncVMISelLowering.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMISelLowering.cpp
@@ -5,6 +5,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "SyncVMISelLowering.h"
+
+#include <unordered_map>
 #include "SyncVM.h"
 #include "SyncVMMachineFunctionInfo.h"
 #include "SyncVMSubtarget.h"

--- a/llvm/lib/Target/SyncVM/SyncVMInstrFormats.td
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrFormats.td
@@ -12,7 +12,9 @@
 class PredRel;
 class PseudoRel; // map: `_p` -> `_s`
 class FlagRel; // map: `_s` -> `_v`
-class AddrModeRel; // generic map of addressing mode
+class AddrModeRel; // generic map of addressing mode of operands
+class RetAddrModeRel; // generic map of addressing mode of results
+class SwapRel; // map in0, in1 swapping operand instruction <-> non swapping one
 
 // The addressing mode can be categorized into operand addressing and destination addressing
 // OperandAddrMode:
@@ -66,6 +68,70 @@ def getNonFlagSettingOpcode : InstrMapping {
   let ColFields = ["FlagSetting"];
   let KeyCol = ["0"];
   let ValueCols = [["1"]];
+}
+
+def mapRRInputTo : InstrMapping {
+  let FilterClass = "AddrModeRel";
+  let RowFields = ["BaseOpcode", "DestAddrMode", "FlagSetting"];
+  let ColFields = ["OperandAM"];
+  let KeyCol = ["0"];
+  let ValueCols = [["0"], ["1"], ["2"], ["3"]];
+}
+
+def mapIRInputTo : InstrMapping {
+  let FilterClass = "AddrModeRel";
+  let RowFields = ["BaseOpcode", "DestAddrMode", "FlagSetting"];
+  let ColFields = ["OperandAM"];
+  let KeyCol = ["1"];
+  let ValueCols = [["0"], ["1"], ["2"], ["3"]];
+}
+
+def mapCRInputTo : InstrMapping {
+  let FilterClass = "AddrModeRel";
+  let RowFields = ["BaseOpcode", "DestAddrMode", "FlagSetting"];
+  let ColFields = ["OperandAM"];
+  let KeyCol = ["2"];
+  let ValueCols = [["0"], ["1"], ["2"], ["3"]];
+}
+
+def mapSRInputTo : InstrMapping {
+  let FilterClass = "AddrModeRel";
+  let RowFields = ["BaseOpcode", "DestAddrMode", "FlagSetting"];
+  let ColFields = ["OperandAM"];
+  let KeyCol = ["3"];
+  let ValueCols = [["0"], ["1"], ["2"], ["3"]];
+}
+
+def withStackResult : InstrMapping {
+  let FilterClass = "RetAddrModeRel";
+  let RowFields = ["BaseOpcode", "OperandAddrMode", "FlagSetting", "ReverseOperand"];
+  let ColFields = ["ResultAM"];
+  let KeyCol = ["0"];
+  let ValueCols = [["3"]];
+}
+
+def withRegisterResult : InstrMapping {
+  let FilterClass = "RetAddrModeRel";
+  let RowFields = ["BaseOpcode", "OperandAddrMode", "FlagSetting", "ReverseOperand"];
+  let ColFields = ["ResultAM"];
+  let KeyCol = ["3"];
+  let ValueCols = [["0"]];
+}
+
+def withInsSwapped : InstrMapping {
+  let FilterClass = "PredRel";
+  let RowFields = ["BaseOpcode", "OperandAddrMode", "DestAddrMode", "FlagSetting"];
+  let ColFields = ["ReverseOperand"];
+  let KeyCol = ["0"];
+  let ValueCols = [["1"]];
+}
+
+def withInsNotSwapped : InstrMapping {
+  let FilterClass = "PredRel";
+  let RowFields = ["BaseOpcode", "OperandAddrMode", "DestAddrMode", "FlagSetting"];
+  let ColFields = ["ReverseOperand"];
+  let KeyCol = ["1"];
+  let ValueCols = [["0"]];
 }
 
 //===----------------------------------------------------------------------===//
@@ -236,6 +302,8 @@ class IBinary<bits<8> opcode,
   bit IsPseudoArith = 0;
   bits<3> OperandAddrMode = OpndAddrNotSet.Value;
   bits<3> DestAddrMode = DestAddrNotSet.Value;
+  int OperandAM = 0;
+  int ResultAM = 0;
   let Inst{32} = swap_operands;
   let Inst{36} = silent;
   let Inst{48-51} = rs1;
@@ -253,6 +321,7 @@ class IBinaryR<bits<8> opcode,
   bits<4> rd0;
   let DestAddrMode = ToReg.Value;
   let Inst{40-43} = rd0;
+  let ResultAM = 0;
 }
 
 class IBinaryS<bits<8> opcode,
@@ -268,6 +337,7 @@ class IBinaryS<bits<8> opcode,
   let DestAddrMode = ToStack.Value;
   let Inst{44-47} = dst0{0-3};
   let Inst{ 0-15} = dst0{4-19};
+  let ResultAM = 3;
 }
 
 class Irrr<bits<8> opcode,
@@ -281,6 +351,7 @@ class Irrr<bits<8> opcode,
   bits<4> rs0;
   let OperandAddrMode = OpndRR.Value;
   let Inst{52-55} = rs0;
+  let OperandAM = 0;
 }
 
 class Irrrr<bits<8> opcode,
@@ -294,6 +365,7 @@ class Irrrr<bits<8> opcode,
   bits<4> rd1;
   let DestAddrMode = ToRegReg.Value;
   let Inst{40-43} = rd1;
+  let OperandAM = 0;
 }
 
 class Iirr<bits<8> opcode,
@@ -308,6 +380,7 @@ class Iirr<bits<8> opcode,
   let OperandAddrMode = OpndIR.Value;
   let Inst{52-55} = 0;
   let Inst{16-31} = imm;
+  let OperandAM = 1;
 }
 
 class Iirrr<bits<8> opcode,
@@ -321,6 +394,7 @@ class Iirrr<bits<8> opcode,
   bits<4> rd1;
   let DestAddrMode = ToRegReg.Value;
   let Inst{40-43} = rd1;
+  let OperandAM = 1;
 }
 
 class Imrr<bits<8> opcode,
@@ -336,6 +410,7 @@ class Imrr<bits<8> opcode,
   let OperandAddrMode = OpndCR.Value;
   let Inst{52-55} = src0{0-3};
   let Inst{16-31} = src0{4-19};
+  let OperandAM = 2;
 }
 
 class Isrr<bits<8> opcode,
@@ -351,6 +426,7 @@ class Isrr<bits<8> opcode,
   let OperandAddrMode = OpndSR.Value;
   let Inst{52-55} = src0{0-3};
   let Inst{16-31} = src0{4-19};
+  let OperandAM = 3;
 }
 
 class Imrrr<bits<8> opcode,
@@ -366,6 +442,7 @@ class Imrrr<bits<8> opcode,
   let DestAddrMode = ToRegReg.Value;
   let OperandAddrMode = OpndCR.Value;
   let Inst{40-43} = rd1;
+  let OperandAM = 2;
 }
 
 class Isrrr<bits<8> opcode,
@@ -380,6 +457,7 @@ class Isrrr<bits<8> opcode,
   bits<4> rd1;
   let DestAddrMode = ToRegReg.Value;
   let Inst{40-43} = rd1;
+  let OperandAM = 3;
 }
 
 class Irrs<bits<8> opcode,
@@ -393,6 +471,7 @@ class Irrs<bits<8> opcode,
   bits<4>  rs0;
   let OperandAddrMode = OpndRR.Value;
   let Inst{52-55} = rs0;
+  let OperandAM = 0;
 }
 
 class Irrsr<bits<8> opcode,
@@ -406,6 +485,7 @@ class Irrsr<bits<8> opcode,
   bits<4> rd1;
   let DestAddrMode = ToStackReg.Value;
   let Inst{40-43} = rd1;
+  let OperandAM = 0;
 }
 
 class Iirs<bits<8> opcode,
@@ -420,6 +500,7 @@ class Iirs<bits<8> opcode,
   let OperandAddrMode = OpndIR.Value;
   let Inst{52-55} = 0;
   let Inst{16-31} = imm;
+  let OperandAM = 1;
 }
 
 class Iirsr<bits<8> opcode,
@@ -433,6 +514,7 @@ class Iirsr<bits<8> opcode,
   bits<4> rd1;
   let DestAddrMode = ToStackReg.Value;
   let Inst{40-43} = rd1;
+  let OperandAM = 1;
 }
 
 class Imrs<bits<8> opcode,
@@ -448,6 +530,7 @@ class Imrs<bits<8> opcode,
   let OperandAddrMode = OpndCR.Value;
   let Inst{52-55} = src0{0-3};
   let Inst{16-31} = src0{4-19};
+  let OperandAM = 2;
 }
 
 class Isrs<bits<8> opcode,
@@ -463,6 +546,7 @@ class Isrs<bits<8> opcode,
   let OperandAddrMode = OpndSR.Value;
   let Inst{52-55} = src0{0-3};
   let Inst{16-31} = src0{4-19};
+  let OperandAM = 3;
 }
 
 class Imrsr<bits<8> opcode,
@@ -477,6 +561,7 @@ class Imrsr<bits<8> opcode,
   bits<4> rd1;
   let DestAddrMode = ToStackReg.Value;
   let Inst{40-43} = rd1;
+  let OperandAM = 2;
 }
 
 class Isrsr<bits<8> opcode,
@@ -491,12 +576,14 @@ class Isrsr<bits<8> opcode,
   bits<4> rd1;
   let DestAddrMode = ToStackReg.Value;
   let Inst{40-43} = rd1;
+  let OperandAM = 3;
 }
 
 // Pseudo instructions
 class Pseudo<dag outs, dag ins, string asmstr, list<dag> pattern>
   : SyncVMInstruction <outs, ins, 0, asmstr, pattern>, PseudoRel {
   string BaseOpcode;
+  int OperandAM = 0;
   bit FlagSetting = 0;
   bit IsPseudoArith = 1;
   bit ReverseOperand = 0;

--- a/llvm/lib/Target/SyncVM/SyncVMInstrInfo.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrInfo.cpp
@@ -23,6 +23,103 @@ using namespace llvm;
 #define GET_INSTRMAP_INFO
 #include "SyncVMGenInstrInfo.inc"
 
+namespace llvm {
+namespace SyncVM {
+int getWithRRInAddrMode(uint16_t Opcode) {
+  Opcode = getWithInsNotSwapped(Opcode);
+  if (int Result = mapRRInputTo(Opcode, OperandAM_0); Result != -1)
+    return Result;
+  if (int Result = mapIRInputTo(Opcode, OperandAM_0); Result != -1)
+    return Result;
+  if (int Result = mapCRInputTo(Opcode, OperandAM_0); Result != -1)
+    return Result;
+  return mapSRInputTo(Opcode, OperandAM_0);
+}
+
+int getWithIRInAddrMode(uint16_t Opcode) {
+  Opcode = getWithInsNotSwapped(Opcode);
+  if (int Result = mapRRInputTo(Opcode, OperandAM_1); Result != -1)
+    return Result;
+  if (int Result = mapIRInputTo(Opcode, OperandAM_1); Result != -1)
+    return Result;
+  if (int Result = mapCRInputTo(Opcode, OperandAM_1); Result != -1)
+    return Result;
+  return mapSRInputTo(Opcode, OperandAM_1);
+}
+
+int getWithCRInAddrMode(uint16_t Opcode) {
+  Opcode = getWithInsNotSwapped(Opcode);
+  if (int Result = mapRRInputTo(Opcode, OperandAM_2); Result != -1)
+    return Result;
+  if (int Result = mapIRInputTo(Opcode, OperandAM_2); Result != -1)
+    return Result;
+  if (int Result = mapCRInputTo(Opcode, OperandAM_2); Result != -1)
+    return Result;
+  return mapSRInputTo(Opcode, OperandAM_2);
+}
+
+int getWithSRInAddrMode(uint16_t Opcode) {
+  Opcode = getWithInsNotSwapped(Opcode);
+  if (int Result = mapRRInputTo(Opcode, OperandAM_3); Result != -1)
+    return Result;
+  if (int Result = mapIRInputTo(Opcode, OperandAM_3); Result != -1)
+    return Result;
+  if (int Result = mapCRInputTo(Opcode, OperandAM_3); Result != -1)
+    return Result;
+  return mapSRInputTo(Opcode, OperandAM_3);
+}
+
+int getWithRROutAddrMode(uint16_t Opcode) {
+  if (int Result = withRegisterResult(Opcode); Result != -1)
+    return Result;
+  return Opcode;
+}
+
+int getWithSROutAddrMode(uint16_t Opcode) {
+  if (int Result = withStackResult(Opcode); Result != -1)
+    return Result;
+  return Opcode;
+}
+
+int getWithInsNotSwapped(uint16_t Opcode) {
+  if (int Result = withInsNotSwapped(Opcode); Result != -1)
+    return Result;
+  return Opcode;
+}
+
+int getWithInsSwapped(uint16_t Opcode) {
+  if (int Result = withInsSwapped(Opcode); Result != -1)
+    return Result;
+  return Opcode;
+}
+
+bool hasRRInAddressingMode(const MachineInstr &MI) {
+  return (unsigned)mapRRInputTo(MI.getOpcode(), OperandAM_0) == MI.getOpcode();
+}
+
+bool hasIRInAddressingMode(const MachineInstr &MI) {
+  return (unsigned)mapIRInputTo(MI.getOpcode(), OperandAM_1) == MI.getOpcode();
+}
+
+bool hasCRInAddressingMode(const MachineInstr &MI) {
+  return (unsigned)mapCRInputTo(MI.getOpcode(), OperandAM_2) == MI.getOpcode();
+}
+
+bool hasSRInAddressingMode(const MachineInstr &MI) {
+  return (unsigned)mapSRInputTo(MI.getOpcode(), OperandAM_3) == MI.getOpcode();
+}
+
+bool hasRROutAddressingMode(const MachineInstr &MI) {
+  return withStackResult(MI.getOpcode()) != -1;
+}
+
+bool hasSROutAddressingMode(const MachineInstr &MI) {
+  return withRegisterResult(MI.getOpcode()) != -1;
+}
+
+} // namespace SyncVM
+} // namespace llvm
+
 // Pin the vtable to this file.
 void SyncVMInstrInfo::anchor() {}
 
@@ -362,8 +459,8 @@ bool SyncVMInstrInfo::isPtr(const MachineInstr &MI) const {
 }
 
 bool SyncVMInstrInfo::isNull(const MachineInstr &MI) const {
-  return isAdd(MI) && hasRROperandAddressingMode(MI) && MI.getNumDefs() == 1u &&
-         MI.getOperand(1).getReg() == SyncVM::R0 &&
+  return isAdd(MI) && SyncVM::hasRRInAddressingMode(MI) &&
+         MI.getNumDefs() == 1u && MI.getOperand(1).getReg() == SyncVM::R0 &&
          MI.getOperand(2).getReg() == SyncVM::R0;
 }
 
@@ -383,30 +480,6 @@ SyncVMInstrInfo::genericInstructionFor(const MachineInstr &MI) const {
   if (isDiv(MI))
     return DIV;
   return Unsupported;
-}
-
-bool SyncVMInstrInfo::hasRIOperandAddressingMode(const MachineInstr &MI) const {
-  StringRef Mnemonic = getName(MI.getOpcode());
-  return find(Mnemonic, 'i') != Mnemonic.end();
-}
-
-bool SyncVMInstrInfo::hasRXOperandAddressingMode(const MachineInstr &MI) const {
-  StringRef Mnemonic = getName(MI.getOpcode());
-  return find(Mnemonic, 'x') != Mnemonic.end();
-}
-
-bool SyncVMInstrInfo::hasRSOperandAddressingMode(const MachineInstr &MI) const {
-  StringRef Mnemonic = getName(MI.getOpcode());
-  auto LCIt = find_if<StringRef, int(int)>(std::move(Mnemonic), std::islower);
-
-  return LCIt != Mnemonic.end() && (*LCIt == 's' || *LCIt == 'y');
-}
-
-bool SyncVMInstrInfo::hasRROperandAddressingMode(const MachineInstr &MI) const {
-  StringRef Mnemonic = getName(MI.getOpcode());
-  auto LCIt = find_if<StringRef, int(int)>(std::move(Mnemonic), std::islower);
-
-  return LCIt != Mnemonic.end() && *LCIt == 'r' && *std::next(LCIt) == 'r';
 }
 
 /// Mark a copy to a fat pointer register or from a fat pointer register with

--- a/llvm/lib/Target/SyncVM/SyncVMInstrInfo.h
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrInfo.h
@@ -17,9 +17,45 @@
 namespace llvm {
 
 namespace SyncVM {
+
 int getPseudoMapOpcode(uint16_t);
 int getFlagSettingOpcode(uint16_t);
 int getNonFlagSettingOpcode(uint16_t);
+
+/// Return opcode of the instruction with RR input addressing mode otherwise
+/// identical to \p Opcode.
+int getWithRRInAddrMode(uint16_t Opcode);
+/// Return opcode of the instruction with IR input addressing mode otherwise
+/// identical to \p Opcode. For a fat pointer instruction return an opcode with
+/// operands swapped (i.e. XR).
+int getWithIRInAddrMode(uint16_t Opcode);
+/// Return opcode of the instruction with CR input addressing mode otherwise
+/// identical to \p Opcode. For a fat pointer instruction return an opcode with
+/// operands swapped (i.e. YR).
+int getWithCRInAddrMode(uint16_t Opcode);
+/// Return opcode of the instruction with SR input addressing mode otherwise
+/// identical to \p Opcode.
+int getWithSRInAddrMode(uint16_t Opcode);
+/// Return opcode of the instruction with RR otput addressing mode otherwise
+/// identical to \p Opcode.
+int getWithRROutAddrMode(uint16_t Opcode);
+/// Return opcode of the instruction with SR otput addressing mode otherwise
+/// identical to \p Opcode.
+int getWithSROutAddrMode(uint16_t Opcode);
+/// Return opcode of the instruction with operands not swapped
+/// otherwise identical to \p Opcode.
+int getWithInsNotSwapped(uint16_t Opcode);
+/// Return opcode of the instruction with operands swapped otherwise identical
+/// to \p Opcode.
+int getWithInsSwapped(uint16_t Opcode);
+
+bool hasRRInAddressingMode(const MachineInstr &MI);
+bool hasIRInAddressingMode(const MachineInstr &MI);
+bool hasCRInAddressingMode(const MachineInstr &MI);
+bool hasSRInAddressingMode(const MachineInstr &MI);
+bool hasRROutAddressingMode(const MachineInstr &MI);
+bool hasSROutAddressingMode(const MachineInstr &MI);
+
 } // namespace SyncVM
 
 class SyncVMInstrInfo : public SyncVMGenInstrInfo {
@@ -77,11 +113,6 @@ public:
   int64_t getFramePoppedByCallee(const MachineInstr &I) const { return 0; }
 
   // Properties and mappings
-  bool hasRROperandAddressingMode(const MachineInstr &MI) const;
-  bool hasRIOperandAddressingMode(const MachineInstr &MI) const;
-  bool hasRXOperandAddressingMode(const MachineInstr &MI) const;
-  bool hasRSOperandAddressingMode(const MachineInstr &MI) const;
-  bool hasTwoOuts(const MachineInstr &MI) const;
   bool isAdd(const MachineInstr &MI) const;
   bool isSub(const MachineInstr &MI) const;
   bool isMul(const MachineInstr &MI) const;

--- a/llvm/lib/Target/SyncVM/SyncVMInstrInfo.td
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrInfo.td
@@ -376,14 +376,15 @@ multiclass Arith<bits<8> opcode, string asmstring, SDPatternOperator node, bit c
                      [(set GR256:$rd0, (node GR256:$rs0, GR256:$rs1))]> {
                       let DestAddrMode = ToReg.Value;
                       let OperandAddrMode = OpndRR.Value;
+                      let OperandAM = 0;
                      }
   def rrr_s : Irrr<opcode, 0, 1,
                    (outs GR256:$rd0), (ins GR256:$rs0, GR256:$rs1, cc:$cc),
-                   !strconcat(asmstring, "$cc\t$rs0, $rs1, $rd0"), []>, PseudoRel, FlagRel;
+                   !strconcat(asmstring, "$cc\t$rs0, $rs1, $rd0"), []>, PseudoRel, FlagRel, AddrModeRel, RetAddrModeRel;
   let Defs = [Flags], hasPostISelHook = 1 in
   def rrr_v : Irrr<opcode, 0, 0,
                    (outs GR256:$rd0), (ins GR256:$rs0, GR256:$rs1, cc:$cc),
-                   !strconcat(asmstring, "$cc!\t$rs0, $rs1, $rd0"), []>, FlagRel;
+                   !strconcat(asmstring, "$cc!\t$rs0, $rs1, $rd0"), []>, FlagRel, AddrModeRel, RetAddrModeRel;
 
   let mayLoad = 1 in {
   let isPseudo = 1, isCodeGenOnly = 1 in
@@ -395,11 +396,11 @@ multiclass Arith<bits<8> opcode, string asmstring, SDPatternOperator node, bit c
                      }
   def crr_s : Imrr<opcode, SrcCode, 0, 1,
                    (outs GR256:$rd0), (ins memop:$src0, GR256:$rs1, cc:$cc),
-                   !strconcat(asmstring, "$cc\t$src0[0], $rs1, $rd0"), []>, PseudoRel, FlagRel;
+                   !strconcat(asmstring, "$cc\t$src0[0], $rs1, $rd0"), []>, PseudoRel, FlagRel, AddrModeRel, RetAddrModeRel;
   let Defs = [Flags], hasPostISelHook = 1 in
   def crr_v : Imrr<opcode, SrcCode, 0, 0,
                    (outs GR256:$rd0), (ins memop:$src0, GR256:$rs1, cc:$cc),
-                   !strconcat(asmstring, "$cc!\t$src0[0], $rs1, $rd0"), []>, FlagRel;
+                   !strconcat(asmstring, "$cc!\t$src0[0], $rs1, $rd0"), []>, FlagRel, AddrModeRel, RetAddrModeRel;
   let isPseudo = 1, isCodeGenOnly = 1 in
   def srr_p : Pseudo<(outs GR256:$rd0), (ins stackop:$src0, GR256:$rs1),
                      !strconcat(asmstring, "\t$src0, $rs1, $rd0"),
@@ -409,11 +410,11 @@ multiclass Arith<bits<8> opcode, string asmstring, SDPatternOperator node, bit c
                      }
   def srr_s : Isrr<opcode, SrcStack, 0, 1,
                    (outs GR256:$rd0), (ins stackop:$src0, GR256:$rs1, cc:$cc),
-                   !strconcat(asmstring, "$cc\t$src0, $rs1, $rd0"), []>, PseudoRel, FlagRel;
+                   !strconcat(asmstring, "$cc\t$src0, $rs1, $rd0"), []>, PseudoRel, FlagRel, AddrModeRel, RetAddrModeRel;
   let Defs = [Flags], hasPostISelHook = 1 in
   def srr_v : Isrr<opcode, SrcStack, 0, 0,
                    (outs GR256:$rd0), (ins stackop:$src0, GR256:$rs1, cc:$cc),
-                   !strconcat(asmstring, "$cc!\t$src0, $rs1, $rd0"), []>, FlagRel;
+                   !strconcat(asmstring, "$cc!\t$src0, $rs1, $rd0"), []>, FlagRel, AddrModeRel, RetAddrModeRel;
   }
   
   let mayStore = 1 in {
@@ -426,11 +427,11 @@ multiclass Arith<bits<8> opcode, string asmstring, SDPatternOperator node, bit c
                      }
   def rrs_s : Irrs<opcode, 0, 1,
                    (outs), (ins GR256:$rs0, GR256:$rs1, stackop:$dst0, cc:$cc),
-                   !strconcat(asmstring, "$cc\t$rs0, $rs1, $dst0"), []>, PseudoRel, FlagRel;
+                   !strconcat(asmstring, "$cc\t$rs0, $rs1, $dst0"), []>, PseudoRel, FlagRel, AddrModeRel, RetAddrModeRel;
   let Defs = [Flags], hasPostISelHook = 1 in
   def rrs_v : Irrs<opcode, 0, 0,
                    (outs), (ins GR256:$rs0, GR256:$rs1, stackop:$dst0, cc:$cc),
-                   !strconcat(asmstring, "$cc!\t$rs0, $rs1, $dst0"), []>, FlagRel;
+                   !strconcat(asmstring, "$cc!\t$rs0, $rs1, $dst0"), []>, FlagRel, AddrModeRel, RetAddrModeRel;
   }
 
   let mayLoad = 1, mayStore = 1 in {
@@ -443,11 +444,11 @@ multiclass Arith<bits<8> opcode, string asmstring, SDPatternOperator node, bit c
                      }
   def crs_s : Imrs<opcode, SrcCode, 0, 1,
                    (outs), (ins memop:$src0, GR256:$rs1, stackop:$dst0, cc:$cc),
-                   !strconcat(asmstring, "$cc\t$src0[0], $rs1, $dst0"), []>, PseudoRel, FlagRel;
+                   !strconcat(asmstring, "$cc\t$src0[0], $rs1, $dst0"), []>, PseudoRel, FlagRel, AddrModeRel, RetAddrModeRel;
   let Defs = [Flags], hasPostISelHook = 1 in
   def crs_v : Imrs<opcode, SrcCode, 0, 0,
                    (outs), (ins memop:$src0, GR256:$rs1, stackop:$dst0, cc:$cc),
-                   !strconcat(asmstring, "$cc!\t$src0[0], $rs1, $dst0"), []>, FlagRel;
+                   !strconcat(asmstring, "$cc!\t$src0[0], $rs1, $dst0"), []>, FlagRel, AddrModeRel, RetAddrModeRel;
 
   let isPseudo = 1, isCodeGenOnly = 1 in
   def srs_p : Pseudo<(outs), (ins stackop:$src0, GR256:$rs1, stackop:$dst0),
@@ -458,12 +459,12 @@ multiclass Arith<bits<8> opcode, string asmstring, SDPatternOperator node, bit c
                      }
   def srs_s : Isrs<opcode, SrcStack, 0, 1,
                    (outs), (ins stackop:$src0, GR256:$rs1, stackop:$dst0, cc:$cc),
-                   !strconcat(asmstring, "$cc\t$src0, $rs1, $dst0"), []>, PseudoRel, FlagRel;
+                   !strconcat(asmstring, "$cc\t$src0, $rs1, $dst0"), []>, PseudoRel, FlagRel, AddrModeRel, RetAddrModeRel;
 
   let Defs = [Flags], hasPostISelHook = 1 in
   def srs_v : Isrs<opcode, SrcStack, 0, 0,
                    (outs), (ins stackop:$src0, GR256:$rs1, stackop:$dst0, cc:$cc),
-                   !strconcat(asmstring, "$cc!\t$src0, $rs1, $dst0"), []>, FlagRel;
+                   !strconcat(asmstring, "$cc!\t$src0, $rs1, $dst0"), []>, FlagRel, AddrModeRel, RetAddrModeRel;
   }
   }
 }
@@ -479,11 +480,11 @@ multiclass ArithICommutable<bits<8> opcode, string asmstring, SDPatternOperator 
                      }
   def irr_s : Iirr<opcode, 0, 1,
                    (outs GR256:$rd0), (ins imm16:$imm, GR256:$rs1, cc:$cc),
-                   !strconcat(asmstring, "$cc\t$imm, $rs1, $rd0"), []>, PseudoRel, FlagRel;
+                   !strconcat(asmstring, "$cc\t$imm, $rs1, $rd0"), []>, PseudoRel, FlagRel, AddrModeRel, RetAddrModeRel;
   let Defs = [Flags] , hasPostISelHook = 1 in
   def irr_v : Iirr<opcode, 0, 0,
                    (outs GR256:$rd0), (ins imm16:$imm, GR256:$rs1, cc:$cc),
-                   !strconcat(asmstring, "$cc!\t$imm, $rs1, $rd0"), []>, FlagRel;
+                   !strconcat(asmstring, "$cc!\t$imm, $rs1, $rd0"), []>, FlagRel, AddrModeRel, RetAddrModeRel;
   let mayStore = 1 in {
   let isPseudo = 1, isCodeGenOnly = 1 in
   def irs_p : Pseudo<(outs), (ins imm16:$imm, GR256:$rs1, stackop:$dst0),
@@ -494,11 +495,11 @@ multiclass ArithICommutable<bits<8> opcode, string asmstring, SDPatternOperator 
                      }
   def irs_s : Iirs<opcode, 0, 1,
                    (outs), (ins imm16:$imm, GR256:$rs1, stackop:$dst0, cc:$cc),
-                   !strconcat(asmstring, "$cc\t$imm, $rs1, $dst0"), []>, PseudoRel, FlagRel;
+                   !strconcat(asmstring, "$cc\t$imm, $rs1, $dst0"), []>, PseudoRel, FlagRel, AddrModeRel, RetAddrModeRel;
   let Defs = [Flags], hasPostISelHook = 1 in
   def irs_v : Iirs<opcode, 0, 0,
                    (outs), (ins imm16:$imm, GR256:$rs1, stackop:$dst0, cc:$cc),
-                   !strconcat(asmstring, "$cc!\t$imm, $rs1, $dst0"), []>, FlagRel;
+                   !strconcat(asmstring, "$cc!\t$imm, $rs1, $dst0"), []>, FlagRel, AddrModeRel, RetAddrModeRel;
   }
   } // end isCommutable = 1
 
@@ -530,18 +531,21 @@ multiclass ArithINonCommutable<bits<8> opcode, string asmstring, SDPatternOperat
   
   def irr_s : Iirr<opcode, 0, 1,
                        (outs GR256:$rd0), (ins imm16:$imm, GR256:$rs1, cc:$cc),
-                       !strconcat(asmstring, "$cc\t$imm, $rs1, $rd0"), []>, PseudoRel, FlagRel;
+                       !strconcat(asmstring, "$cc\t$imm, $rs1, $rd0"), []>, PseudoRel, FlagRel, AddrModeRel, RetAddrModeRel;
   def xrr_s : Iirr<opcode, 1, 1,
                        (outs GR256:$rd0), (ins imm16:$imm, GR256:$rs1, cc:$cc),
                        !strconcat(!strconcat(asmstring, ".s"),
-                                  "$cc\t$imm, $rs1, $rd0"), []>, PseudoRel, FlagRel;
+                                  "$cc\t$imm, $rs1, $rd0"), []>, PseudoRel, FlagRel, RetAddrModeRel;
 
-  foreach swap = ["i", "x"] in
-  let Defs = [Flags], hasPostISelHook = 1 in
-  def swap#rr_v : Iirr<opcode, !if(!eq(swap, "i"), 0, 1), 0,
+  let Defs = [Flags], hasPostISelHook = 1 in {
+  def irr_v : Iirr<opcode, 0, 0,
                        (outs GR256:$rd0), (ins imm16:$imm, GR256:$rs1, cc:$cc),
-                       !strconcat(!strconcat(asmstring, !if(!eq(swap, "i"), "", ".s")),
-                                  "$cc!\t$imm, $rs1, $rd0"), []>, FlagRel;
+                       !strconcat(asmstring, "$cc!\t$imm, $rs1, $rd0"), []>, FlagRel, AddrModeRel, RetAddrModeRel;
+  def xrr_v : Iirr<opcode, 1, 0,
+                       (outs GR256:$rd0), (ins imm16:$imm, GR256:$rs1, cc:$cc),
+                       !strconcat(asmstring, ".s$cc!\t$imm, $rs1, $rd0"), []>, FlagRel, RetAddrModeRel;
+  }
+
   let mayLoad = 1 in {
   let isPseudo = 1, isCodeGenOnly = 1 in
   def yrr_p : Pseudo<(outs GR256:$rd0), (ins memop:$src0, GR256:$rs1),
@@ -553,11 +557,11 @@ multiclass ArithINonCommutable<bits<8> opcode, string asmstring, SDPatternOperat
                      }
   def yrr_s : Imrr<opcode, SrcCode, 1, 1,
                    (outs GR256:$rd0), (ins memop:$src0, GR256:$rs1, cc:$cc),
-                   !strconcat(asmstring, ".s$cc\t$src0[0], $rs1, $rd0"), []>, PseudoRel, FlagRel;
+                   !strconcat(asmstring, ".s$cc\t$src0[0], $rs1, $rd0"), []>, PseudoRel, FlagRel, RetAddrModeRel;
   let Defs = [Flags], hasPostISelHook = 1 in
   def yrr_v : Imrr<opcode, SrcCode, 1, 0,
                    (outs GR256:$rd0), (ins memop:$src0, GR256:$rs1, cc:$cc),
-                   !strconcat(asmstring, ".s$cc!\t$src0[0], $rs1, $rd0"), []>, FlagRel;
+                   !strconcat(asmstring, ".s$cc!\t$src0[0], $rs1, $rd0"), []>, FlagRel, RetAddrModeRel;
   let isPseudo = 1, isCodeGenOnly = 1 in
   def zrr_p : Pseudo<(outs GR256:$rd0), (ins stackop:$src0, GR256:$rs1),
                      !strconcat(asmstring, ".s\t$src0, $rs1, $rd0"),
@@ -568,11 +572,11 @@ multiclass ArithINonCommutable<bits<8> opcode, string asmstring, SDPatternOperat
                      }
   def zrr_s : Isrr<opcode, SrcStack, 1, 1,
                    (outs GR256:$rd0), (ins stackop:$src0, GR256:$rs1, cc:$cc),
-                   !strconcat(asmstring, ".s$cc\t$src0, $rs1, $rd0"), []>, PseudoRel, FlagRel;
+                   !strconcat(asmstring, ".s$cc\t$src0, $rs1, $rd0"), []>, PseudoRel, FlagRel, RetAddrModeRel;
   let Defs = [Flags], hasPostISelHook = 1 in
   def zrr_v : Isrr<opcode, SrcStack, 1, 0,
                    (outs GR256:$rd0), (ins stackop:$src0, GR256:$rs1, cc:$cc),
-                   !strconcat(asmstring, ".s$cc!\t$src0, $rs1, $rd0"), []>, FlagRel;
+                   !strconcat(asmstring, ".s$cc!\t$src0, $rs1, $rd0"), []>, FlagRel, RetAddrModeRel;
   }
   let mayStore = 1 in {
   let isPseudo = 1, isCodeGenOnly = 1 in {
@@ -592,18 +596,20 @@ multiclass ArithINonCommutable<bits<8> opcode, string asmstring, SDPatternOperat
   }
   def irs_s : Iirs<opcode, 0, 1,
                        (outs), (ins imm16:$imm, GR256:$rs1, stackop:$dst0, cc:$cc),
-                       !strconcat(asmstring, "$cc\t$imm, $rs1, $dst0"), []>, PseudoRel, FlagRel;
+                       !strconcat(asmstring, "$cc\t$imm, $rs1, $dst0"), []>, PseudoRel, FlagRel, AddrModeRel, RetAddrModeRel;
 
   def xrs_s : Iirs<opcode, 1, 1,
                        (outs), (ins imm16:$imm, GR256:$rs1, stackop:$dst0, cc:$cc),
-                       !strconcat(!strconcat(asmstring, ".s"), "$cc\t$imm, $rs1, $dst0"), []>, PseudoRel, FlagRel;
+                       !strconcat(!strconcat(asmstring, ".s"), "$cc\t$imm, $rs1, $dst0"), []>, PseudoRel, FlagRel, RetAddrModeRel;
 
-  foreach swap = ["i", "x"] in
-  let Defs = [Flags], hasPostISelHook = 1 in
-  def swap#rs_v : Iirs<opcode, !if(!eq(swap, "i"), 0, 1), 0,
+  let Defs = [Flags], hasPostISelHook = 1 in {
+  def irs_v : Iirs<opcode, 0, 0,
                        (outs), (ins imm16:$imm, GR256:$rs1, stackop:$dst0, cc:$cc),
-                       !strconcat(!strconcat(asmstring, !if(!eq(swap, "i"), "", ".s")),
-                                  "$cc!\t$imm, $rs1, $dst0"), []>, FlagRel;
+                       !strconcat(asmstring, "$cc!\t$imm, $rs1, $dst0"), []>, FlagRel, AddrModeRel, RetAddrModeRel;
+  def xrs_v : Iirs<opcode, 1, 0,
+                       (outs), (ins imm16:$imm, GR256:$rs1, stackop:$dst0, cc:$cc),
+                       !strconcat(asmstring, ".s$cc!\t$imm, $rs1, $dst0"), []>, FlagRel, RetAddrModeRel;
+  }
   let mayLoad = 1 in {
   let isPseudo = 1, isCodeGenOnly = 1 in
   def yrs_p : Pseudo<(outs), (ins memop:$src0, GR256:$rs1, stackop:$dst0),
@@ -616,12 +622,12 @@ multiclass ArithINonCommutable<bits<8> opcode, string asmstring, SDPatternOperat
 
   def yrs_s : Imrs<opcode, SrcCode, 1, 1,
                    (outs), (ins memop:$src0, GR256:$rs1, stackop:$dst0, cc:$cc),
-                   !strconcat(asmstring, ".s$cc\t$src0[0], $rs1, $dst0"), []>, PseudoRel, FlagRel;
+                   !strconcat(asmstring, ".s$cc\t$src0[0], $rs1, $dst0"), []>, PseudoRel, FlagRel, RetAddrModeRel;
 
   let Defs = [Flags], hasPostISelHook = 1 in
   def yrs_v : Imrs<opcode, SrcCode, 1, 0,
                    (outs), (ins memop:$src0, GR256:$rs1, stackop:$dst0, cc:$cc),
-                   !strconcat(asmstring, ".s$cc!\t$src0[0], $rs1, $dst0"), []>, FlagRel;
+                   !strconcat(asmstring, ".s$cc!\t$src0[0], $rs1, $dst0"), []>, FlagRel, RetAddrModeRel;
 
   let isPseudo = 1, isCodeGenOnly = 1 in
   def zrs_p : Pseudo<(outs), (ins stackop:$src0, GR256:$rs1, stackop:$dst0),
@@ -633,11 +639,11 @@ multiclass ArithINonCommutable<bits<8> opcode, string asmstring, SDPatternOperat
                      }
   def zrs_s : Isrs<opcode, SrcStack, 1, 1,
                    (outs), (ins stackop:$src0, GR256:$rs1, stackop:$dst0, cc:$cc),
-                   !strconcat(asmstring, ".s$cc\t$src0, $rs1, $dst0"), []>, PseudoRel, FlagRel;
+                   !strconcat(asmstring, ".s$cc\t$src0, $rs1, $dst0"), []>, PseudoRel, FlagRel, RetAddrModeRel;
   let Defs = [Flags], hasPostISelHook = 1 in
   def zrs_v : Isrs<opcode, SrcStack, 1, 0,
                    (outs), (ins stackop:$src0, GR256:$rs1, stackop:$dst0, cc:$cc),
-                   !strconcat(asmstring, ".s$cc!\t$src0, $rs1, $dst0"), []>, FlagRel;
+                   !strconcat(asmstring, ".s$cc!\t$src0, $rs1, $dst0"), []>, FlagRel, RetAddrModeRel;
   }
   }
   }
@@ -660,7 +666,7 @@ multiclass ArithINonCommutable<bits<8> opcode, string asmstring, SDPatternOperat
 }
 
 multiclass PtrInstr<bits<8> opcode, string asmstring, SDPatternOperator node> {
-  let BaseOpcode = asmstring, isCommutable = 1 in {
+  let BaseOpcode = asmstring in {
 
   let isPseudo = 1, isCodeGenOnly = 1 in
   def rrr_p : Pseudo<(outs GRPTR:$rd0), (ins GRPTR:$rs0, GR256:$rs1),
@@ -671,11 +677,11 @@ multiclass PtrInstr<bits<8> opcode, string asmstring, SDPatternOperator node> {
                      }
   def rrr_s : Irrr<opcode, 0, 1,
                    (outs GRPTR:$rd0), (ins GRPTR:$rs0, GR256:$rs1, cc:$cc),
-                   !strconcat(asmstring, "$cc\t$rs0, $rs1, $rd0"), []>, PseudoRel, FlagRel;
+                   !strconcat(asmstring, "$cc\t$rs0, $rs1, $rd0"), []>, PseudoRel, FlagRel, AddrModeRel, RetAddrModeRel;
   let Defs = [Flags] in
   def rrr_v : Irrr<opcode, 0, 0,
                    (outs GRPTR:$rd0), (ins GRPTR:$rs0, GR256:$rs1, cc:$cc),
-                   !strconcat(asmstring, "$cc!\t$rs0, $rs1, $rd0"), []>, FlagRel;
+                   !strconcat(asmstring, "$cc!\t$rs0, $rs1, $rd0"), []>, FlagRel, AddrModeRel, RetAddrModeRel;
 
   let mayLoad = 1 in {
   let isPseudo = 1, isCodeGenOnly = 1 in
@@ -687,11 +693,11 @@ multiclass PtrInstr<bits<8> opcode, string asmstring, SDPatternOperator node> {
                      }
   def srr_s : Isrr<opcode, SrcStack, 0, 1,
                    (outs GRPTR:$rd0), (ins stackop:$src0, GR256:$rs1, cc:$cc),
-                   !strconcat(asmstring, "$cc\t$src0, $rs1, $rd0"), []>, PseudoRel, FlagRel;
+                   !strconcat(asmstring, "$cc\t$src0, $rs1, $rd0"), []>, PseudoRel, FlagRel, AddrModeRel, RetAddrModeRel;
   let Defs = [Flags] in
   def srr_v : Isrr<opcode, SrcStack, 0, 0,
                    (outs GRPTR:$rd0), (ins stackop:$src0, GR256:$rs1, cc:$cc),
-                   !strconcat(asmstring, "$cc!\t$src0, $rs1, $rd0"), []>, FlagRel;
+                   !strconcat(asmstring, "$cc!\t$src0, $rs1, $rd0"), []>, FlagRel, AddrModeRel, RetAddrModeRel;
   }
   
   let mayStore = 1 in {
@@ -704,11 +710,28 @@ multiclass PtrInstr<bits<8> opcode, string asmstring, SDPatternOperator node> {
                      }
   def rrs_s : Irrs<opcode, 0, 1,
                    (outs), (ins GRPTR:$rs0, GR256:$rs1, stackop:$dst0, cc:$cc),
-                   !strconcat(asmstring, "$cc\t$rs0, $rs1, $dst0"), []>, PseudoRel, FlagRel;
+                   !strconcat(asmstring, "$cc\t$rs0, $rs1, $dst0"), []>, PseudoRel, FlagRel, AddrModeRel, RetAddrModeRel;
   let Defs = [Flags] in
   def rrs_v : Irrs<opcode, 0, 0,
                    (outs), (ins GRPTR:$rs0, GR256:$rs1, stackop:$dst0, cc:$cc),
-                   !strconcat(asmstring, "$cc!\t$rs0, $rs1, $dst0"), []>, FlagRel;
+                   !strconcat(asmstring, "$cc!\t$rs0, $rs1, $dst0"), []>, FlagRel, AddrModeRel, RetAddrModeRel;
+  }
+
+  let mayLoad =1, mayStore = 1 in {
+  let isPseudo = 1, isCodeGenOnly = 1 in
+  def srs_p : Pseudo<(outs), (ins stackop:$src0, GR256:$rs1, stackop:$dst0),
+                     !strconcat(asmstring, "\t$src0, $rs1, $dst0"),
+                     [(store_stack (node (load_stack stackaddr:$src0), GR256:$rs1), stackaddr:$dst0)]> {
+                      let DestAddrMode = ToStack.Value;
+                      let OperandAddrMode = OpndSR.Value;
+                     }
+  def srs_s : Isrs<opcode, SrcStack, 0, 1,
+                   (outs), (ins stackop:$src0, GR256:$rs1, stackop:$dst0, cc:$cc),
+                   !strconcat(asmstring, "$cc\t$src0, $rs1, $dst0"), []>, PseudoRel, FlagRel, AddrModeRel, RetAddrModeRel;
+  let Defs = [Flags] in
+  def srs_v : Isrs<opcode, SrcStack, 0, 0,
+                   (outs), (ins GRPTR:$src0, GR256:$rs1, stackop:$dst0, cc:$cc),
+                   !strconcat(asmstring, "$cc!\t$src0, $rs1, $dst0"), []>, FlagRel, AddrModeRel, RetAddrModeRel;
   }
 
   let isPseudo = 1, isCodeGenOnly = 1 in {
@@ -723,13 +746,13 @@ multiclass PtrInstr<bits<8> opcode, string asmstring, SDPatternOperator node> {
   def xrr_s : Iirr<opcode, 1, 1,
                        (outs GRPTR:$rd0), (ins imm16:$imm, GRPTR:$rs1, cc:$cc),
                        !strconcat(!strconcat(asmstring, ".s"),
-                                  "$cc\t$imm, $rs1, $rd0"), []>, PseudoRel, FlagRel;
+                                  "$cc\t$imm, $rs1, $rd0"), []>, PseudoRel, FlagRel, AddrModeRel, RetAddrModeRel;
 
   let Defs = [Flags] in
   def xrr_v : Iirr<opcode, 1, 0,
                        (outs GRPTR:$rd0), (ins imm16:$imm, GRPTR:$rs1, cc:$cc),
                        !strconcat(!strconcat(asmstring, ".s"),
-                                  "$cc!\t$imm, $rs1, $rd0"), []>, FlagRel;
+                                  "$cc!\t$imm, $rs1, $rd0"), []>, FlagRel, AddrModeRel, RetAddrModeRel;
   let mayLoad = 1 in {
   let isPseudo = 1, isCodeGenOnly = 1 in
   def yrr_p : Pseudo<(outs GRPTR:$rd0), (ins memop:$src0, GRPTR:$rs1),
@@ -741,12 +764,12 @@ multiclass PtrInstr<bits<8> opcode, string asmstring, SDPatternOperator node> {
                      }
   def yrr_s : Imrr<opcode, SrcCode, 1, 1,
                    (outs GRPTR:$rd0), (ins memop:$src0, GRPTR:$rs1, cc:$cc),
-                   !strconcat(asmstring, ".s$cc\t$src0[0], $rs1, $rd0"), []>, PseudoRel, FlagRel;
+                   !strconcat(asmstring, ".s$cc\t$src0[0], $rs1, $rd0"), []>, PseudoRel, FlagRel, AddrModeRel, RetAddrModeRel;
 
   let Defs = [Flags] in
   def yrr_v : Imrr<opcode, SrcCode, 1, 0,
                    (outs GRPTR:$rd0), (ins memop:$src0, GRPTR:$rs1, cc:$cc),
-                   !strconcat(asmstring, ".s$cc!\t$src0[0], $rs1, $rd0"), []>, FlagRel;
+                   !strconcat(asmstring, ".s$cc!\t$src0[0], $rs1, $rd0"), []>, FlagRel, AddrModeRel, RetAddrModeRel;
 
   let isPseudo = 1, isCodeGenOnly = 1 in
   def zrr_p : Pseudo<(outs GRPTR:$rd0), (ins stackop:$src0, GRPTR:$rs1),
@@ -759,12 +782,12 @@ multiclass PtrInstr<bits<8> opcode, string asmstring, SDPatternOperator node> {
 
   def zrr_s : Isrr<opcode, SrcStack, 1, 1,
                    (outs GRPTR:$rd0), (ins stackop:$src0, GRPTR:$rs1, cc:$cc),
-                   !strconcat(asmstring, ".s$cc\t$src0, $rs1, $rd0"), []>, PseudoRel, FlagRel;
+                   !strconcat(asmstring, ".s$cc\t$src0, $rs1, $rd0"), []>, PseudoRel, FlagRel, RetAddrModeRel;
 
   let Defs = [Flags] in
   def zrr_v : Isrr<opcode, SrcStack, 1, 0,
                    (outs GRPTR:$rd0), (ins stackop:$src0, GRPTR:$rs1, cc:$cc),
-                   !strconcat(asmstring, ".s$cc!\t$src0, $rs1, $rd0"), []>, FlagRel;
+                   !strconcat(asmstring, ".s$cc!\t$src0, $rs1, $rd0"), []>, FlagRel, RetAddrModeRel;
   }
 
   let mayStore = 1 in {
@@ -780,13 +803,13 @@ multiclass PtrInstr<bits<8> opcode, string asmstring, SDPatternOperator node> {
 
   def xrs_s : Iirs<opcode, 1, 1,
                        (outs), (ins imm16:$imm, GRPTR:$rs1, stackop:$dst0, cc:$cc),
-                       !strconcat(!strconcat(asmstring, ".s"), "$cc\t$imm, $rs1, $dst0"), []>, PseudoRel, FlagRel;
+                       !strconcat(!strconcat(asmstring, ".s"), "$cc\t$imm, $rs1, $dst0"), []>, PseudoRel, FlagRel, AddrModeRel, RetAddrModeRel;
 
   let Defs = [Flags] in
   def xrs_v : Iirs<opcode, 1, 0,
                        (outs), (ins imm16:$imm, GRPTR:$rs1, stackop:$dst0, cc:$cc),
                        !strconcat(!strconcat(asmstring, ".s"),
-                                  "$cc!\t$imm, $rs1, $dst0"), []>, FlagRel;
+                                  "$cc!\t$imm, $rs1, $dst0"), []>, FlagRel, AddrModeRel, RetAddrModeRel;
   let mayLoad = 1 in {
   let isPseudo = 1, isCodeGenOnly = 1 in
   def yrs_p : Pseudo<(outs), (ins memop:$src0, GRPTR:$rs1, stackop:$dst0),
@@ -799,12 +822,12 @@ multiclass PtrInstr<bits<8> opcode, string asmstring, SDPatternOperator node> {
 
   def yrs_s : Imrs<opcode, SrcCode, 1, 1,
                    (outs), (ins memop:$src0, GRPTR:$rs1, stackop:$dst0, cc:$cc),
-                   !strconcat(asmstring, ".s$cc\t$src0[0], $rs1, $dst0"), []>, PseudoRel, FlagRel;
+                   !strconcat(asmstring, ".s$cc\t$src0[0], $rs1, $dst0"), []>, PseudoRel, FlagRel, AddrModeRel, RetAddrModeRel;
 
   let Defs = [Flags] in
   def yrs_v : Imrs<opcode, SrcCode, 1, 0,
                    (outs), (ins memop:$src0, GRPTR:$rs1, stackop:$dst0, cc:$cc),
-                   !strconcat(asmstring, ".s$cc!\t$src0[0], $rs1, $dst0"), []>, FlagRel;
+                   !strconcat(asmstring, ".s$cc!\t$src0[0], $rs1, $dst0"), []>, FlagRel, AddrModeRel, RetAddrModeRel;
 
   let isPseudo = 1, isCodeGenOnly = 1 in
   def zrs_p : Pseudo<(outs), (ins stackop:$src0, GRPTR:$rs1, stackop:$dst0),
@@ -817,12 +840,12 @@ multiclass PtrInstr<bits<8> opcode, string asmstring, SDPatternOperator node> {
 
   def zrs_s : Isrs<opcode, SrcStack, 1, 1,
                    (outs), (ins stackop:$src0, GRPTR:$rs1, stackop:$dst0, cc:$cc),
-                   !strconcat(asmstring, ".s$cc\t$src0, $rs1, $dst0"), []>, PseudoRel, FlagRel;
+                   !strconcat(asmstring, ".s$cc\t$src0, $rs1, $dst0"), []>, PseudoRel, FlagRel, RetAddrModeRel;
 
   let Defs = [Flags] in
   def zrs_v : Isrs<opcode, SrcStack, 1, 0,
                    (outs), (ins stackop:$src0, GRPTR:$rs1, stackop:$dst0, cc:$cc),
-                   !strconcat(asmstring, ".s$cc!\t$src0, $rs1, $dst0"), []>, FlagRel;
+                   !strconcat(asmstring, ".s$cc!\t$src0, $rs1, $dst0"), []>, FlagRel, RetAddrModeRel;
   }
   }
   }
@@ -852,12 +875,11 @@ multiclass Arith2<bits<8> opcode, string asmstring, SDPatternOperator node, bit 
                       }
   def rrrr_s : Irrrr<opcode, 0, 1,
                      (outs GR256:$rd0, GR256:$rd1), (ins GR256:$rs0, GR256:$rs1, cc:$cc),
-                     !strconcat(asmstring, "$cc\t$rs0, $rs1, $rd0, $rd1"), []>, PseudoRel, FlagRel;
-  let Defs = [Flags], hasPostISelHook = 1 in {
+                     !strconcat(asmstring, "$cc\t$rs0, $rs1, $rd0, $rd1"), []>, PseudoRel, FlagRel, AddrModeRel, RetAddrModeRel;
+  let Defs = [Flags], hasPostISelHook = 1 in
   def rrrr_v : Irrrr<opcode, 0, 0,
                      (outs GR256:$rd0, GR256:$rd1), (ins GR256:$rs0, GR256:$rs1, cc:$cc),
-                     !strconcat(asmstring, "$cc!\t$rs0, $rs1, $rd0, $rd1"), []>, FlagRel;
-  }
+                     !strconcat(asmstring, "$cc!\t$rs0, $rs1, $rd0, $rd1"), []>, FlagRel, AddrModeRel, RetAddrModeRel;
 
   let mayLoad = 1 in {
   let isPseudo = 1, isCodeGenOnly = 1 in
@@ -869,11 +891,11 @@ multiclass Arith2<bits<8> opcode, string asmstring, SDPatternOperator node, bit 
                       }
   def crrr_s : Imrrr<opcode, SrcCode, 0, 1,
                      (outs GR256:$rd0, GR256:$rd1), (ins memop:$src0, GR256:$rs1, cc:$cc),
-                     !strconcat(asmstring, "$cc\t$src0[0], $rs1, $rd0, $rd1"), []>, PseudoRel, FlagRel;
+                     !strconcat(asmstring, "$cc\t$src0[0], $rs1, $rd0, $rd1"), []>, PseudoRel, FlagRel, AddrModeRel, RetAddrModeRel;
   let Defs = [Flags], hasPostISelHook = 1 in
   def crrr_v : Imrrr<opcode, SrcCode, 0, 0,
                      (outs GR256:$rd0, GR256:$rd1), (ins memop:$src0, GR256:$rs1, cc:$cc),
-                     !strconcat(asmstring, "$cc!\t$src0[0], $rs1, $rd0, $rd1"), []>, FlagRel;
+                     !strconcat(asmstring, "$cc!\t$src0[0], $rs1, $rd0, $rd1"), []>, FlagRel, AddrModeRel, RetAddrModeRel;
   let isPseudo = 1, isCodeGenOnly = 1 in
   def srrr_p : Pseudo<(outs GR256:$rd0, GR256:$rd1), (ins stackop:$src0, GR256:$rs1),
                       !strconcat(asmstring, "\t$src0, $rs1, $rd0, $rd1"),
@@ -883,11 +905,11 @@ multiclass Arith2<bits<8> opcode, string asmstring, SDPatternOperator node, bit 
                       }
   def srrr_s : Isrrr<opcode, SrcStack, 0, 1,
                      (outs GR256:$rd0, GR256:$rd1), (ins stackop:$src0, GR256:$rs1, cc:$cc),
-                     !strconcat(asmstring, "$cc\t$src0, $rs1, $rd0, $rd1"), []>, PseudoRel, FlagRel;
+                     !strconcat(asmstring, "$cc\t$src0, $rs1, $rd0, $rd1"), []>, PseudoRel, FlagRel, AddrModeRel, RetAddrModeRel;
   let Defs = [Flags], hasPostISelHook = 1 in
   def srrr_v : Isrrr<opcode, SrcStack, 0, 0,
                      (outs GR256:$rd0, GR256:$rd1), (ins stackop:$src0, GR256:$rs1, cc:$cc),
-                     !strconcat(asmstring, "$cc!\t$src0, $rs1, $rd0, $rd1"), []>, FlagRel;
+                     !strconcat(asmstring, "$cc!\t$src0, $rs1, $rd0, $rd1"), []>, FlagRel, AddrModeRel, RetAddrModeRel;
   }
 
   let mayStore = 1 in {
@@ -898,11 +920,11 @@ multiclass Arith2<bits<8> opcode, string asmstring, SDPatternOperator node, bit 
                       }
   def rrsr_s : Irrsr<opcode, 0, 1,
                      (outs GR256:$rd1), (ins GR256:$rs0, GR256:$rs1, stackop:$dst0, cc:$cc),
-                     !strconcat(asmstring, "$cc\t$rs0, $rs1, $dst0, $rd1"), []>, PseudoRel, FlagRel;
+                     !strconcat(asmstring, "$cc\t$rs0, $rs1, $dst0, $rd1"), []>, PseudoRel, FlagRel, AddrModeRel, RetAddrModeRel;
   let Defs = [Flags], hasPostISelHook = 1 in
   def rrsr_v : Irrsr<opcode, 0, 0,
                      (outs GR256:$rd1), (ins GR256:$rs0, GR256:$rs1, stackop:$dst0, cc:$cc),
-                     !strconcat(asmstring, "$cc!\t$rs0, $rs1, $dst0, $rd1"), []>, FlagRel;
+                     !strconcat(asmstring, "$cc!\t$rs0, $rs1, $dst0, $rd1"), []>, FlagRel, AddrModeRel, RetAddrModeRel;
   let mayLoad = 1 in {
   def crsr_p : Pseudo<(outs GR256:$rd1), (ins memop:$src0, GR256:$rs1, stackop:$dst0),
                       !strconcat(asmstring, "\t$src0[0], $rs1, $dst0, $rd1"), []> {
@@ -911,11 +933,11 @@ multiclass Arith2<bits<8> opcode, string asmstring, SDPatternOperator node, bit 
                       }
   def crsr_s : Imrsr<opcode, SrcCode, 0, 1,
                      (outs GR256:$rd1), (ins memop:$src0, GR256:$rs1, stackop:$dst0, cc:$cc),
-                     !strconcat(asmstring, "$cc\t$src0[0], $rs1, $dst0, $rd1"), []>, PseudoRel, FlagRel;
+                     !strconcat(asmstring, "$cc\t$src0[0], $rs1, $dst0, $rd1"), []>, PseudoRel, FlagRel, AddrModeRel, RetAddrModeRel;
   let Defs = [Flags], hasPostISelHook = 1 in
   def crsr_v : Imrsr<opcode, SrcCode, 0, 0,
                      (outs GR256:$rd1), (ins memop:$src0, GR256:$rs1, stackop:$dst0, cc:$cc),
-                     !strconcat(asmstring, "$cc!\t$src0[0], $rs1, $dst0, $rd1"), []>, FlagRel;
+                     !strconcat(asmstring, "$cc!\t$src0[0], $rs1, $dst0, $rd1"), []>, FlagRel, AddrModeRel, RetAddrModeRel;
   def srsr_p : Pseudo<(outs GR256:$rd1), (ins stackop:$src0, GR256:$rs1, stackop:$dst0),
                       !strconcat(asmstring, "\t$src0, $rs1, $dst0, $rd1"), []> {
                         let DestAddrMode = ToStackReg.Value;
@@ -924,11 +946,11 @@ multiclass Arith2<bits<8> opcode, string asmstring, SDPatternOperator node, bit 
                       }
   def srsr_s : Isrsr<opcode, SrcStack, 0, 1,
                      (outs GR256:$rd1), (ins stackop:$src0, GR256:$rs1, stackop:$dst0, cc:$cc),
-                     !strconcat(asmstring, "$cc\t$src0, $rs1, $dst0, $rd1"), []>, PseudoRel, FlagRel;
+                     !strconcat(asmstring, "$cc\t$src0, $rs1, $dst0, $rd1"), []>, PseudoRel, FlagRel, AddrModeRel, RetAddrModeRel;
   let Defs = [Flags], hasPostISelHook = 1 in
   def srsr_v : Isrsr<opcode, SrcStack, 0, 0,
                      (outs GR256:$rd1), (ins stackop:$src0, GR256:$rs1, stackop:$dst0, cc:$cc),
-                     !strconcat(asmstring, "$cc!\t$src0, $rs1, $dst0, $rd1"), []>, FlagRel;
+                     !strconcat(asmstring, "$cc!\t$src0, $rs1, $dst0, $rd1"), []>, FlagRel, AddrModeRel, RetAddrModeRel;
   }
   }
   }
@@ -945,11 +967,11 @@ multiclass Arith2ICommutable<bits<8> opcode, string asmstring, SDPatternOperator
                       }
   def irrr_s : Iirrr<opcode, 0, 1,
                      (outs GR256:$rd0, GR256:$rd1), (ins imm16:$imm, GR256:$rs1, cc:$cc),
-                     !strconcat(asmstring, "$cc\t$imm, $rs1, $rd0, $rd1"), []>, PseudoRel, FlagRel;
+                     !strconcat(asmstring, "$cc\t$imm, $rs1, $rd0, $rd1"), []>, PseudoRel, FlagRel, AddrModeRel, RetAddrModeRel;
   let Defs = [Flags], hasPostISelHook = 1 in
   def irrr_v : Iirrr<opcode, 0, 0,
                      (outs GR256:$rd0, GR256:$rd1), (ins imm16:$imm, GR256:$rs1, cc:$cc),
-                     !strconcat(asmstring, "$cc!\t$imm, $rs1, $rd0, $rd1"), []>, FlagRel;
+                     !strconcat(asmstring, "$cc!\t$imm, $rs1, $rd0, $rd1"), []>, FlagRel, AddrModeRel, RetAddrModeRel;
   let mayStore = 1 in {
   def irsr_p : Pseudo<(outs GR256:$rd1), (ins imm16:$imm, GR256:$rs1, stackop:$dst0),
                       !strconcat(asmstring, "\t$imm, $rs1, $dst0, $rd1"), []> {
@@ -958,11 +980,11 @@ multiclass Arith2ICommutable<bits<8> opcode, string asmstring, SDPatternOperator
                       }
   def irsr_s : Iirsr<opcode, 0, 1,
                      (outs GR256:$rd1), (ins imm16:$imm, GR256:$rs1, stackop:$dst0, cc:$cc),
-                     !strconcat(asmstring, "$cc\t$imm, $rs1, $dst0, $rd1"), []>, PseudoRel, FlagRel;
+                     !strconcat(asmstring, "$cc\t$imm, $rs1, $dst0, $rd1"), []>, PseudoRel, FlagRel, AddrModeRel, RetAddrModeRel;
   let Defs = [Flags] in
   def irsr_v : Iirsr<opcode, 0, 0,
                      (outs GR256:$rd1), (ins imm16:$imm, GR256:$rs1, stackop:$dst0, cc:$cc),
-                     !strconcat(asmstring, "$cc!\t$imm, $rs1, $dst0, $rd1"), []>, FlagRel;
+                     !strconcat(asmstring, "$cc!\t$imm, $rs1, $dst0, $rd1"), []>, FlagRel, AddrModeRel, RetAddrModeRel;
   }
   }
 
@@ -991,17 +1013,19 @@ multiclass Arith2INonCommutable<bits<8> opcode, string asmstring, SDPatternOpera
   }
   def irrr_s : Iirrr<opcode, 0, 1,
                        (outs GR256:$rd0, GR256:$rd1), (ins imm16:$imm, GR256:$rs1, cc:$cc),
-                       !strconcat(asmstring, "$cc\t$imm, $rs1, $rd0, $rd1"), []>, PseudoRel, FlagRel;
+                       !strconcat(asmstring, "$cc\t$imm, $rs1, $rd0, $rd1"), []>, PseudoRel, FlagRel, AddrModeRel, RetAddrModeRel;
   def xrrr_s : Iirrr<opcode, 1, 1,
                        (outs GR256:$rd0, GR256:$rd1), (ins imm16:$imm, GR256:$rs1, cc:$cc),
-                       !strconcat(!strconcat(asmstring, ".s"), "$cc\t$imm, $rs1, $rd0, $rd1"), []>, PseudoRel, FlagRel;
+                       !strconcat(!strconcat(asmstring, ".s"), "$cc\t$imm, $rs1, $rd0, $rd1"), []>, PseudoRel, FlagRel, RetAddrModeRel;
 
-  foreach swap = ["i", "x"] in
-  let Defs = [Flags] in
-  def swap#rrr_v : Iirrr<opcode, !if(!eq(swap, "i"), 0, 1), 0,
+  let Defs = [Flags] in {
+  def irrr_v : Iirrr<opcode, 0, 0,
                        (outs GR256:$rd0, GR256:$rd1), (ins imm16:$imm, GR256:$rs1, cc:$cc),
-                       !strconcat(!strconcat(asmstring, !if(!eq(swap, "i"), "", ".s")),
-                                  "$cc!\t$imm, $rs1, $rd0, $rd1"), []>, FlagRel;
+                       !strconcat(asmstring, "$cc!\t$imm, $rs1, $rd0, $rd1"), []>, FlagRel, AddrModeRel, RetAddrModeRel;
+  def xrrr_v : Iirrr<opcode, 1, 0,
+                       (outs GR256:$rd0, GR256:$rd1), (ins imm16:$imm, GR256:$rs1, cc:$cc),
+                       !strconcat(asmstring, ".s$cc!\t$imm, $rs1, $rd0, $rd1"), []>, FlagRel, RetAddrModeRel;
+  }
 
   let mayLoad = 1 in {
   let isPseudo = 1, isCodeGenOnly = 1 in
@@ -1014,11 +1038,11 @@ multiclass Arith2INonCommutable<bits<8> opcode, string asmstring, SDPatternOpera
                       }
   def yrrr_s : Imrrr<opcode, SrcCode, 1, 1,
                      (outs GR256:$rd0, GR256:$rd1), (ins memop:$src0, GR256:$rs1, cc:$cc),
-                     !strconcat(asmstring, ".s$cc\t$src0[0], $rs1, $rd0, $rd1"), []>, PseudoRel, FlagRel;
+                     !strconcat(asmstring, ".s$cc\t$src0[0], $rs1, $rd0, $rd1"), []>, PseudoRel, FlagRel, RetAddrModeRel;
   let Defs = [Flags] in
   def yrrr_v : Imrrr<opcode, SrcCode, 1, 0,
                      (outs GR256:$rd0, GR256:$rd1), (ins memop:$src0, GR256:$rs1, cc:$cc),
-                     !strconcat(asmstring, ".s$cc!\t$src0[0], $rs1, $rd0, $rd1"), []>, FlagRel;
+                     !strconcat(asmstring, ".s$cc!\t$src0[0], $rs1, $rd0, $rd1"), []>, FlagRel, RetAddrModeRel;
   let isPseudo = 1, isCodeGenOnly = 1 in
   def zrrr_p : Pseudo<(outs GR256:$rd0, GR256:$rd1), (ins stackop:$src0, GR256:$rs1),
                       !strconcat(asmstring, ".s\t$src0, $rs1, $rd0, $rd1"),
@@ -1029,11 +1053,11 @@ multiclass Arith2INonCommutable<bits<8> opcode, string asmstring, SDPatternOpera
                       }
   def zrrr_s : Isrrr<opcode, SrcStack, 1, 1,
                      (outs GR256:$rd0, GR256:$rd1), (ins stackop:$src0, GR256:$rs1, cc:$cc),
-                     !strconcat(asmstring, ".s$cc\t$src0, $rs1, $rd0, $rd1"), []>, PseudoRel, FlagRel;
+                     !strconcat(asmstring, ".s$cc\t$src0, $rs1, $rd0, $rd1"), []>, PseudoRel, FlagRel, RetAddrModeRel;
   let Defs = [Flags] in
   def zrrr_v : Isrrr<opcode, SrcStack, 1, 0,
                    (outs GR256:$rd0, GR256:$rd1), (ins stackop:$src0, GR256:$rs1, cc:$cc),
-                   !strconcat(asmstring, ".s$cc!\t$src0, $rs1, $rd0, $rd1"), []>, FlagRel;
+                   !strconcat(asmstring, ".s$cc!\t$src0, $rs1, $rd0, $rd1"), []>, FlagRel, RetAddrModeRel;
   }
   let mayStore = 1 in {
   foreach swap = ["i", "x"] in {
@@ -1045,17 +1069,21 @@ multiclass Arith2INonCommutable<bits<8> opcode, string asmstring, SDPatternOpera
       let OperandAddrMode = OpndIR.Value;
       let ReverseOperand = !if(!eq(swap, "i"), 0, 1);
     }
-  def swap#rsr_s : Iirsr<opcode, !if(!eq(swap, "i"), 0, 1), 1,
-                         (outs GR256:$rd1), (ins imm16:$imm, GR256:$rs1, stackop:$dst0, cc:$cc),
-                         !strconcat(!strconcat(asmstring, !if(!eq(swap, "i"), "", ".s")),
-                                    "$cc\t$imm, $rs1, $dst0, $rd1"), []>, PseudoRel, FlagRel;
   }
-  foreach swap = ["i", "x"] in
-  let Defs = [Flags] in
-  def swap#rsr_v : Iirsr<opcode, !if(!eq(swap, "i"), 0, 1), 0,
+  def irsr_s : Iirsr<opcode, 0, 1,
+                         (outs GR256:$rd1), (ins imm16:$imm, GR256:$rs1, stackop:$dst0, cc:$cc),
+                         !strconcat(asmstring, "$cc\t$imm, $rs1, $dst0, $rd1"), []>, PseudoRel, FlagRel, AddrModeRel, RetAddrModeRel;
+  def xrsr_s : Iirsr<opcode, 1, 1,
+                         (outs GR256:$rd1), (ins imm16:$imm, GR256:$rs1, stackop:$dst0, cc:$cc),
+                         !strconcat(asmstring, ".s$cc\t$imm, $rs1, $dst0, $rd1"), []>, PseudoRel, FlagRel, RetAddrModeRel;
+  let Defs = [Flags] in {
+  def irsr_v : Iirsr<opcode, 0, 0,
                          (outs GR256:$rd1), (ins imm16:$imm, GR256:$rs1, GR256:$dst0, cc:$cc),
-                         !strconcat(!strconcat(asmstring, !if(!eq(swap, "i"), "", ".s")),
-                                    "$cc!\t$imm, $rs1, $dst0, $rd1"), []>, FlagRel;
+                         !strconcat(asmstring, "$cc!\t$imm, $rs1, $dst0, $rd1"), []>, FlagRel, AddrModeRel, RetAddrModeRel;
+  def xrsr_v : Iirsr<opcode, 1, 0,
+                         (outs GR256:$rd1), (ins imm16:$imm, GR256:$rs1, GR256:$dst0, cc:$cc),
+                         !strconcat(asmstring, ".s$cc!\t$imm, $rs1, $dst0, $rd1"), []>, FlagRel, RetAddrModeRel;
+  }
   let mayLoad = 1 in {
   let isPseudo = 1, isCodeGenOnly = 1 in
   def yrsr_p : Pseudo<(outs GR256:$rd0), (ins memop:$src0, GR256:$rs1, stackop:$dst0),
@@ -1066,11 +1094,11 @@ multiclass Arith2INonCommutable<bits<8> opcode, string asmstring, SDPatternOpera
                       }
   def yrsr_s : Imrsr<opcode, SrcCode, 1, 1,
                      (outs GR256:$rd0), (ins memop:$src0, GR256:$rs1, stackop:$dst0, cc:$cc),
-                     !strconcat(asmstring, ".s$cc\t$src0[0], $rs1, $dst0, $rd0"), []>, PseudoRel, FlagRel;
+                     !strconcat(asmstring, ".s$cc\t$src0[0], $rs1, $dst0, $rd0"), []>, PseudoRel, FlagRel, RetAddrModeRel;
   let Defs = [Flags] in
   def yrsr_v : Imrsr<opcode, SrcCode, 1, 0,
                      (outs GR256:$rd0), (ins memop:$src0, GR256:$rs1, stackop:$dst0, cc:$cc),
-                     !strconcat(asmstring, ".s$cc!\t$src0[0], $rs1, $dst0, $rd0"), []>, FlagRel;
+                     !strconcat(asmstring, ".s$cc!\t$src0[0], $rs1, $dst0, $rd0"), []>, FlagRel, RetAddrModeRel;
   let isPseudo = 1, isCodeGenOnly = 1 in
   def zrsr_p : Pseudo<(outs GR256:$rd0), (ins stackop:$src0, GR256:$rs1, stackop:$dst0),
                       !strconcat(asmstring, ".s\t$src0, $rs1, $dst0, $rd0"), []> {
@@ -1080,11 +1108,11 @@ multiclass Arith2INonCommutable<bits<8> opcode, string asmstring, SDPatternOpera
                       }
   def zrsr_s : Isrsr<opcode, SrcStack, 1, 1,
                      (outs GR256:$rd0), (ins stackop:$src0, GR256:$rs1, stackop:$dst0, cc:$cc),
-                     !strconcat(asmstring, ".s$cc\t$src0, $rs1, $dst0, $rd0"), []>, PseudoRel, FlagRel;
+                     !strconcat(asmstring, ".s$cc\t$src0, $rs1, $dst0, $rd0"), []>, PseudoRel, FlagRel, RetAddrModeRel;
   let Defs = [Flags] in
   def zrsr_v : Isrsr<opcode, SrcStack, 1, 0,
                      (outs GR256:$rd0), (ins stackop:$src0, GR256:$rs1, stackop:$dst0, cc:$cc),
-                     !strconcat(asmstring, ".s$cc!\t$src0, $rs1, $dst0, $rd0"), []>, FlagRel;
+                     !strconcat(asmstring, ".s$cc!\t$src0, $rs1, $dst0, $rd0"), []>, FlagRel, RetAddrModeRel;
   }
   }
   }
@@ -1226,7 +1254,7 @@ def THROW : IRet<7, RFErr, (ins GR256:$rs0), "ret.error\t$rs0",
 def : InstAlias<"revert", (THROW R1)>;
 def : InstAlias<"panic", (PANIC R1)>;
 
-let isTerminator = 1, isBarrier = 1 in {
+let isTerminator = 1, isBarrier = 1, isReturn = 1 in {
 def RETURN : IRet<52, RFErr, (ins GR256:$rs0), "ret.ok.to_label\t$rs0, @DEFAULT_FAR_RETURN",
                   [(SyncVMreturn GR256:$rs0)]>;
 def REVERT : IRet<53, RFErr, (ins GR256:$rs0), "ret.revert.to_label\t$rs0, @DEFAULT_FAR_REVERT",

--- a/llvm/test/CodeGen/SyncVM/ptradd.ll
+++ b/llvm/test/CodeGen/SyncVM/ptradd.ll
@@ -159,9 +159,7 @@ define void @ptraddrcs(i8 addrspace(3)* %rs1) nounwind {
 ; CHECK-LABEL: ptraddgrs
 define void @ptraddgrs(i256 %rs2) nounwind {
   %result = alloca i8 addrspace(3)*
-; TODO: should be ptr.add stack[@ptr], r1, stack-[1]
-; CHECK: ptr.add stack[@ptr], r0, r2
-; CHECK: ptr.add r2, r1, stack-[1]
+; CHECK: ptr.add stack[@ptr], r1, stack-[1]
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** @ptr
   %res1 = getelementptr i8, i8 addrspace(3)* %ptr, i256 %rs2
   store i8 addrspace(3)* %res1, i8 addrspace(3)** %result
@@ -171,8 +169,8 @@ define void @ptraddgrs(i256 %rs2) nounwind {
 ; CHECK-LABEL: ptraddgis
 define void @ptraddgis(i8 addrspace(3)* %rs1) nounwind {
   %result = alloca i8 addrspace(3)*
-; CHECK: ptr.add stack[@ptr], r0, r1
-; CHECK: ptr.add.s 42, r1, stack-[1]
+  ; CHECK: add 42, r0, r1
+  ; CHECK: ptr.add stack[@ptr], r1, stack-[1]
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** @ptr
   %res1 = getelementptr i8, i8 addrspace(3)* %ptr, i256 42
   store i8 addrspace(3)* %res1, i8 addrspace(3)** %result
@@ -182,8 +180,8 @@ define void @ptraddgis(i8 addrspace(3)* %rs1) nounwind {
 ; CHECK-LABEL: ptraddgss
 define void @ptraddgss(i8 addrspace(3)* %rs1) nounwind {
   %result = alloca i8 addrspace(3)*
-; CHECK: ptr.add stack[@ptr], r0, r1
-; CHECK: ptr.add.s stack-[1], r1, stack-[2]
+; CHECK: add stack-[1], r0, r1
+; CHECK: ptr.add stack[@ptr], r1, stack-[2]
   %valptr = alloca i256
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** @ptr
   %val = load i256, i256* %valptr
@@ -195,8 +193,8 @@ define void @ptraddgss(i8 addrspace(3)* %rs1) nounwind {
 ; CHECK-LABEL: ptraddgcs
 define void @ptraddgcs(i8 addrspace(3)* %rs1) nounwind {
   %result = alloca i8 addrspace(3)*
-; CHECK: ptr.add stack[@ptr], r0, r1
-; CHECK: ptr.add.s @val[0], r1, stack-[1]
+  ; CHECK: add @val[0], r0, r1
+  ; CHECK: ptr.add stack[@ptr], r1, stack-[1]
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** @ptr
   %val = load i256, i256 addrspace(4)* @val
   %res1 = getelementptr i8, i8 addrspace(3)* %ptr, i256 %val
@@ -207,9 +205,7 @@ define void @ptraddgcs(i8 addrspace(3)* %rs1) nounwind {
 ; CHECK-LABEL: ptraddsrs
 define void @ptraddsrs(i256 %rs2) nounwind {
   %result = alloca i8 addrspace(3)*
-; TODO: should be ptr.add stack-[1], r0, stack-[2]
-; CHECK: ptr.add stack-[1], r0, r2
-; CHECK: ptr.add r2, r1, stack-[2]
+; CHECK: ptr.add stack-[1], r1, stack-[2]
   %ptrptr = alloca i8 addrspace(3)*
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** %ptrptr
   %res1 = getelementptr i8, i8 addrspace(3)* %ptr, i256 %rs2
@@ -220,8 +216,8 @@ define void @ptraddsrs(i256 %rs2) nounwind {
 ; CHECK-LABEL: ptraddsis
 define void @ptraddsis(i8 addrspace(3)* %rs1) nounwind {
   %result = alloca i8 addrspace(3)*
-; CHECK: ptr.add stack-[1], r0, r1
-; CHECK: ptr.add.s 42, r1, stack-[2]
+  ; CHECK: add 42, r0, r1
+  ; CHECK: ptr.add stack-[1], r1, stack-[2]
   %ptrptr = alloca i8 addrspace(3)*
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** %ptrptr
   %res1 = getelementptr i8, i8 addrspace(3)* %ptr, i256 42
@@ -232,8 +228,8 @@ define void @ptraddsis(i8 addrspace(3)* %rs1) nounwind {
 ; CHECK-LABEL: ptraddsss
 define void @ptraddsss(i8 addrspace(3)* %rs1) nounwind {
   %result = alloca i8 addrspace(3)*
-; CHECK: ptr.add stack-[1], r0, r1
-; CHECK: ptr.add.s stack-[2], r1, stack-[3]
+  ; CHECK: add stack-[2], r0, r1
+  ; CHECK: ptr.add stack-[1], r1, stack-[3]
   %valptr = alloca i256
   %ptrptr = alloca i8 addrspace(3)*
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** %ptrptr
@@ -246,8 +242,8 @@ define void @ptraddsss(i8 addrspace(3)* %rs1) nounwind {
 ; CHECK-LABEL: ptraddscs
 define void @ptraddscs(i8 addrspace(3)* %rs1) nounwind {
   %result = alloca i8 addrspace(3)*
-; CHECK: ptr.add stack-[1], r0, r1
-; CHECK: ptr.add.s @val[0], r1, stack-[2]
+  ; CHECK: add @val[0], r0, r1
+  ; CHECK: ptr.add stack-[1], r1, stack-[2]
   %ptrptr = alloca i8 addrspace(3)*
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** %ptrptr
   %val = load i256, i256 addrspace(4)* @val
@@ -258,9 +254,7 @@ define void @ptraddscs(i8 addrspace(3)* %rs1) nounwind {
 
 ; CHECK-LABEL: ptraddgrg
 define void @ptraddgrg(i256 %rs2) nounwind {
-; TODO: should be ptr.add stack[@ptr], r1, stack[@ptr]
-; CHECK: ptr.add stack[@ptr], r0, r2
-; CHECK: ptr.add r2, r1, stack[@ptr]
+; CHECK: ptr.add stack[@ptr], r1, stack[@ptr]
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** @ptr
   %res1 = getelementptr i8, i8 addrspace(3)* %ptr, i256 %rs2
   store i8 addrspace(3)* %res1, i8 addrspace(3)** @ptr
@@ -269,8 +263,8 @@ define void @ptraddgrg(i256 %rs2) nounwind {
 
 ; CHECK-LABEL: ptraddgig
 define void @ptraddgig(i8 addrspace(3)* %rs1) nounwind {
-; CHECK: ptr.add stack[@ptr], r0, r1
-; CHECK: ptr.add.s 42, r1, stack[@ptr]
+  ; CHECK: add 42, r0, r1
+  ; CHECK: ptr.add stack[@ptr], r1, stack[@ptr]
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** @ptr
   %res1 = getelementptr i8, i8 addrspace(3)* %ptr, i256 42
   store i8 addrspace(3)* %res1, i8 addrspace(3)** @ptr
@@ -279,8 +273,8 @@ define void @ptraddgig(i8 addrspace(3)* %rs1) nounwind {
 
 ; CHECK-LABEL: ptraddgsg
 define void @ptraddgsg(i8 addrspace(3)* %rs1) nounwind {
-; CHECK: ptr.add stack[@ptr], r0, r1
-; CHECK: ptr.add.s stack-[1], r1, stack[@ptr]
+  ; CHECK: add stack-[1], r0, r1
+  ; CHECK: ptr.add stack[@ptr], r1, stack[@ptr]
   %valptr = alloca i256
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** @ptr
   %val = load i256, i256* %valptr
@@ -291,8 +285,8 @@ define void @ptraddgsg(i8 addrspace(3)* %rs1) nounwind {
 
 ; CHECK-LABEL: ptraddgcg
 define void @ptraddgcg(i8 addrspace(3)* %rs1) nounwind {
-; CHECK: ptr.add stack[@ptr], r0, r1
-; CHECk: ptr.add.s @val[0], r1, stack[@ptr]
+; CHECK: add @val[0], r0, r1
+; CHECK: ptr.add stack[@ptr], r1, stack[@ptr]
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** @ptr
   %val = load i256, i256 addrspace(4)* @val
   %res1 = getelementptr i8, i8 addrspace(3)* %ptr, i256 %val
@@ -302,9 +296,7 @@ define void @ptraddgcg(i8 addrspace(3)* %rs1) nounwind {
 
 ; CHECK-LABEL: ptraddsrg
 define void @ptraddsrg(i256 %rs2) nounwind {
-; TODO: should be ptr.add stack-[1], r0, stack[@ptr]
-; CHECK: ptr.add stack-[1], r0, r2
-; CHECK: ptr.add r2, r1, stack[@ptr]
+; CHECK: ptr.add stack-[1], r1, stack[@ptr]
   %ptrptr = alloca i8 addrspace(3)*
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** %ptrptr
   %res1 = getelementptr i8, i8 addrspace(3)* %ptr, i256 %rs2
@@ -314,8 +306,8 @@ define void @ptraddsrg(i256 %rs2) nounwind {
 
 ; CHECK-LABEL: ptraddsig
 define void @ptraddsig(i8 addrspace(3)* %rs1) nounwind {
-; CHECK: ptr.add stack-[1], r0, r1
-; CHECK: ptr.add.s 42, r1, stack[@ptr]
+  ; CHECK: add 42, r0, r1
+  ; CHECK: ptr.add stack-[1], r1, stack[@ptr]
   %ptrptr = alloca i8 addrspace(3)*
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** %ptrptr
   %res1 = getelementptr i8, i8 addrspace(3)* %ptr, i256 42
@@ -325,8 +317,8 @@ define void @ptraddsig(i8 addrspace(3)* %rs1) nounwind {
 
 ; CHECK-LABEL: ptraddssg
 define void @ptraddssg(i8 addrspace(3)* %rs1) nounwind {
-; CHECK: ptr.add stack-[1], r0, r1
-; CHECK: ptr.add.s stack-[2], r1, stack[@ptr]
+  ; CHECK: add stack-[2], r0, r1
+  ; CHECK: ptr.add stack-[1], r1, stack[@ptr]
   %valptr = alloca i256
   %ptrptr = alloca i8 addrspace(3)*
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** %ptrptr
@@ -338,8 +330,8 @@ define void @ptraddssg(i8 addrspace(3)* %rs1) nounwind {
 
 ; CHECK-LABEL: ptraddscg
 define void @ptraddscg(i8 addrspace(3)* %rs1) nounwind {
-; CHECK: ptr.add stack-[1], r0, r1
-; CHECK: ptr.add.s @val[0], r1, stack[@ptr]
+  ; CHECK: add @val[0], r0, r1
+  ; CHECK: ptr.add stack-[1], r1, stack[@ptr]
   %ptrptr = alloca i8 addrspace(3)*
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** %ptrptr
   %val = load i256, i256 addrspace(4)* @val

--- a/llvm/test/CodeGen/SyncVM/ptrpack.ll
+++ b/llvm/test/CodeGen/SyncVM/ptrpack.ll
@@ -157,9 +157,7 @@ define void @ptrpackrcs(i8 addrspace(3)* %rs1) nounwind {
 ; CHECK-LABEL: ptrpackgrs
 define void @ptrpackgrs(i256 %rs2) nounwind {
   %result = alloca i8 addrspace(3)*
-; TODO: should be ptr.pack stack[@ptr], r1, stack-[1]
-; CHECK: ptr.add stack[@ptr], r0, r2
-; CHECK: ptr.pack        r2, r1, stack-[1]
+; CHECK: ptr.pack stack[@ptr], r1, stack-[1]
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** @ptr
   %res1 = call i8 addrspace(3)* @llvm.syncvm.ptr.pack(i8 addrspace(3)* %ptr, i256 %rs2)
   store i8 addrspace(3)* %res1, i8 addrspace(3)** %result
@@ -169,9 +167,10 @@ define void @ptrpackgrs(i256 %rs2) nounwind {
 ; CHECK-LABEL: ptrpackgis
 define void @ptrpackgis(i8 addrspace(3)* %rs1) nounwind {
   %result = alloca i8 addrspace(3)*
-; CHECK: ptr.pack.s 42, r1, stack-[1]
+  ; CHECK: add 42, r0, r1
+ 	; CHECK: ptr.pack stack[@ptr], r1, stack-[1]
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** @ptr
-  %res1 = call i8 addrspace(3)* @llvm.syncvm.ptr.pack(i8 addrspace(3)* %rs1, i256 42)
+  %res1 = call i8 addrspace(3)* @llvm.syncvm.ptr.pack(i8 addrspace(3)* %ptr, i256 42)
   store i8 addrspace(3)* %res1, i8 addrspace(3)** %result
   ret void
 }
@@ -179,8 +178,8 @@ define void @ptrpackgis(i8 addrspace(3)* %rs1) nounwind {
 ; CHECK-LABEL: ptrpackgss
 define void @ptrpackgss(i8 addrspace(3)* %rs1) nounwind {
   %result = alloca i8 addrspace(3)*
-; CHECK: ptr.add stack[@ptr], r0, r1
-; CHECK: ptr.pack.s stack-[1], r1, stack-[2]
+; CHECK: add stack-[1], r0, r1
+; CHECK: ptr.pack stack[@ptr], r1, stack-[2]
   %valptr = alloca i256
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** @ptr
   %val = load i256, i256* %valptr
@@ -192,8 +191,8 @@ define void @ptrpackgss(i8 addrspace(3)* %rs1) nounwind {
 ; CHECK-LABEL: ptrpackgcs
 define void @ptrpackgcs(i8 addrspace(3)* %rs1) nounwind {
   %result = alloca i8 addrspace(3)*
-; CHECK: ptr.add stack[@ptr], r0, r1
-; CHECK: ptr.pack.s @val[0], r1, stack-[1]
+  ; CHECK: add @val[0], r0, r1
+  ; CHECK: ptr.pack stack[@ptr], r1, stack-[1]
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** @ptr
   %val = load i256, i256 addrspace(4)* @val
   %res1 = call i8 addrspace(3)* @llvm.syncvm.ptr.pack(i8 addrspace(3)* %ptr, i256 %val)
@@ -204,9 +203,7 @@ define void @ptrpackgcs(i8 addrspace(3)* %rs1) nounwind {
 ; CHECK-LABEL: ptrpacksrs
 define void @ptrpacksrs(i256 %rs2) nounwind {
   %result = alloca i8 addrspace(3)*
-; TODO: should be ptr.pack stack-[1], r0, stack-[2]
-; CHECK: ptr.add stack-[1], r0, r2
-; CHECK: ptr.pack r2, r1, stack-[2]
+; CHECK: ptr.pack stack-[1], r1, stack-[2]
   %ptrptr = alloca i8 addrspace(3)*
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** %ptrptr
   %res1 = call i8 addrspace(3)* @llvm.syncvm.ptr.pack(i8 addrspace(3)* %ptr, i256 %rs2)
@@ -217,8 +214,8 @@ define void @ptrpacksrs(i256 %rs2) nounwind {
 ; CHECK-LABEL: ptrpacksis
 define void @ptrpacksis(i8 addrspace(3)* %rs1) nounwind {
   %result = alloca i8 addrspace(3)*
-; CHECK: ptr.add stack-[1], r0, r1
-; CHECK: ptr.pack.s 42, r1, stack-[2]
+  ; CHECK: add 42, r0, r1
+  ; CHECK: ptr.pack stack-[1], r1, stack-[2]
   %ptrptr = alloca i8 addrspace(3)*
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** %ptrptr
   %res1 = call i8 addrspace(3)* @llvm.syncvm.ptr.pack(i8 addrspace(3)* %ptr, i256 42)
@@ -229,8 +226,8 @@ define void @ptrpacksis(i8 addrspace(3)* %rs1) nounwind {
 ; CHECK-LABEL: ptrpacksss
 define void @ptrpacksss(i8 addrspace(3)* %rs1) nounwind {
   %result = alloca i8 addrspace(3)*
-; CHECK: ptr.add stack-[1], r0, r1
-; CHECK: ptr.pack.s stack-[2], r1, stack-[3]
+  ; CHECK: add stack-[2], r0, r1
+  ; CHECK: ptr.pack stack-[1], r1, stack-[3]
   %valptr = alloca i256
   %ptrptr = alloca i8 addrspace(3)*
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** %ptrptr
@@ -243,8 +240,8 @@ define void @ptrpacksss(i8 addrspace(3)* %rs1) nounwind {
 ; CHECK-LABEL: ptrpackscs
 define void @ptrpackscs(i8 addrspace(3)* %rs1) nounwind {
   %result = alloca i8 addrspace(3)*
-; CHECK: ptr.add stack-[1], r0, r1
-; CHECK: ptr.pack.s @val[0], r1, stack-[2]
+  ; CHECK: add @val[0], r0, r1
+  ; CHECK: ptr.pack stack-[1], r1, stack-[2]
   %ptrptr = alloca i8 addrspace(3)*
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** %ptrptr
   %val = load i256, i256 addrspace(4)* @val
@@ -255,9 +252,7 @@ define void @ptrpackscs(i8 addrspace(3)* %rs1) nounwind {
 
 ; CHECK-LABEL: ptrpackgrg
 define void @ptrpackgrg(i256 %rs2) nounwind {
-; TODO: should be ptr.pack stack[@ptr], r1, stack[@ptr]
-; CHECK: ptr.add stack[@ptr], r0, r2
-; CHECK: ptr.pack r2, r1, stack[@ptr]
+; CHECK: ptr.pack stack[@ptr], r1, stack[@ptr]
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** @ptr
   %res1 = call i8 addrspace(3)* @llvm.syncvm.ptr.pack(i8 addrspace(3)* %ptr, i256 %rs2)
   store i8 addrspace(3)* %res1, i8 addrspace(3)** @ptr
@@ -266,8 +261,8 @@ define void @ptrpackgrg(i256 %rs2) nounwind {
 
 ; CHECK-LABEL: ptrpackgig
 define void @ptrpackgig(i8 addrspace(3)* %rs1) nounwind {
-; CHECK: ptr.add stack[@ptr], r0, r1
-; CHECK: ptr.pack.s 42, r1, stack[@ptr]
+  ; CHECK: add 42, r0, r1
+  ; CHECK: ptr.pack stack[@ptr], r1, stack[@ptr]
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** @ptr
   %res1 = call i8 addrspace(3)* @llvm.syncvm.ptr.pack(i8 addrspace(3)* %ptr, i256 42)
   store i8 addrspace(3)* %res1, i8 addrspace(3)** @ptr
@@ -276,8 +271,8 @@ define void @ptrpackgig(i8 addrspace(3)* %rs1) nounwind {
 
 ; CHECK-LABEL: ptrpackgsg
 define void @ptrpackgsg(i8 addrspace(3)* %rs1) nounwind {
-; CHECK: ptr.add stack[@ptr], r0, r1
-; CHECK: ptr.pack.s stack-[1], r1, stack[@ptr]
+  ; CHECK: add stack-[1], r0, r1
+  ; CHECK: ptr.pack stack[@ptr], r1, stack[@ptr]
   %valptr = alloca i256
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** @ptr
   %val = load i256, i256* %valptr
@@ -288,8 +283,8 @@ define void @ptrpackgsg(i8 addrspace(3)* %rs1) nounwind {
 
 ; CHECK-LABEL: ptrpackgcg
 define void @ptrpackgcg(i8 addrspace(3)* %rs1) nounwind {
-; CHECK: ptr.add stack[@ptr], r0, r1
-; CHECK: ptr.pack.s @val[0], r1, stack[@ptr]
+; CHECK: add @val[0], r0, r1
+; CHECK: ptr.pack stack[@ptr], r1, stack[@ptr]
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** @ptr
   %val = load i256, i256 addrspace(4)* @val
   %res1 = call i8 addrspace(3)* @llvm.syncvm.ptr.pack(i8 addrspace(3)* %ptr, i256 %val)
@@ -299,9 +294,7 @@ define void @ptrpackgcg(i8 addrspace(3)* %rs1) nounwind {
 
 ; CHECK-LABEL: ptrpacksrg
 define void @ptrpacksrg(i256 %rs2) nounwind {
-; TODO: should be ptr.pack stack-[1], r0, stack[@ptr]
-; CHECK: ptr.add stack-[1], r0, r2
-; CHECK: ptr.pack r2, r1, stack[@ptr]
+; CHECK: ptr.pack stack-[1], r1, stack[@ptr]
   %ptrptr = alloca i8 addrspace(3)*
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** %ptrptr
   %res1 = call i8 addrspace(3)* @llvm.syncvm.ptr.pack(i8 addrspace(3)* %ptr, i256 %rs2)
@@ -311,8 +304,8 @@ define void @ptrpacksrg(i256 %rs2) nounwind {
 
 ; CHECK-LABEL: ptrpacksig
 define void @ptrpacksig(i8 addrspace(3)* %rs1) nounwind {
-; CHECK: ptr.add stack-[1], r0, r1
-; CHECK: ptr.pack.s 42, r1, stack[@ptr]
+  ; CHECK: add 42, r0, r1
+  ; CHECK: ptr.pack stack-[1], r1, stack[@ptr]
   %ptrptr = alloca i8 addrspace(3)*
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** %ptrptr
   %res1 = call i8 addrspace(3)* @llvm.syncvm.ptr.pack(i8 addrspace(3)* %ptr, i256 42)
@@ -322,8 +315,8 @@ define void @ptrpacksig(i8 addrspace(3)* %rs1) nounwind {
 
 ; CHECK-LABEL: ptrpackssg
 define void @ptrpackssg(i8 addrspace(3)* %rs1) nounwind {
-; CHECK: ptr.add stack-[1], r0, r1
-; CHECK: ptr.pack.s stack-[2], r1, stack[@ptr]
+  ; CHECK: add stack-[2], r0, r1
+  ; CHECK: ptr.pack stack-[1], r1, stack[@ptr]
   %valptr = alloca i256
   %ptrptr = alloca i8 addrspace(3)*
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** %ptrptr
@@ -335,8 +328,8 @@ define void @ptrpackssg(i8 addrspace(3)* %rs1) nounwind {
 
 ; CHECK-LABEL: ptrpackscg
 define void @ptrpackscg(i8 addrspace(3)* %rs1) nounwind {
-; CHECK: ptr.add stack-[1], r0, r1
-; CHECK: ptr.pack.s @val[0], r1, stack[@ptr]
+  ; CHECK: add @val[0], r0, r1
+  ; CHECK: ptr.pack stack-[1], r1, stack[@ptr]
   %ptrptr = alloca i8 addrspace(3)*
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** %ptrptr
   %val = load i256, i256 addrspace(4)* @val

--- a/llvm/test/CodeGen/SyncVM/ptrshrink.ll
+++ b/llvm/test/CodeGen/SyncVM/ptrshrink.ll
@@ -159,9 +159,7 @@ define void @ptrshrinkrcs(i8 addrspace(3)* %rs1) nounwind {
 ; CHECK-LABEL: ptrshrinkgrs
 define void @ptrshrinkgrs(i256 %rs2) nounwind {
   %result = alloca i8 addrspace(3)*
-; TODO: should be ptr.shrink stack[@ptr], r1, stack-[1]
-; CHECK: ptr.add stack[@ptr], r0, r2
-; CHECK: ptr.shrink      r2, r1, stack-[1]
+; CHECK: ptr.shrink stack[@ptr], r1, stack-[1]
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** @ptr
   %res1 = call i8 addrspace(3)* @llvm.syncvm.ptr.shrink(i8 addrspace(3)* %ptr, i256 %rs2)
   store i8 addrspace(3)* %res1, i8 addrspace(3)** %result
@@ -171,9 +169,10 @@ define void @ptrshrinkgrs(i256 %rs2) nounwind {
 ; CHECK-LABEL: ptrshrinkgis
 define void @ptrshrinkgis(i8 addrspace(3)* %rs1) nounwind {
   %result = alloca i8 addrspace(3)*
-; CHECK: ptr.shrink.s 42, r1, stack-[1]
+  ; CHECK: add 42, r0, r1
+  ; CHECK: ptr.shrink stack[@ptr], r1, stack-[1]
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** @ptr
-  %res1 = call i8 addrspace(3)* @llvm.syncvm.ptr.shrink(i8 addrspace(3)* %rs1, i256 42)
+  %res1 = call i8 addrspace(3)* @llvm.syncvm.ptr.shrink(i8 addrspace(3)* %ptr, i256 42)
   store i8 addrspace(3)* %res1, i8 addrspace(3)** %result
   ret void
 }
@@ -181,8 +180,8 @@ define void @ptrshrinkgis(i8 addrspace(3)* %rs1) nounwind {
 ; CHECK-LABEL: ptrshrinkgss
 define void @ptrshrinkgss(i8 addrspace(3)* %rs1) nounwind {
   %result = alloca i8 addrspace(3)*
-; CHECK: ptr.add stack[@ptr], r0, r1
-; CHECK: ptr.shrink.s stack-[1], r1, stack-[2]
+; CHECK: add stack-[1], r0, r1
+; CHECK: ptr.shrink stack[@ptr], r1, stack-[2]
   %valptr = alloca i256
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** @ptr
   %val = load i256, i256* %valptr
@@ -194,8 +193,8 @@ define void @ptrshrinkgss(i8 addrspace(3)* %rs1) nounwind {
 ; CHECK-LABEL: ptrshrinkgcs
 define void @ptrshrinkgcs(i8 addrspace(3)* %rs1) nounwind {
   %result = alloca i8 addrspace(3)*
-; CHECK: ptr.add stack[@ptr], r0, r1
-; CHECK: ptr.shrink.s @val[0], r1, stack-[1]
+  ; CHECK: add @val[0], r0, r1
+  ; CHECK: ptr.shrink stack[@ptr], r1, stack-[1]
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** @ptr
   %val = load i256, i256 addrspace(4)* @val
   %res1 = call i8 addrspace(3)* @llvm.syncvm.ptr.shrink(i8 addrspace(3)* %ptr, i256 %val)
@@ -206,9 +205,7 @@ define void @ptrshrinkgcs(i8 addrspace(3)* %rs1) nounwind {
 ; CHECK-LABEL: ptrshrinksrs
 define void @ptrshrinksrs(i256 %rs2) nounwind {
   %result = alloca i8 addrspace(3)*
-; TODO: should be ptr.shrink stack-[1], r0, stack-[2]
-; CHECK: ptr.add stack-[1], r0, r2
-; CHECK: ptr.shrink r2, r1, stack-[2]
+; CHECK: ptr.shrink stack-[1], r1, stack-[2]
   %ptrptr = alloca i8 addrspace(3)*
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** %ptrptr
   %res1 = call i8 addrspace(3)* @llvm.syncvm.ptr.shrink(i8 addrspace(3)* %ptr, i256 %rs2)
@@ -219,8 +216,8 @@ define void @ptrshrinksrs(i256 %rs2) nounwind {
 ; CHECK-LABEL: ptrshrinksis
 define void @ptrshrinksis(i8 addrspace(3)* %rs1) nounwind {
   %result = alloca i8 addrspace(3)*
-; CHECK: ptr.add stack-[1], r0, r1
-; CHECK: ptr.shrink.s 42, r1, stack-[2]
+  ; CHECK: add 42, r0, r1
+  ; CHECK: ptr.shrink stack-[1], r1, stack-[2]
   %ptrptr = alloca i8 addrspace(3)*
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** %ptrptr
   %res1 = call i8 addrspace(3)* @llvm.syncvm.ptr.shrink(i8 addrspace(3)* %ptr, i256 42)
@@ -231,8 +228,8 @@ define void @ptrshrinksis(i8 addrspace(3)* %rs1) nounwind {
 ; CHECK-LABEL: ptrshrinksss
 define void @ptrshrinksss(i8 addrspace(3)* %rs1) nounwind {
   %result = alloca i8 addrspace(3)*
-; CHECK: ptr.add stack-[1], r0, r1
-; CHECK: ptr.shrink.s stack-[2], r1, stack-[3]
+  ; CHECK: add stack-[2], r0, r1
+  ; CHECK: ptr.shrink stack-[1], r1, stack-[3]
   %valptr = alloca i256
   %ptrptr = alloca i8 addrspace(3)*
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** %ptrptr
@@ -245,8 +242,8 @@ define void @ptrshrinksss(i8 addrspace(3)* %rs1) nounwind {
 ; CHECK-LABEL: ptrshrinkscs
 define void @ptrshrinkscs(i8 addrspace(3)* %rs1) nounwind {
   %result = alloca i8 addrspace(3)*
-; CHECK: ptr.add stack-[1], r0, r1
-; CHECK: ptr.shrink.s @val[0], r1, stack-[2]
+  ; CHECK: add @val[0], r0, r1
+  ; CHECK: ptr.shrink stack-[1], r1, stack-[2]
   %ptrptr = alloca i8 addrspace(3)*
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** %ptrptr
   %val = load i256, i256 addrspace(4)* @val
@@ -257,9 +254,7 @@ define void @ptrshrinkscs(i8 addrspace(3)* %rs1) nounwind {
 
 ; CHECK-LABEL: ptrshrinkgrg
 define void @ptrshrinkgrg(i256 %rs2) nounwind {
-; TODO: should be ptr.shrink stack[@ptr], r1, stack[@ptr]
-; CHECK: ptr.add stack[@ptr], r0, r2
-; CHECK: ptr.shrink      r2, r1, stack[@ptr]
+; CHECK: ptr.shrink stack[@ptr], r1, stack[@ptr]
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** @ptr
   %res1 = call i8 addrspace(3)* @llvm.syncvm.ptr.shrink(i8 addrspace(3)* %ptr, i256 %rs2)
   store i8 addrspace(3)* %res1, i8 addrspace(3)** @ptr
@@ -268,8 +263,8 @@ define void @ptrshrinkgrg(i256 %rs2) nounwind {
 
 ; CHECK-LABEL: ptrshrinkgig
 define void @ptrshrinkgig(i8 addrspace(3)* %rs1) nounwind {
-; CHECK: ptr.add stack[@ptr], r0, r1
-; CHECK: ptr.shrink.s 42, r1, stack[@ptr]
+  ; CHECK: add 42, r0, r1
+  ; CHECK: ptr.shrink stack[@ptr], r1, stack[@ptr]
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** @ptr
   %res1 = call i8 addrspace(3)* @llvm.syncvm.ptr.shrink(i8 addrspace(3)* %ptr, i256 42)
   store i8 addrspace(3)* %res1, i8 addrspace(3)** @ptr
@@ -278,8 +273,8 @@ define void @ptrshrinkgig(i8 addrspace(3)* %rs1) nounwind {
 
 ; CHECK-LABEL: ptrshrinkgsg
 define void @ptrshrinkgsg(i8 addrspace(3)* %rs1) nounwind {
-; CHECK: ptr.add stack[@ptr], r0, r1
-; CHECK: ptr.shrink.s stack-[1], r1, stack[@ptr]
+  ; CHECK: add stack-[1], r0, r1
+  ; CHECK: ptr.shrink stack[@ptr], r1, stack[@ptr]
   %valptr = alloca i256
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** @ptr
   %val = load i256, i256* %valptr
@@ -290,8 +285,8 @@ define void @ptrshrinkgsg(i8 addrspace(3)* %rs1) nounwind {
 
 ; CHECK-LABEL: ptrshrinkgcg
 define void @ptrshrinkgcg(i8 addrspace(3)* %rs1) nounwind {
-; CHECK: ptr.add stack[@ptr], r0, r1
-; CHECK: ptr.shrink.s @val[0], r1, stack[@ptr]
+; CHECK: add @val[0], r0, r1
+; CHECK: ptr.shrink stack[@ptr], r1, stack[@ptr]
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** @ptr
   %val = load i256, i256 addrspace(4)* @val
   %res1 = call i8 addrspace(3)* @llvm.syncvm.ptr.shrink(i8 addrspace(3)* %ptr, i256 %val)
@@ -301,9 +296,7 @@ define void @ptrshrinkgcg(i8 addrspace(3)* %rs1) nounwind {
 
 ; CHECK-LABEL: ptrshrinksrg
 define void @ptrshrinksrg(i256 %rs2) nounwind {
-; TODO: should be ptr.shrink stack-[1], r0, stack[@ptr]
-; CHECK: ptr.add stack-[1], r0, r2
-; CHECK: ptr.shrink      r2, r1, stack[@ptr]
+; CHECK: ptr.shrink stack-[1], r1, stack[@ptr]
   %ptrptr = alloca i8 addrspace(3)*
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** %ptrptr
   %res1 = call i8 addrspace(3)* @llvm.syncvm.ptr.shrink(i8 addrspace(3)* %ptr, i256 %rs2)
@@ -313,8 +306,8 @@ define void @ptrshrinksrg(i256 %rs2) nounwind {
 
 ; CHECK-LABEL: ptrshrinksig
 define void @ptrshrinksig(i8 addrspace(3)* %rs1) nounwind {
-; CHECK: ptr.add stack-[1], r0, r1
-; CHECK: ptr.shrink.s 42, r1, stack[@ptr]
+  ; CHECK: add 42, r0, r1
+  ; CHECK: ptr.shrink stack-[1], r1, stack[@ptr]
   %ptrptr = alloca i8 addrspace(3)*
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** %ptrptr
   %res1 = call i8 addrspace(3)* @llvm.syncvm.ptr.shrink(i8 addrspace(3)* %ptr, i256 42)
@@ -324,8 +317,8 @@ define void @ptrshrinksig(i8 addrspace(3)* %rs1) nounwind {
 
 ; CHECK-LABEL: ptrshrinkssg
 define void @ptrshrinkssg(i8 addrspace(3)* %rs1) nounwind {
-; CHECK: ptr.add stack-[1], r0, r1
-; CHECK: ptr.shrink.s stack-[2], r1, stack[@ptr]
+  ; CHECK: add stack-[2], r0, r1
+  ; CHECK: ptr.shrink stack-[1], r1, stack[@ptr]
   %valptr = alloca i256
   %ptrptr = alloca i8 addrspace(3)*
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** %ptrptr
@@ -337,8 +330,8 @@ define void @ptrshrinkssg(i8 addrspace(3)* %rs1) nounwind {
 
 ; CHECK-LABEL: ptrshrinkscg
 define void @ptrshrinkscg(i8 addrspace(3)* %rs1) nounwind {
-; CHECK: ptr.add stack-[1], r0, r1
-; CHECK: ptr.shrink.s @val[0], r1, stack[@ptr]
+  ; CHECK: add @val[0], r0, r1
+  ; CHECK: ptr.shrink stack-[1], r1, stack[@ptr]
   %ptrptr = alloca i8 addrspace(3)*
   %ptr = load i8 addrspace(3)*, i8 addrspace(3)** %ptrptr
   %val = load i256, i256 addrspace(4)* @val

--- a/llvm/unittests/Target/SyncVM/InstrMappingTest.cpp
+++ b/llvm/unittests/Target/SyncVM/InstrMappingTest.cpp
@@ -54,9 +54,86 @@
   EXPECT_MAP_EQ_OPCODE_BASE(Opcode##yrr_, S1, S2);                             \
   EXPECT_MAP_EQ_OPCODE_BASE(Opcode##zrr_, S1, S2);                             \
   EXPECT_MAP_EQ_OPCODE_BASE(Opcode##rrs_, S1, S2);                             \
+  EXPECT_MAP_EQ_OPCODE_BASE(Opcode##srs_, S1, S2);                             \
   EXPECT_MAP_EQ_OPCODE_BASE(Opcode##xrs_, S1, S2);                             \
   EXPECT_MAP_EQ_OPCODE_BASE(Opcode##yrs_, S1, S2);                             \
   EXPECT_MAP_EQ_OPCODE_BASE(Opcode##zrs_, S1, S2)
+
+#define EXPECT_MAP_OPERAND_IN_AM_PTR(Mnemonic, S1, S2)                         \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##S1##rr_s, Mnemonic##S2##rr_s);           \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##S1##rr_v, Mnemonic##S2##rr_v);
+
+#define EXPECT_MAP_OPERAND_IN_AM(Mnemonic, S1, S2)                             \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##S1##rr_s, Mnemonic##S2##rr_s);           \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##S1##rr_v, Mnemonic##S2##rr_v);           \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##S1##rs_s, Mnemonic##S2##rs_s);           \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##S1##rs_v, Mnemonic##S2##rs_v);
+
+#define EXPECT_MAP_OPERAND_IN_AM2(Mnemonic, S1, S2)                            \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##S1##rrr_s, Mnemonic##S2##rrr_s);         \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##S1##rrr_v, Mnemonic##S2##rrr_v);         \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##S1##rsr_s, Mnemonic##S2##rsr_s);         \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##S1##rsr_v, Mnemonic##S2##rsr_v);
+
+#define EXPECT_MAP_OPERAND_OUT_AM_BASE(Mnemonic, S1, S2)                       \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##rr##S1##_s, Mnemonic##rr##S2##_s);       \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##rr##S1##_v, Mnemonic##rr##S2##_v);       \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##ir##S1##_s, Mnemonic##ir##S2##_s);       \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##ir##S1##_v, Mnemonic##ir##S2##_v);       \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##cr##S1##_s, Mnemonic##cr##S2##_s);       \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##cr##S1##_v, Mnemonic##cr##S2##_v);       \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##sr##S1##_s, Mnemonic##sr##S2##_s);       \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##sr##S1##_v, Mnemonic##sr##S2##_v);
+
+#define EXPECT_MAP_OPERAND_OUT_AM_NONCOMMUTABLE(Mnemonic, S1, S2)              \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##xr##S1##_s, Mnemonic##xr##S2##_s);       \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##xr##S1##_v, Mnemonic##xr##S2##_v);       \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##yr##S1##_s, Mnemonic##yr##S2##_s);       \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##yr##S1##_v, Mnemonic##yr##S2##_v);       \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##zr##S1##_s, Mnemonic##zr##S2##_s);       \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##zr##S1##_v, Mnemonic##zr##S2##_v);
+
+#define EXPECT_MAP_OPERAND_OUT_AM_PTR(Mnemonic, S1, S2)                        \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##rr##S1##_s, Mnemonic##rr##S2##_s);       \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##rr##S1##_v, Mnemonic##rr##S2##_v);       \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##sr##S1##_s, Mnemonic##sr##S2##_s);       \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##sr##S1##_v, Mnemonic##sr##S2##_v);       \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##xr##S1##_s, Mnemonic##xr##S2##_s);       \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##xr##S1##_v, Mnemonic##xr##S2##_v);       \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##yr##S1##_s, Mnemonic##yr##S2##_s);       \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##yr##S1##_v, Mnemonic##yr##S2##_v);       \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##zr##S1##_s, Mnemonic##zr##S2##_s);       \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##zr##S1##_v, Mnemonic##zr##S2##_v);
+
+#define EXPECT_MAP_OPERAND_OUT_AM_BASE2(Mnemonic, S1, S2)                      \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##rr##S1##r_s, Mnemonic##rr##S2##r_s);     \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##rr##S1##r_v, Mnemonic##rr##S2##r_v);     \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##ir##S1##r_s, Mnemonic##ir##S2##r_s);     \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##ir##S1##r_v, Mnemonic##ir##S2##r_v);     \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##cr##S1##r_s, Mnemonic##cr##S2##r_s);     \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##cr##S1##r_v, Mnemonic##cr##S2##r_v);     \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##sr##S1##r_s, Mnemonic##sr##S2##r_s);     \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##sr##S1##r_v, Mnemonic##sr##S2##r_v);
+
+#define EXPECT_MAP_OPERAND_OUT_AM_NONCOMMUTABLE2(Mnemonic, S1, S2)             \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##xr##S1##r_s, Mnemonic##xr##S2##r_s);     \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##xr##S1##r_v, Mnemonic##xr##S2##r_v);     \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##yr##S1##r_s, Mnemonic##yr##S2##r_s);     \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##yr##S1##r_v, Mnemonic##yr##S2##r_v);     \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##zr##S1##r_s, Mnemonic##zr##S2##r_s);     \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##zr##S1##r_v, Mnemonic##zr##S2##r_v);
+
+#define EXPECT_MAP_OPERAND_SWAP(Mnemonic, S1, S2)                              \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##S1##rr_s, Mnemonic##S2##rr_s);           \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##S1##rr_v, Mnemonic##S2##rr_v);           \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##S1##rs_s, Mnemonic##S2##rs_s);           \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##S1##rs_v, Mnemonic##S2##rs_v);
+
+#define EXPECT_MAP_OPERAND_SWAP2(Mnemonic, S1, S2)                             \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##S1##rrr_s, Mnemonic##S2##rrr_s);         \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##S1##rrr_v, Mnemonic##S2##rrr_v);         \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##S1##rsr_s, Mnemonic##S2##rsr_s);         \
+  EXPECT_MAP_EQ_OPCODE_BASE(Mnemonic##S1##rsr_v, Mnemonic##S2##rsr_v);
 
 #define TEST_INSTR_MAPS(S1, S2)                                                \
   EXPECT_MAP_COMMUTABLE(SyncVM::ADD, S1, S2);                                  \
@@ -73,6 +150,116 @@
   EXPECT_MAP_PTR(SyncVM::PTR_SHRINK, S1, S2);                                  \
   EXPECT_MAP_ARITH2(SyncVM::MUL, S1, S2);                                      \
   EXPECT_MAP_ARITH2_EXTEND(SyncVM::DIV, S1, S2)
+
+#define TEST_IN_AM_MAPS_NONPTR(S2)                                             \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::ADD, r, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::ADD, i, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::ADD, c, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::ADD, s, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::AND, r, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::AND, i, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::AND, c, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::AND, s, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::OR, r, S2);                                 \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::OR, i, S2);                                 \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::OR, c, S2);                                 \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::OR, s, S2);                                 \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::XOR, r, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::XOR, i, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::XOR, c, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::XOR, s, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM2(SyncVM::MUL, r, S2);                               \
+  EXPECT_MAP_OPERAND_IN_AM2(SyncVM::MUL, i, S2);                               \
+  EXPECT_MAP_OPERAND_IN_AM2(SyncVM::MUL, c, S2);                               \
+  EXPECT_MAP_OPERAND_IN_AM2(SyncVM::MUL, s, S2);                               \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::SUB, r, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::SUB, i, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::SUB, x, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::SUB, c, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::SUB, y, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::SUB, s, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::SUB, z, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::SHL, r, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::SHL, i, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::SHL, x, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::SHL, c, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::SHL, y, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::SHL, s, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::SHL, z, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::SHR, r, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::SHR, i, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::SHR, x, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::SHR, c, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::SHR, y, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::SHR, s, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::SHR, z, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::ROL, r, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::ROL, i, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::ROL, x, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::ROL, c, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::ROL, y, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::ROL, s, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::ROL, z, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::ROR, r, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::ROR, i, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::ROR, x, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::ROR, c, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::ROR, y, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::ROR, s, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM(SyncVM::ROR, z, S2);                                \
+  EXPECT_MAP_OPERAND_IN_AM2(SyncVM::DIV, r, S2)                                \
+  EXPECT_MAP_OPERAND_IN_AM2(SyncVM::DIV, i, S2)                                \
+  EXPECT_MAP_OPERAND_IN_AM2(SyncVM::DIV, x, S2)                                \
+  EXPECT_MAP_OPERAND_IN_AM2(SyncVM::DIV, c, S2)                                \
+  EXPECT_MAP_OPERAND_IN_AM2(SyncVM::DIV, y, S2)                                \
+  EXPECT_MAP_OPERAND_IN_AM2(SyncVM::DIV, s, S2)                                \
+  EXPECT_MAP_OPERAND_IN_AM2(SyncVM::DIV, z, S2)
+
+#define TEST_IN_AM_MAPS_PTR(S2)                                                \
+  EXPECT_MAP_OPERAND_IN_AM_PTR(SyncVM::PTR_ADD, r, S2);                        \
+  EXPECT_MAP_OPERAND_IN_AM_PTR(SyncVM::PTR_ADD, x, S2);                        \
+  EXPECT_MAP_OPERAND_IN_AM_PTR(SyncVM::PTR_ADD, y, S2);                        \
+  EXPECT_MAP_OPERAND_IN_AM_PTR(SyncVM::PTR_ADD, s, S2);                        \
+  EXPECT_MAP_OPERAND_IN_AM_PTR(SyncVM::PTR_ADD, z, S2);                        \
+  EXPECT_MAP_OPERAND_IN_AM_PTR(SyncVM::PTR_PACK, r, S2);                       \
+  EXPECT_MAP_OPERAND_IN_AM_PTR(SyncVM::PTR_PACK, x, S2);                       \
+  EXPECT_MAP_OPERAND_IN_AM_PTR(SyncVM::PTR_PACK, y, S2);                       \
+  EXPECT_MAP_OPERAND_IN_AM_PTR(SyncVM::PTR_PACK, s, S2);                       \
+  EXPECT_MAP_OPERAND_IN_AM_PTR(SyncVM::PTR_PACK, z, S2);                       \
+  EXPECT_MAP_OPERAND_IN_AM_PTR(SyncVM::PTR_SHRINK, r, S2);                     \
+  EXPECT_MAP_OPERAND_IN_AM_PTR(SyncVM::PTR_SHRINK, x, S2);                     \
+  EXPECT_MAP_OPERAND_IN_AM_PTR(SyncVM::PTR_SHRINK, y, S2);                     \
+  EXPECT_MAP_OPERAND_IN_AM_PTR(SyncVM::PTR_SHRINK, s, S2);                     \
+  EXPECT_MAP_OPERAND_IN_AM_PTR(SyncVM::PTR_SHRINK, z, S2);
+
+#define TEST_OUT_AM_MAPS(S1, S2)                                               \
+  EXPECT_MAP_OPERAND_OUT_AM_BASE(SyncVM::ADD, S1, S2);                         \
+  EXPECT_MAP_OPERAND_OUT_AM_BASE(SyncVM::AND, S1, S2);                         \
+  EXPECT_MAP_OPERAND_OUT_AM_BASE(SyncVM::OR, S1, S2);                          \
+  EXPECT_MAP_OPERAND_OUT_AM_BASE(SyncVM::XOR, S1, S2);                         \
+  EXPECT_MAP_OPERAND_OUT_AM_NONCOMMUTABLE(SyncVM::SUB, S1, S2);                \
+  EXPECT_MAP_OPERAND_OUT_AM_NONCOMMUTABLE(SyncVM::SHL, S1, S2);                \
+  EXPECT_MAP_OPERAND_OUT_AM_NONCOMMUTABLE(SyncVM::SHR, S1, S2);                \
+  EXPECT_MAP_OPERAND_OUT_AM_NONCOMMUTABLE(SyncVM::ROL, S1, S2);                \
+  EXPECT_MAP_OPERAND_OUT_AM_NONCOMMUTABLE(SyncVM::ROR, S1, S2);                \
+  EXPECT_MAP_OPERAND_OUT_AM_PTR(SyncVM::PTR_ADD, S1, S2);                      \
+  EXPECT_MAP_OPERAND_OUT_AM_PTR(SyncVM::PTR_PACK, S1, S2);                     \
+  EXPECT_MAP_OPERAND_OUT_AM_PTR(SyncVM::PTR_SHRINK, S1, S2);                   \
+  EXPECT_MAP_OPERAND_OUT_AM_BASE2(SyncVM::MUL, S1, S2);                        \
+  EXPECT_MAP_OPERAND_OUT_AM_NONCOMMUTABLE2(SyncVM::DIV, S1, S2)
+
+#define TEST_MAPS_SWAP_NONPTR(S1, S2)                                          \
+  EXPECT_MAP_OPERAND_SWAP(SyncVM::SUB, S1, S2);                                \
+  EXPECT_MAP_OPERAND_SWAP(SyncVM::SHL, S1, S2);                                \
+  EXPECT_MAP_OPERAND_SWAP(SyncVM::SHR, S1, S2);                                \
+  EXPECT_MAP_OPERAND_SWAP(SyncVM::ROL, S1, S2);                                \
+  EXPECT_MAP_OPERAND_SWAP(SyncVM::ROR, S1, S2);                                \
+  EXPECT_MAP_OPERAND_SWAP2(SyncVM::DIV, S1, S2);
+
+#define TEST_MAPS_SWAP_PTR(S1, S2)                                             \
+  EXPECT_MAP_OPERAND_SWAP(SyncVM::PTR_ADD, S1, S2);                            \
+  EXPECT_MAP_OPERAND_SWAP(SyncVM::PTR_PACK, S1, S2);                           \
+  EXPECT_MAP_OPERAND_SWAP(SyncVM::PTR_SHRINK, S1, S2);
 
 TEST(GetFlagSettingOpcode, TheTest) {
 #undef EXPECT_MAP_EQ_OPCODE_BASE
@@ -96,4 +283,107 @@ TEST(GetPseudoMapOpcode, TheTest) {
   EXPECT_EQ(SyncVM::getPseudoMapOpcode(Opcode##Subfix1), Opcode##Subfix2)
 
   TEST_INSTR_MAPS(p, s);
+}
+
+TEST(GetOperandAM_RR, TheTest) {
+#undef EXPECT_MAP_EQ_OPCODE_BASE
+#define EXPECT_MAP_EQ_OPCODE_BASE(Opcode1, Opcode2)                            \
+  EXPECT_EQ(SyncVM::getWithRRInAddrMode(Opcode1), Opcode2)
+
+  TEST_IN_AM_MAPS_NONPTR(r);
+  TEST_IN_AM_MAPS_PTR(r);
+}
+
+TEST(GetOperandAM_IR, TheTest) {
+#undef EXPECT_MAP_EQ_OPCODE_BASE
+#define EXPECT_MAP_EQ_OPCODE_BASE(Opcode1, Opcode2)                            \
+  EXPECT_EQ(SyncVM::getWithIRInAddrMode(Opcode1), Opcode2)
+
+  TEST_IN_AM_MAPS_NONPTR(i);
+  TEST_IN_AM_MAPS_PTR(x);
+}
+
+TEST(GetOperandAM_CR, TheTest) {
+#undef EXPECT_MAP_EQ_OPCODE_BASE
+#define EXPECT_MAP_EQ_OPCODE_BASE(Opcode1, Opcode2)                            \
+  EXPECT_EQ(SyncVM::getWithCRInAddrMode(Opcode1), Opcode2)
+
+  TEST_IN_AM_MAPS_NONPTR(c);
+  TEST_IN_AM_MAPS_PTR(y);
+}
+
+TEST(GetOperandAM_SR, TheTest) {
+#undef EXPECT_MAP_EQ_OPCODE_BASE
+#define EXPECT_MAP_EQ_OPCODE_BASE(Opcode1, Opcode2)                            \
+  EXPECT_EQ(SyncVM::getWithSRInAddrMode(Opcode1), Opcode2)
+
+  TEST_IN_AM_MAPS_NONPTR(s);
+  TEST_IN_AM_MAPS_PTR(s);
+}
+
+TEST(GetResultAM_RR, TheTest) {
+#undef EXPECT_MAP_EQ_OPCODE_BASE
+#define EXPECT_MAP_EQ_OPCODE_BASE(Opcode1, Opcode2)                            \
+  EXPECT_EQ(SyncVM::getWithRROutAddrMode(Opcode1), Opcode2)
+
+  TEST_OUT_AM_MAPS(r, r);
+  TEST_OUT_AM_MAPS(s, r);
+}
+
+TEST(SwapToX, TheTest) {
+#undef EXPECT_MAP_EQ_OPCODE_BASE
+#define EXPECT_MAP_EQ_OPCODE_BASE(Opcode1, Opcode2)                            \
+  EXPECT_EQ(SyncVM::getWithInsSwapped(Opcode1), Opcode2)
+
+  TEST_MAPS_SWAP_NONPTR(i, x);
+  TEST_MAPS_SWAP_NONPTR(x, x);
+}
+
+TEST(SwapToI, TheTest) {
+#undef EXPECT_MAP_EQ_OPCODE_BASE
+#define EXPECT_MAP_EQ_OPCODE_BASE(Opcode1, Opcode2)                            \
+  EXPECT_EQ(SyncVM::getWithInsNotSwapped(Opcode1), Opcode2)
+
+  TEST_MAPS_SWAP_NONPTR(i, i);
+  TEST_MAPS_SWAP_NONPTR(x, i);
+}
+
+TEST(SwapToY, TheTest) {
+#undef EXPECT_MAP_EQ_OPCODE_BASE
+#define EXPECT_MAP_EQ_OPCODE_BASE(Opcode1, Opcode2)                            \
+  EXPECT_EQ(SyncVM::getWithInsSwapped(Opcode1), Opcode2)
+
+  TEST_MAPS_SWAP_NONPTR(c, y);
+  TEST_MAPS_SWAP_NONPTR(y, y);
+}
+
+TEST(SwapToC, TheTest) {
+#undef EXPECT_MAP_EQ_OPCODE_BASE
+#define EXPECT_MAP_EQ_OPCODE_BASE(Opcode1, Opcode2)                            \
+  EXPECT_EQ(SyncVM::getWithInsNotSwapped(Opcode1), Opcode2)
+
+  TEST_MAPS_SWAP_NONPTR(c, c);
+  TEST_MAPS_SWAP_NONPTR(y, c);
+}
+
+TEST(SwapToZ, TheTest) {
+#undef EXPECT_MAP_EQ_OPCODE_BASE
+#define EXPECT_MAP_EQ_OPCODE_BASE(Opcode1, Opcode2)                            \
+  EXPECT_EQ(SyncVM::getWithInsSwapped(Opcode1), Opcode2)
+
+  TEST_MAPS_SWAP_NONPTR(s, z);
+  TEST_MAPS_SWAP_NONPTR(z, z);
+  TEST_MAPS_SWAP_PTR(s, z);
+  TEST_MAPS_SWAP_PTR(z, z);
+}
+
+TEST(SwapToS, TheTest) {
+#undef EXPECT_MAP_EQ_OPCODE_BASE
+#define EXPECT_MAP_EQ_OPCODE_BASE(Opcode1, Opcode2)                            \
+  EXPECT_EQ(SyncVM::getWithInsNotSwapped(Opcode1), Opcode2)
+
+  TEST_MAPS_SWAP_NONPTR(s, s);
+  TEST_MAPS_SWAP_NONPTR(z, s);
+  TEST_MAPS_SWAP_PTR(s, s);
+  TEST_MAPS_SWAP_PTR(z, s);
 }


### PR DESCRIPTION
The patch implements mapping to access instruction families with different input and output addressing modes, and swap argument flags. It also add missing fat pointer patterns to make mappings complete.