### PR TITLE
 [EVM] Adding support of globals lowering, support of non-256 bit loads/stores and frame index lowering

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -4300,8 +4300,9 @@ SDValue TargetLowering::SimplifySetCC(EVT VT, SDValue N0, SDValue N1,
     }
 
     // SyncVM local begin
-    // Load narrowing is not profiable for SyncVM
-    if (!DAG.getTarget().getTargetTriple().isSyncVM()) {
+    // Load narrowing is not profiable for SyncVM/EVM
+    if (!DAG.getTarget().getTargetTriple().isSyncVM() &&
+        !DAG.getTarget().getTargetTriple().isEVM()) {
     // SyncVM local end
     // If the LHS is '(and load, const)', the RHS is 0, the test is for
     // equality or unsigned, and all 1 bits of the const are in the same

--- a/llvm/lib/Target/EVM/EVMISelLowering.cpp
+++ b/llvm/lib/Target/EVM/EVMISelLowering.cpp
@@ -36,7 +36,8 @@ EVMTargetLowering::EVMTargetLowering(const TargetMachine &TM,
   // Legal operations
   setOperationAction({ISD::ADD, ISD::SUB, ISD::MUL, ISD::AND, ISD::OR, ISD::XOR,
                       ISD::SHL, ISD::SRL, ISD::SRA, ISD::SDIV, ISD::UDIV,
-                      ISD::UREM, ISD::SREM, ISD::SETCC, ISD::SELECT},
+                      ISD::UREM, ISD::SREM, ISD::SETCC, ISD::SELECT,
+                      ISD::FrameIndex},
                      MVT::i256, Legal);
 
   for (auto CC : {ISD::SETULT, ISD::SETUGT, ISD::SETLT, ISD::SETGT, ISD::SETGE,

--- a/llvm/lib/Target/EVM/EVMISelLowering.h
+++ b/llvm/lib/Target/EVM/EVMISelLowering.h
@@ -38,7 +38,49 @@ public:
     return MVT::i256;
   }
 
+  /// Return true if it is profitable to move this shift by a constant amount
+  /// through its operand, adjusting any immediate operands as necessary to
+  /// preserve semantics. This transformation may not be desirable if it
+  /// disrupts a particularly auspicious target-specific tree (e.g. bitfield
+  /// extraction in AArch64). By default, it returns true.
+  /// For EVM this may result in the creation of a big immediate,
+  /// which is not profitable.
+  virtual bool
+  isDesirableToCommuteWithShift(const SDNode *N,
+                                CombineLevel Level) const override {
+    return false;
+  }
+
+  /// Return true if creating a shift of the type by the given
+  /// amount is not profitable.
+  bool shouldAvoidTransformToShift(EVT VT, unsigned Amount) const override {
+    return true;
+  }
+
+  /// Return true if it is profitable to fold a pair of shifts into a mask.
+  /// This is usually true on most targets. But some targets, like Thumb1,
+  /// have immediate shift instructions, but no immediate "and" instruction;
+  /// this makes the fold unprofitable.
+  /// For EVM this may result in the creation of a big immediate,
+  /// which is not profitable.
+  virtual bool
+  shouldFoldConstantShiftPairToMask(const SDNode *N,
+                                    CombineLevel Level) const override {
+    return false;
+  }
+
 private:
+  void ReplaceNodeResults(SDNode *N, SmallVectorImpl<SDValue> &Results,
+                          SelectionDAG &DAG) const override;
+
+  SDValue LowerOperation(SDValue Op, SelectionDAG &DAG) const override;
+
+  SDValue LowerGlobalAddress(SDValue Op, SelectionDAG &DAG) const;
+
+  SDValue LowerLOAD(SDValue Op, SelectionDAG &DAG) const;
+
+  SDValue LowerSTORE(SDValue Op, SelectionDAG &DAG) const;
+
   SDValue LowerFormalArguments(SDValue Chain, CallingConv::ID CallConv,
                                bool isVarArg,
                                const SmallVectorImpl<ISD::InputArg> &Ins,

--- a/llvm/lib/Target/EVM/EVMInstrInfo.td
+++ b/llvm/lib/Target/EVM/EVMInstrInfo.td
@@ -360,6 +360,34 @@ defm MSIZE : I<(outs GPR:$dst), (ins), [(set GPR:$dst, (int_evm_msize))],
 // for this.
 def : Pat<(truncstorei8 GPR:$val, GPR:$off), (MSTORE8 GPR:$off, GPR:$val)>;
 
+// Instructions for the stack manipulation. These are not real EVM instructions.
+// They are used to model 'alloca' before stackification and should be
+// eliminated at that stage.
+
+def to_tframeindex : SDNodeXForm<frameindex, [{
+  return CurDAG->getTargetFrameIndex(N->getIndex(), MVT::i256);
+}]>;
+
+def TargetFI: OutPatFrag<(ops node:$fi), (i256 (to_tframeindex $fi))>;
+
+def add_like: PatFrags<(ops node:$lhs, node:$rhs),
+                       [(add $lhs, $rhs), (or $lhs, $rhs)], [{
+  return N->getOpcode() == ISD::ADD || isOrEquivalentToAdd(N);
+}]>;
+
+let mayLoad = 1 in
+def STACK_LOAD
+  : NI<(outs GPR:$dst), (ins GPR:$fi), [], "STACK_LOAD $dst, $fi">;
+
+let mayStore = 1, hasSideEffects = 1 in
+  def STACK_STORE
+    : NI<(outs), (ins GPR:$fi, GPR:$val), [], "STACK_STORE $fi, $val">;
+
+def : Pat<(i256 frameindex:$fi), (TargetFI $fi)>;
+def : Pat<(load frameindex:$fi), (STACK_LOAD (TargetFI $fi))>;
+def : Pat<(store GPR:$val, frameindex:$fi),
+          (STACK_STORE (TargetFI $fi), GPR:$val)>;
+
 
 //===----------------------------------------------------------------------===//
 // EVM instructions for retrieval values from context.

--- a/llvm/lib/Target/EVM/EVMInstrInfo.td
+++ b/llvm/lib/Target/EVM/EVMInstrInfo.td
@@ -211,11 +211,11 @@ defm SIGNEXTEND
 
 // The first operand of SIGNEXTEND is the type size in bytes of
 // the value being extendent minus one.
-def : Pat<(sext_inreg GPR:$src, i8), (SIGNEXTEND 0, GPR:$src)>;
-def : Pat<(sext_inreg GPR:$src, i16), (SIGNEXTEND 1, GPR:$src)>;
-def : Pat<(sext_inreg GPR:$src, i32), (SIGNEXTEND 3, GPR:$src)>;
-def : Pat<(sext_inreg GPR:$src, i64), (SIGNEXTEND 7, GPR:$src)>;
-def : Pat<(sext_inreg GPR:$src, i128), (SIGNEXTEND 15, GPR:$src)>;
+def : Pat<(sext_inreg GPR:$src, i8), (SIGNEXTEND (CONST_I256 0), GPR:$src)>;
+def : Pat<(sext_inreg GPR:$src, i16), (SIGNEXTEND (CONST_I256 1), GPR:$src)>;
+def : Pat<(sext_inreg GPR:$src, i32), (SIGNEXTEND (CONST_I256 3), GPR:$src)>;
+def : Pat<(sext_inreg GPR:$src, i64), (SIGNEXTEND (CONST_I256 7), GPR:$src)>;
+def : Pat<(sext_inreg GPR:$src, i128), (SIGNEXTEND (CONST_I256 15), GPR:$src)>;
 
 // Reverse some operations with negative immediate operands to reduce bit-size
 // of the immediate encoding.
@@ -355,6 +355,10 @@ let hasSideEffects = 1 in {
 
 defm MSIZE : I<(outs GPR:$dst), (ins), [(set GPR:$dst, (int_evm_msize))],
                 "MSIZE $dst", 0x59, 2>;
+
+// The i8 store is handled a speciall way, as EVM has a dedicated instruction
+// for this.
+def : Pat<(truncstorei8 GPR:$val, GPR:$off), (MSTORE8 GPR:$off, GPR:$val)>;
 
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/EVM/EVMRegisterInfo.cpp
+++ b/llvm/lib/Target/EVM/EVMRegisterInfo.cpp
@@ -7,7 +7,9 @@
 
 #include "EVMFrameLowering.h"
 #include "EVMInstrInfo.h"
+#include "EVMSubtarget.h"
 #include "MCTargetDesc/EVMMCTargetDesc.h"
+#include "llvm/CodeGen/MachineFrameInfo.h"
 using namespace llvm;
 
 #define DEBUG_TYPE "evm-reg-info"
@@ -33,11 +35,41 @@ EVMRegisterInfo::getReservedRegs(const MachineFunction & /*MF*/) const {
 void EVMRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator II,
                                           int SPAdj, unsigned FIOperandNum,
                                           RegScavenger *RS) const {
-  llvm_unreachable("Subrotines are not supported yet");
+  assert(SPAdj == 0);
+  MachineInstr &MI = *II;
+
+  MachineBasicBlock &MBB = *MI.getParent();
+  MachineFunction &MF = *MBB.getParent();
+  MachineRegisterInfo &MRI = MF.getRegInfo();
+  int FrameIndex = MI.getOperand(FIOperandNum).getIndex();
+  const MachineFrameInfo &MFI = MF.getFrameInfo();
+  int64_t FrameOffset = MFI.getObjectOffset(FrameIndex);
+  const auto *TII = MF.getSubtarget<EVMSubtarget>().getInstrInfo();
+
+  assert(FrameOffset >= 0 && "FrameOffset < 0");
+  assert(FrameOffset < static_cast<int64_t>(MFI.getStackSize()) &&
+         "FrameOffset overflows stack size");
+  assert(MFI.getObjectSize(FrameIndex) != 0 &&
+         "We assume that variable-sized objects have already been lowered, "
+         "and don't use FrameIndex operands.");
+
+  Register FrameRegister = getFrameRegister(MF);
+  Register FIRegOperand = FrameRegister;
+  if (FrameOffset > 0) {
+    FIRegOperand = MRI.createVirtualRegister(&EVM::GPRRegClass);
+    Register OffsetReg = MRI.createVirtualRegister(&EVM::GPRRegClass);
+    BuildMI(MBB, MI, II->getDebugLoc(), TII->get(EVM::CONST_I256), OffsetReg)
+        .addImm(FrameOffset);
+    BuildMI(MBB, MI, II->getDebugLoc(), TII->get(EVM::ADD), FIRegOperand)
+        .addReg(FrameRegister)
+        .addReg(OffsetReg);
+  }
+
+  MI.getOperand(FIOperandNum).ChangeToRegister(FIRegOperand, /*isDef=*/false);
 }
 
 Register EVMRegisterInfo::getFrameRegister(const MachineFunction &MF) const {
-  return 0;
+  return EVM::SP;
 }
 
 const TargetRegisterClass *

--- a/llvm/test/CodeGen/EVM/aext.ll
+++ b/llvm/test/CodeGen/EVM/aext.ll
@@ -1,0 +1,11 @@
+; RUN: llc --mtriple=evm < %s | FileCheck %s
+
+define i8 @aexti8(i8 %rs1) nounwind {
+; CHECK-LABEL: @aexti8
+; CHECK: CONST_I256 [[C:\$[0-9]+]], 1
+; CHECK: ARGUMENT [[IN:\$[0-9]+]], 0
+; CHECK: ADD {{.*}}, [[IN]], [[C]]
+
+  %res = add i8 %rs1, 1
+  ret i8 %res
+}

--- a/llvm/test/CodeGen/EVM/frameidx.ll
+++ b/llvm/test/CodeGen/EVM/frameidx.ll
@@ -1,0 +1,32 @@
+; RUN: llc --mtriple=evm < %s | FileCheck %s
+
+define i256 @alloca() nounwind {
+; CHECK-LABEL: alloca:
+; CHECK: STACK_LOAD [[RES:\$[0-9]+]], %SP
+
+  %var = alloca i256, align 1
+  %rv = load i256, ptr %var
+  ret i256 %rv
+}
+
+define i256 @alloca2() nounwind {
+; CHECK-LABEL: alloca2:
+; CHECK: CONST_I256 [[FILL:\$[0-9]+]], 4096
+; CHECK: ADD [[PTR:\$[0-9]+]], %SP, [[FILL]]
+; CHECK: STACK_LOAD [[RES:\$[0-9]+]], [[PTR]]
+
+  %fill = alloca i256, i32 128
+  %var = alloca i256, align 1
+  %rv = load i256, ptr %var
+  ret i256 %rv
+}
+
+define void @alloca3(i256 %val) nounwind {
+; CHECK-LABEL: alloca3:
+; CHECK: ARGUMENT [[VAL:\$[0-9]+]], 0
+; CHECK: STACK_STORE %SP, [[VAL]]
+
+  %fill = alloca i256, align 1
+  store i256 %val, ptr %fill
+  ret void
+}

--- a/llvm/test/CodeGen/EVM/globals.ll
+++ b/llvm/test/CodeGen/EVM/globals.ll
@@ -1,0 +1,86 @@
+; RUN: llc --mtriple=evm < %s | FileCheck %s
+
+%struct.w = type { i32, i256 }
+
+@val = global i256 0
+@val2 = global i256 42
+@val3 = global i256 0
+@val.arr = global [4 x i256] zeroinitializer
+@val2.arr = global [4 x i256] [i256 1, i256 2, i256 3, i256 4]
+@as_ptr = global ptr zeroinitializer
+@w = external dso_local local_unnamed_addr global %struct.w, align 1
+
+define i256 @load.stelem() {
+; CHECK-LABEL: load.stelem
+; CHECK: CONST_I256 [[ADDR:\$[0-9]+]], @w+32
+; CHECK: MLOAD [[TMP:\$[0-9]+]], [[ADDR]]
+
+  %elem = getelementptr inbounds %struct.w, ptr @w, i32 0, i32 1
+  %load = load i256, ptr %elem
+  ret i256 %load
+}
+
+define i256 @load.elem() nounwind {
+; CHECK-LABEL: load.elem
+; CHECK: CONST_I256 [[ADDR:\$[0-9]+]], @val
+; CHECK: MLOAD [[TMP:\$[0-9]+]], [[ADDR]]
+
+  %res = load i256, i256* @val
+  ret i256 %res
+}
+
+define void @store.elem(i256 %val) nounwind {
+; CHECK-LABEL: store.elem
+; CHECK: CONST_I256 [[ADDR:\$[0-9]+]], @val
+; CHECK: MSTORE [[ADDR]], {{.*}}
+
+  store i256 %val, i256* @val
+  ret void
+}
+
+define i256 @load.fromarray(i256 %i) nounwind {
+; CHECK-LABEL: load.fromarray
+; CHECK: CONST_I256 [[C:\$[0-9]+]], 5
+; CHECK: ARGUMENT [[IDX:\$[0-9]+]], 0
+; CHECK: SHL [[SHL:\$[0-9]+]], [[IDX]], [[C]]
+; CHECK: CONST_I256 [[TMP:\$[0-9]+]], @val2.arr
+; CHECK: ADD  [[ADDR:\$[0-9]+]], [[TMP]], [[SHL]]
+; CHECK: MLOAD [[RES:\$[0-9]+]], [[ADDR]]
+
+  %elem = getelementptr [4 x i256], [4 x i256]* @val2.arr, i256 0, i256 %i
+  %res = load i256, i256* %elem
+  ret i256 %res
+}
+
+define void @store.toarray(i256 %val, i256 %i) nounwind {
+; CHECK-LABEL: store.toarray
+; CHECK: CONST_I256 [[C:\$[0-9]+]], 5
+; CHECK: ARGUMENT [[IDX:\$[0-9]+]], 1
+; CHECK: SHL [[SHL:\$[0-9]+]], [[IDX]], [[C]]
+; CHECK: CONST_I256 [[TMP:\$[0-9]+]], @val.arr
+; CHECK: ADD  [[ADDR:\$[0-9]+]], [[TMP]], [[SHL]]
+; CHECK: ARGUMENT [[VAL:\$[0-9]+]], 0
+; CHECK: MSTORE [[ADDR]], [[VAL]]
+
+  %elem = getelementptr [4 x i256], [4 x i256]* @val.arr, i256 0, i256 %i
+  store i256 %val, i256* %elem
+  ret void
+}
+
+define ptr @load.ptr() nounwind {
+; CHECK-LABEL: load.ptr
+; CHECK: CONST_I256 [[ADDR:\$[0-9]+]], @as_ptr
+; CHECK: MLOAD [[TMP:\$[0-9]+]], [[ADDR]]
+
+  %res = load ptr, ptr @as_ptr
+  ret ptr %res
+}
+
+define void @store.ptr(ptr %val) nounwind {
+; CHECK-LABEL: store.ptr
+; CHECK: CONST_I256 [[ADDR:\$[0-9]+]], @as_ptr
+; CHECK: MSTORE [[ADDR]], {{.*}}
+
+  store ptr %val, ptr @as_ptr
+  ret void
+}

--- a/llvm/test/CodeGen/EVM/load-narrowing-disable.ll
+++ b/llvm/test/CodeGen/EVM/load-narrowing-disable.ll
@@ -1,0 +1,12 @@
+; RUN: llc --mtriple=evm < %s | FileCheck %s
+
+@ptr = private unnamed_addr global i256 0
+
+define i1 @simplify_setcc() {
+; CHECK-LABEL: simplify_setcc
+; CHECK-NOT: @ptr+31
+  %val = load i256, ptr @ptr, align 32
+  %val.and = and i256 %val, 2
+  %cmp = icmp eq i256 %val.and, 0
+  ret i1 %cmp
+}

--- a/llvm/test/CodeGen/EVM/sext.ll
+++ b/llvm/test/CodeGen/EVM/sext.ll
@@ -3,7 +3,8 @@
 define i256 @sexti8(i8 %rs1) nounwind {
 ; CHECK-LABEL: @sexti8
 ; CHECK: ARGUMENT [[IN1:\$[0-9]+]], 0
-; CHECK: SIGNEXTEND [[TMP:\$[0-9]+]], 0, [[IN1]]
+; CHECK: CONST_I256 [[EXT:\$[0-9]+]], 0
+; CHECK: SIGNEXTEND [[TMP:\$[0-9]+]], [[EXT]], [[IN1]]
 
   %res = sext i8 %rs1 to i256
   ret i256 %res
@@ -12,7 +13,8 @@ define i256 @sexti8(i8 %rs1) nounwind {
 define i256 @sexti16(i16 %rs1) nounwind {
 ; CHECK-LABEL: @sexti16
 ; CHECK: ARGUMENT [[IN1:\$[0-9]+]], 0
-; CHECK: SIGNEXTEND [[TMP:\$[0-9]+]], 1, [[IN1]]
+; CHECK: CONST_I256 [[EXT:\$[0-9]+]], 1
+; CHECK: SIGNEXTEND [[TMP:\$[0-9]+]], [[EXT]], [[IN1]]
 
   %res = sext i16 %rs1 to i256
   ret i256 %res
@@ -21,7 +23,8 @@ define i256 @sexti16(i16 %rs1) nounwind {
 define i256 @sexti32(i32 %rs1) nounwind {
 ; CHECK-LABEL: @sexti32
 ; CHECK: ARGUMENT [[IN1:\$[0-9]+]], 0
-; CHECK: SIGNEXTEND [[TMP:\$[0-9]+]], 3, [[IN1]]
+; CHECK: CONST_I256 [[EXT:\$[0-9]+]], 3
+; CHECK: SIGNEXTEND [[TMP:\$[0-9]+]], [[EXT]], [[IN1]]
 
   %res = sext i32 %rs1 to i256
   ret i256 %res
@@ -30,7 +33,8 @@ define i256 @sexti32(i32 %rs1) nounwind {
 define i256 @sexti64(i64 %rs1) nounwind {
 ; CHECK-LABEL: @sexti64
 ; CHECK: ARGUMENT [[IN1:\$[0-9]+]], 0
-; CHECK: SIGNEXTEND [[TMP:\$[0-9]+]], 7, [[IN1]]
+; CHECK: CONST_I256 [[EXT:\$[0-9]+]], 7
+; CHECK: SIGNEXTEND [[TMP:\$[0-9]+]], [[EXT]], [[IN1]]
 
   %res = sext i64 %rs1 to i256
   ret i256 %res
@@ -39,7 +43,8 @@ define i256 @sexti64(i64 %rs1) nounwind {
 define i256 @sexti128(i128 %rs1) nounwind {
 ; CHECK-LABEL: @sexti128
 ; CHECK: ARGUMENT [[IN1:\$[0-9]+]], 0
-; CHECK: SIGNEXTEND [[TMP:\$[0-9]+]], 15, [[IN1]]
+; CHECK: CONST_I256 [[EXT:\$[0-9]+]], 15
+; CHECK: SIGNEXTEND [[TMP:\$[0-9]+]], [[EXT]], [[IN1]]
 
   %res = sext i128 %rs1 to i256
   ret i256 %res

--- a/llvm/test/CodeGen/EVM/signextload.ll
+++ b/llvm/test/CodeGen/EVM/signextload.ll
@@ -1,0 +1,56 @@
+; RUN: llc --mtriple=evm < %s | FileCheck %s
+
+define i256 @load_signexti8(ptr %ptr) nounwind {
+; CHECK-LABEL: @load_signexti8
+; CHECK: MLOAD [[LOAD:\$[0-9]+]], [[PTR:\$[0-9]+]]
+; CHECK: CONST_I256 [[EXT:\$[0-9]+]], 248
+; CHECK: SAR [[RES:\$[0-9]+]], [[LOAD]], [[EXT]]
+
+  %load = load i8, ptr %ptr
+  %sext = sext i8 %load to i256
+  ret i256 %sext
+}
+
+define i256 @load_signexti16(ptr %ptr) nounwind {
+; CHECK-LABEL: @load_signexti16
+; CHECK: MLOAD [[LOAD:\$[0-9]+]], [[PTR:\$[0-9]+]]
+; CHECK: CONST_I256 [[EXT:\$[0-9]+]], 240
+; CHECK: SAR [[RES:\$[0-9]+]], [[LOAD]], [[EXT]]
+
+  %load = load i16, ptr %ptr
+  %sext = sext i16 %load to i256
+  ret i256 %sext
+}
+
+define i256 @load_signexti32(ptr %ptr) nounwind {
+; CHECK-LABEL: @load_signexti32
+; CHECK: MLOAD [[LOAD:\$[0-9]+]], [[PTR:\$[0-9]+]]
+; CHECK: CONST_I256 [[EXT:\$[0-9]+]], 224
+; CHECK: SAR [[RES:\$[0-9]+]], [[LOAD]], [[EXT]]
+
+  %load = load i32, ptr %ptr
+  %sext = sext i32 %load to i256
+  ret i256 %sext
+}
+
+define i256 @load_signexti64(ptr %ptr) nounwind {
+; CHECK-LABEL: @load_signexti64
+; CHECK: MLOAD [[LOAD:\$[0-9]+]], [[PTR:\$[0-9]+]]
+; CHECK: CONST_I256 [[EXT:\$[0-9]+]], 192
+; CHECK: SAR [[RES:\$[0-9]+]], [[LOAD]], [[EXT]]
+
+  %load = load i64, ptr %ptr
+  %sext = sext i64 %load to i256
+  ret i256 %sext
+}
+
+define i256 @load_signexti128(ptr %ptr) nounwind {
+; CHECK-LABEL: @load_signexti128
+; CHECK: MLOAD [[LOAD:\$[0-9]+]], [[PTR:\$[0-9]+]]
+; CHECK: CONST_I256 [[EXT:\$[0-9]+]], 128
+; CHECK: SAR [[RES:\$[0-9]+]], [[LOAD]], [[EXT]]
+
+  %load = load i128, ptr %ptr
+  %sext = sext i128 %load to i256
+  ret i256 %sext
+}

--- a/llvm/test/CodeGen/EVM/truncstore.ll
+++ b/llvm/test/CodeGen/EVM/truncstore.ll
@@ -1,0 +1,32 @@
+; RUN: llc --mtriple=evm < %s | FileCheck %s
+
+@glob_i8 = global i8 0
+@glob_i32 = global i32 0
+
+define void @storei8(i8 %val) nounwind {
+; CHECK-LABEL: @storei8
+; CHECK: ARGUMENT [[VAL:\$[0-9]+]], 0
+; CHECK: CONST_I256 [[ADDR:\$[0-9]+]], @glob_i8
+; CHECK: MSTORE8 [[ADDR]], [[VAL]]
+
+  store i8 %val, ptr @glob_i8
+  ret void
+}
+
+define void @storei32(i32 %val) nounwind {
+; CHECK-LABEL: @storei32
+; CHECK: CONST_I256 [[TMP1:\$[0-9]+]], 224
+; CHECK: ARGUMENT [[VAL:\$[0-9]+]], 0
+; CHECK: SHL [[SHL_VAL:\$[0-9]+]], [[VAL]], [[TMP1]]
+; CHECK: CONST_I256 [[ADDR:\$[0-9]+]], @glob_i32
+; CHECK: MLOAD [[ORIG_MEM:\$[0-9]+]], [[ADDR]]
+; CHECK: CONST_I256 [[TMP2:\$[0-9]+]], 32
+; CHECK: SHR [[SHR_MEM:\$[0-9]+]], [[ORIG_MEM]], [[TMP2]]
+; CHECK: SHL [[SHL_MEM:\$[0-9]+]], [[SHR_MEM]], [[TMP2]]
+; CHECK: OR [[RES_MEM:\$[0-9]+]], [[SHL_VAL]], [[SHL_MEM]]
+; CHECK: MSTORE [[ADDR]], [[RES_MEM]]
+
+  store i32 %val, ptr @glob_i32
+  ret void
+}
+

--- a/llvm/test/CodeGen/EVM/zero_any_extload.ll
+++ b/llvm/test/CodeGen/EVM/zero_any_extload.ll
@@ -1,0 +1,106 @@
+; RUN: llc --mtriple=evm < %s | FileCheck %s
+
+define i8 @load_anyext_i8(ptr %ptr) nounwind {
+; CHECK-LABEL: @load_anyext_i8
+; CHECK: MLOAD [[LOAD:\$[0-9]+]], [[PTR:\$[0-9]+]]
+; CHECK: CONST_I256 [[EXT:\$[0-9]+]], 248
+; CHECK: SHR [[SHR:\$[0-9]+]], [[LOAD]], [[EXT]]
+
+  %load = load i8, ptr %ptr
+  ret i8 %load
+}
+
+define i16 @load_anyext_i16(ptr %ptr) nounwind {
+; CHECK-LABEL: @load_anyext_i16
+; CHECK: MLOAD [[LOAD:\$[0-9]+]], [[PTR:\$[0-9]+]]
+; CHECK: CONST_I256 [[EXT:\$[0-9]+]], 240
+; CHECK: SHR [[SHR:\$[0-9]+]], [[LOAD]], [[EXT]]
+
+  %load = load i16, ptr %ptr
+  ret i16 %load
+}
+
+define i32 @load_anyext_i32(ptr %ptr) nounwind {
+; CHECK-LABEL: @load_anyext_i32
+; CHECK: MLOAD [[LOAD:\$[0-9]+]], [[PTR:\$[0-9]+]]
+; CHECK: CONST_I256 [[EXT:\$[0-9]+]], 224
+; CHECK: SHR [[SHR:\$[0-9]+]], [[LOAD]], [[EXT]]
+
+  %load = load i32, ptr %ptr
+  ret i32 %load
+}
+
+define i64 @load_anyext_i64(ptr %ptr) nounwind {
+; CHECK-LABEL: @load_anyext_i64
+; CHECK: MLOAD [[LOAD:\$[0-9]+]], [[PTR:\$[0-9]+]]
+; CHECK: CONST_I256 [[EXT:\$[0-9]+]], 192
+; CHECK: SHR [[SHR:\$[0-9]+]], [[LOAD]], [[EXT]]
+
+  %load = load i64, ptr %ptr
+  ret i64 %load
+}
+
+define i128 @load_anyext_i128(ptr %ptr) nounwind {
+; CHECK-LABEL: @load_anyext_i128
+; CHECK: MLOAD [[LOAD:\$[0-9]+]], [[PTR:\$[0-9]+]]
+; CHECK: CONST_I256 [[EXT:\$[0-9]+]], 128
+; CHECK: SHR [[SHR:\$[0-9]+]], [[LOAD]], [[EXT]]
+
+  %load = load i128, ptr %ptr
+  ret i128 %load
+}
+
+define i256 @load_zeroext_i8(ptr %ptr) nounwind {
+; CHECK-LABEL: @load_zeroext_i8
+; CHECK: MLOAD [[LOAD:\$[0-9]+]], [[PTR:\$[0-9]+]]
+; CHECK: CONST_I256 [[EXT:\$[0-9]+]], 248
+; CHECK: SHR [[SHR:\$[0-9]+]], [[LOAD]], [[EXT]]
+
+  %load = load i8, ptr %ptr
+  %zext = zext i8 %load to i256
+  ret i256 %zext
+}
+
+define i256 @load_zeroext_i16(ptr %ptr) nounwind {
+; CHECK-LABEL: @load_zeroext_i16
+; CHECK: MLOAD [[LOAD:\$[0-9]+]], [[PTR:\$[0-9]+]]
+; CHECK: CONST_I256 [[EXT:\$[0-9]+]], 240
+; CHECK: SHR [[SHR:\$[0-9]+]], [[LOAD]], [[EXT]]
+
+  %load = load i16, ptr %ptr
+  %zext = zext i16 %load to i256
+  ret i256 %zext
+}
+
+define i256 @load_zeroext_i32(ptr %ptr) nounwind {
+; CHECK-LABEL: @load_zeroext_i32
+; CHECK: MLOAD [[LOAD:\$[0-9]+]], [[PTR:\$[0-9]+]]
+; CHECK: CONST_I256 [[EXT:\$[0-9]+]], 224
+; CHECK: SHR [[SHR:\$[0-9]+]], [[LOAD]], [[EXT]]
+
+  %load = load i32, ptr %ptr
+  %zext = zext i32 %load to i256
+  ret i256 %zext
+}
+
+define i256 @load_zeroext_i64(ptr %ptr) nounwind {
+; CHECK-LABEL: @load_zeroext_i64
+; CHECK: MLOAD [[LOAD:\$[0-9]+]], [[PTR:\$[0-9]+]]
+; CHECK: CONST_I256 [[EXT:\$[0-9]+]], 192
+; CHECK: SHR [[SHR:\$[0-9]+]], [[LOAD]], [[EXT]]
+
+  %load = load i64, ptr %ptr
+  %zext = zext i64 %load to i256
+  ret i256 %zext
+}
+
+define i256 @load_zeroext_i128(ptr %ptr) nounwind {
+; CHECK-LABEL: @load_zeroext_i128
+; CHECK: MLOAD [[LOAD:\$[0-9]+]], [[PTR:\$[0-9]+]]
+; CHECK: CONST_I256 [[EXT:\$[0-9]+]], 128
+; CHECK: SHR [[SHR:\$[0-9]+]], [[LOAD]], [[EXT]]
+
+  %load = load i128, ptr %ptr
+  %zext = zext i128 %load to i256
+  ret i256 %zext
+}

--- a/llvm/test/CodeGen/EVM/zext.ll
+++ b/llvm/test/CodeGen/EVM/zext.ll
@@ -1,0 +1,46 @@
+; RUN: llc --mtriple=evm < %s | FileCheck %s
+
+define i256 @zexti8(i8 %rs1) nounwind {
+; CHECK-LABEL: @zexti8
+; CHECK: CONST_I256 [[EXT:\$[0-9]+]], 255
+; CHECK: AND {{.*}}, {{.*}}, [[EXT]]
+
+  %res = zext i8 %rs1 to i256
+  ret i256 %res
+}
+
+define i256 @zexti16(i16 %rs1) nounwind {
+; CHECK-LABEL: @zexti16
+; CHECK: CONST_I256 [[EXT:\$[0-9]+]], 65535
+; CHECK: AND {{.*}}, {{.*}}, [[EXT]]
+
+  %res = zext i16 %rs1 to i256
+  ret i256 %res
+}
+
+define i256 @zexti32(i32 %rs1) nounwind {
+; CHECK-LABEL: @zexti32
+; CHECK: CONST_I256 [[EXT:\$[0-9]+]], 4294967295
+; CHECK: AND {{.*}}, {{.*}}, [[EXT]]
+
+  %res = zext i32 %rs1 to i256
+  ret i256 %res
+}
+
+define i256 @zexti64(i64 %rs1) nounwind {
+; CHECK-LABEL: @zexti64
+; CHECK: CONST_I256 [[EXT:\$[0-9]+]], 18446744073709551615
+; CHECK: AND {{.*}}, {{.*}}, [[EXT]]
+
+  %res = zext i64 %rs1 to i256
+  ret i256 %res
+}
+
+define i256 @zexti128(i128 %rs1) nounwind {
+; CHECK-LABEL: @zexti128
+; CHECK: CONST_I256 [[EXT:\$[0-9]+]], 340282366920938463463374607431768211455
+; CHECK: AND {{.*}}, {{.*}}, [[EXT]]
+
+  %res = zext i128 %rs1 to i256
+  ret i256 %res
+}


### PR DESCRIPTION
[EVM] Addign frameindex lowering.
    
    Please, note this implementation assumes the stack is located in
    AS0 memeory and is intended for getting MIR with virtual register.
    We need to design how the frame slots to be represented in the stackified code.
    We can either use EVM stack (though EVM doesn't seem to have instructions to
    do this in a general case), or we can allocate a stack area in the AS0 memory.

 [EVM] Adding support of non-256 bit loads/stores.
    
    This includes:
     - lowering of globals
     - support of extended loads / truncated stores
     - disabling non-profitable transformations on DAGISel