### PR TITLE
Improve instruction info for SyncVM

### DIFF
--- a/llvm/lib/Target/SyncVM/SyncVMInstrInfo.h
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrInfo.h
@@ -49,12 +49,113 @@ int getWithInsNotSwapped(uint16_t Opcode);
 /// to \p Opcode.
 int getWithInsSwapped(uint16_t Opcode);
 
-bool hasRRInAddressingMode(const MachineInstr &MI);
-bool hasIRInAddressingMode(const MachineInstr &MI);
-bool hasCRInAddressingMode(const MachineInstr &MI);
-bool hasSRInAddressingMode(const MachineInstr &MI);
-bool hasRROutAddressingMode(const MachineInstr &MI);
-bool hasSROutAddressingMode(const MachineInstr &MI);
+/// \defgroup AMProperties Addressing mode properties
+/// Functions to identify in and out addressing mode of an instruction
+/// @{
+bool hasRRInAddressingMode(unsigned Opcode);
+bool hasIRInAddressingMode(unsigned Opcode);
+bool hasCRInAddressingMode(unsigned Opcode);
+bool hasSRInAddressingMode(unsigned Opcode);
+bool hasRROutAddressingMode(unsigned Opcode);
+bool hasSROutAddressingMode(unsigned Opcode);
+inline bool hasRRInAddressingMode(const MachineInstr &MI) {
+  return hasRRInAddressingMode(MI.getOpcode());
+}
+inline bool hasIRInAddressingMode(const MachineInstr &MI) {
+  return hasIRInAddressingMode(MI.getOpcode());
+}
+inline bool hasCRInAddressingMode(const MachineInstr &MI) {
+  return hasCRInAddressingMode(MI.getOpcode());
+}
+inline bool hasSRInAddressingMode(const MachineInstr &MI) {
+  return hasSRInAddressingMode(MI.getOpcode());
+}
+inline bool hasRROutAddressingMode(const MachineInstr &MI) {
+  return hasRROutAddressingMode(MI.getOpcode());
+}
+inline bool hasSROutAddressingMode(const MachineInstr &MI) {
+  return hasSROutAddressingMode(MI.getOpcode());
+}
+/// @}
+
+bool isSelect(unsigned Opcode);
+inline bool isSelect(const MachineInstr &MI) {
+  return isSelect(MI.getOpcode());
+}
+
+enum class ArgumentKind { In0, In1, Out0, Out1 };
+
+enum class ArgumentType { Register, Immediate, Code, Stack };
+
+/// Return argument addressing mode for a specified argument.
+ArgumentType argumentType(ArgumentKind Kind, unsigned Opcode);
+inline ArgumentType argumentType(ArgumentKind Kind, const MachineInstr &MI) {
+  return argumentType(Kind, MI.getOpcode());
+}
+
+/// Return number of Machine Operands that represent an ISA operand of \p Type.
+inline unsigned argumentSize(ArgumentType Type) {
+  switch (Type) {
+  case ArgumentType::Register:
+  case ArgumentType::Immediate:
+    return 1;
+  case ArgumentType::Code:
+    return 2;
+  case ArgumentType::Stack:
+    return 3;
+  }
+  llvm_unreachable("Unexpected argument type");
+}
+
+/// Return number of Machine Operands that represent an ISA operand.
+inline unsigned argumentSize(ArgumentKind Kind, const MachineInstr &MI) {
+  return argumentSize(argumentType(Kind, MI));
+}
+
+/// \defgroup ISAOperandIt MOP iterators to instruction operands as per ISA.
+/// Return machine operand iterator to the beginning of an ISA operand.
+/// @{
+MachineInstr::mop_iterator in0Iterator(MachineInstr &MI);
+MachineInstr::mop_iterator in1Iterator(MachineInstr &MI);
+MachineInstr::mop_iterator out0Iterator(MachineInstr &MI);
+MachineInstr::mop_iterator out1Iterator(MachineInstr &MI);
+/// @}
+
+/// \defgroup ISAOperandRange MOP ranges to instruction operands as per ISA.
+/// Return machine operand range of an ISA operand.
+/// @{
+inline auto in0Range(MachineInstr &MI) {
+  auto It = in0Iterator(MI);
+  return make_range(It, It + argumentSize(ArgumentKind::In0, MI));
+}
+inline auto in1Range(MachineInstr &MI) {
+  auto It = in1Iterator(MI);
+  return make_range(It, It + argumentSize(ArgumentKind::In1, MI));
+}
+inline auto out0Range(MachineInstr &MI) {
+  auto It = out0Iterator(MI);
+  return make_range(It, It + argumentSize(ArgumentKind::Out0, MI));
+}
+inline auto out1Range(MachineInstr &MI) {
+  auto It = out1Iterator(MI);
+  return make_range(It, It + argumentSize(ArgumentKind::Out1, MI));
+}
+/// @}
+
+/// Copy \p OpRange to \p Inst.
+inline void copyOperands(MachineInstrBuilder &Inst,
+                         iterator_range<MachineInstr::mop_iterator> OpRange) {
+  for (MachineOperand &MO : OpRange)
+    Inst.add(MO);
+}
+
+/// Copy \p OpRange to \p Inst.
+inline void copyOperands(MachineInstrBuilder &Inst,
+                         MachineInstr::mop_iterator OpBegin,
+                         MachineInstr::mop_iterator OpEnd) {
+  for (MachineOperand &MO : make_range(OpBegin, OpEnd))
+    Inst.add(MO);
+}
 
 } // namespace SyncVM
 
@@ -63,14 +164,6 @@ class SyncVMInstrInfo : public SyncVMGenInstrInfo {
   virtual void anchor();
 
 public:
-  enum GenericInstruction {
-    Unsupported = 0,
-    ADD,
-    SUB,
-    MUL,
-    DIV,
-  };
-
   explicit SyncVMInstrInfo();
 
   /// getRegisterInfo - TargetInstrInfo is a superset of MRegister info.  As
@@ -153,7 +246,6 @@ public:
   bool isNOP(const MachineInstr &MI) const;
 
   bool isSilent(const MachineInstr &MI) const;
-  GenericInstruction genericInstructionFor(const MachineInstr &MI) const;
 
   void tagFatPointerCopy(MachineInstr &) const override;
 

--- a/llvm/lib/Target/SyncVM/SyncVMStackAddressConstantPropagation.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMStackAddressConstantPropagation.cpp
@@ -9,7 +9,7 @@
 
 #include "SyncVM.h"
 
-#include <tuple>
+#include <optional>
 
 #include "llvm/ADT/Statistic.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
@@ -22,19 +22,22 @@
 using namespace llvm;
 
 #define DEBUG_TYPE "syncvm-stack-address-constant-propagation"
-#define SYNCVM_STACK_ADDRESS_CONSTANT_PROPAGATION_NAME "SyncVM bytes to cells"
+#define SYNCVM_STACK_ADDRESS_CONSTANT_PROPAGATION_NAME                         \
+  "SyncVM stack address constant propagation"
 
 STATISTIC(NumInstructionsErased, "Number of instructions erased");
 
 namespace {
 
+struct PropagationResult {
+  Register Base;
+  int64_t Displacement;
+};
+
 class SyncVMStackAddressConstantPropagation : public MachineFunctionPass {
 public:
   static char ID;
   SyncVMStackAddressConstantPropagation() : MachineFunctionPass(ID) {}
-
-  const TargetRegisterInfo *TRI;
-
   bool runOnMachineFunction(MachineFunction &Fn) override;
 
   StringRef getPassName() const override {
@@ -42,151 +45,73 @@ public:
   }
 
 private:
-  void expandConst(MachineInstr &MI) const;
-  void expandLoadConst(MachineInstr &MI) const;
-  void expandThrow(MachineInstr &MI) const;
-  std::tuple<bool, Register, int64_t>
-  tryExtractConstant(MachineInstr &MI, int Multiplier, int Dividor);
+  // If base for a stack address is in form x1 + x2 + ... + xn, propagate and
+  // fold all constants that are in expression.
+  // TODO: When FE start to produce LLVM arrays, it make sense to support
+  // propagation through mul.
+  std::optional<PropagationResult> tryPropagateConstant(MachineInstr &MI);
   const SyncVMInstrInfo *TII;
   MachineRegisterInfo *RegInfo;
-  LLVMContext *Context;
 };
 
 char SyncVMStackAddressConstantPropagation::ID = 0;
 
 } // namespace
 
-static const std::vector<std::string> BinaryIO = {"MUL", "DIV"};
-static const std::vector<std::string> BinaryI = {
-    "ADD", "SUB", "AND", "OR", "XOR", "SHL", "SHR", "ROL", "ROR"};
-
 INITIALIZE_PASS(SyncVMStackAddressConstantPropagation, DEBUG_TYPE,
                 SYNCVM_STACK_ADDRESS_CONSTANT_PROPAGATION_NAME, false, false)
 
-std::tuple<bool, Register, int64_t>
-SyncVMStackAddressConstantPropagation::tryExtractConstant(MachineInstr &MI,
-                                                          int Multiplier,
-                                                          int Divisor) {
-  if (!TII->genericInstructionFor(MI) || !TII->genericInstructionFor(MI) ||
-      !TII->isSilent(MI) || MI.mayStore() || MI.mayLoad())
+std::optional<PropagationResult>
+SyncVMStackAddressConstantPropagation::tryPropagateConstant(MachineInstr &MI) {
+  if (!TII->isAdd(MI) || !TII->isSilent(MI) || MI.mayStore() || MI.mayLoad())
     return {};
-
-  if (TII->isDiv(MI) && !SyncVM::hasIRInAddressingMode(MI))
-    return {};
-
-  // If the second out of MUL or DIV is used, don't extract a constant from it.
-  if (MI.getNumExplicitDefs() == 2) {
-    Register Def2 = MI.getOperand(1).getReg();
-    if (Def2 != SyncVM::R0 && !RegInfo->use_empty(MI.getOperand(1).getReg()))
-      return {};
-  }
 
   // If the result of the operation is used more than once, don't extract a
   // constant from it.
-  if (!RegInfo->hasOneNonDBGUse(MI.getOperand(0).getReg()))
+  if (!RegInfo->hasOneNonDBGUse(SyncVM::out0Iterator(MI)->getReg()))
     return {};
 
-  if (TII->isDiv(MI)) {
-    if (Divisor != 1)
+  auto In0 = SyncVM::in0Iterator(MI);
+  auto In1 = SyncVM::in1Iterator(MI);
+  Register In1Reg = In1->getReg();
+  MachineInstr &In1Def = *RegInfo->getVRegDef(In1Reg);
+  auto In1Res = tryPropagateConstant(In1Def);
+
+  // If Base = VR1 + VR2, try to propagate constant from VR1 and VR2
+  // recursively.
+  if (SyncVM::hasRRInAddressingMode(MI)) {
+    Register In0Reg = In0->getReg();
+    MachineInstr &LHS = *RegInfo->getVRegDef(In0Reg);
+    auto LHSRes = tryPropagateConstant(LHS);
+    if (!LHSRes && In1Res)
       return {};
-    if (getImmOrCImm(MI.getOperand(2)) != 32)
-      return {};
-    Register In2 = MI.getOperand(3).getReg();
-    MachineInstr *DefMI = RegInfo->getVRegDef(In2);
-    auto extracted = tryExtractConstant(*DefMI, 1, 32);
-    if (!std::get<0>(extracted))
-      return {};
+    In0Reg = LHSRes ? LHSRes->Base : In0Reg;
+    In1Reg = In1Res ? In1Res->Base : In1Reg;
+    int64_t In0Const = LHSRes ? LHSRes->Displacement : 0;
+    int64_t In1Const = In1Res ? In1Res->Displacement : 0;
     Register NewVR = RegInfo->createVirtualRegister(&SyncVM::GR256RegClass);
     MachineInstr *NewMI = BuildMI(*MI.getParent(), &MI, MI.getDebugLoc(),
-                                  TII->get(SyncVM::DIVxrrr_s))
+                                  TII->get(SyncVM::ADDrrr_s))
                               .addDef(NewVR)
-                              .addDef(SyncVM::R0)
-                              .addImm(32)
-                              .addReg(std::get<1>(extracted))
+                              .addReg(In0Reg)
+                              .addReg(In1Reg)
                               .addImm(SyncVMCC::COND_NONE)
                               .getInstr();
     LLVM_DEBUG(dbgs() << "Replace " << MI << "\n  with " << NewMI);
     ++NumInstructionsErased;
     MI.eraseFromParent();
-    return {true, NewVR, std::get<2>(extracted)};
+    return PropagationResult{NewVR, In0Const + In1Const};
   }
-
-  auto getNewReg = [](std::tuple<bool, Register, int64_t> Result,
-                      Register Old) {
-    if (std::get<0>(Result))
-      return std::get<1>(Result);
-    return Old;
-  };
-
-  if (TII->isAdd(MI)) {
-    if (SyncVM::hasRRInAddressingMode(MI)) {
-      Register LHSReg = MI.getOperand(1).getReg();
-      Register RHSReg = MI.getOperand(2).getReg();
-      MachineInstr &LHS = *RegInfo->getVRegDef(LHSReg);
-      MachineInstr &RHS = *RegInfo->getVRegDef(RHSReg);
-      auto LHSRes = tryExtractConstant(LHS, Multiplier, Divisor);
-      auto RHSRes = tryExtractConstant(RHS, Multiplier, Divisor);
-      if (!std::get<0>(LHSRes) && !std::get<0>(RHSRes))
-        return {};
-      Register NewVR = RegInfo->createVirtualRegister(&SyncVM::GR256RegClass);
-      MachineInstr *NewMI = BuildMI(*MI.getParent(), &MI, MI.getDebugLoc(),
-                                    TII->get(SyncVM::ADDrrr_s))
-                                .addDef(NewVR)
-                                .addReg(getNewReg(LHSRes, LHSReg))
-                                .addReg(getNewReg(RHSRes, RHSReg))
-                                .addImm(SyncVMCC::COND_NONE)
-                                .getInstr();
-      LLVM_DEBUG(dbgs() << "Replace " << MI << "\n  with " << NewMI);
-      ++NumInstructionsErased;
-      MI.eraseFromParent();
-      return {true, NewVR, std::get<2>(LHSRes) + std::get<2>(RHSRes)};
-    }
-    assert(SyncVM::hasIRInAddressingMode(MI));
-    Register RHSReg = MI.getOperand(2).getReg();
-    unsigned Val = getImmOrCImm(MI.getOperand(1));
-    LLVM_DEBUG(dbgs() << "Erase " << MI);
-    ++NumInstructionsErased;
-    MI.eraseFromParent();
-    return {true, RHSReg, Multiplier * Val / Divisor};
-  }
-  if (TII->isSub(MI)) {
-    if (SyncVM::hasRRInAddressingMode(MI)) {
-      Register LHSReg = MI.getOperand(1).getReg();
-      Register RHSReg = MI.getOperand(2).getReg();
-      MachineInstr &LHS = *RegInfo->getVRegDef(LHSReg);
-      MachineInstr &RHS = *RegInfo->getVRegDef(RHSReg);
-      auto LHSRes = tryExtractConstant(LHS, Multiplier, Divisor);
-      auto RHSRes = tryExtractConstant(RHS, -Multiplier, Divisor);
-      if (!std::get<0>(LHSRes) && !std::get<0>(RHSRes))
-        return {};
-      Register NewVR = RegInfo->createVirtualRegister(&SyncVM::GR256RegClass);
-      MachineInstr *NewMI = BuildMI(*MI.getParent(), &MI, MI.getDebugLoc(),
-                                    TII->get(SyncVM::SUBrrr_s))
-                                .addDef(NewVR)
-                                .addReg(getNewReg(LHSRes, LHSReg))
-                                .addReg(getNewReg(RHSRes, RHSReg))
-                                .addImm(SyncVMCC::COND_NONE)
-                                .getInstr();
-      LLVM_DEBUG(dbgs() << "Replace " << MI << "\n  with " << NewMI);
-      ++NumInstructionsErased;
-      MI.eraseFromParent();
-      return {true, NewVR, std::get<2>(LHSRes) + std::get<2>(RHSRes)};
-    }
-    assert(SyncVM::hasIRInAddressingMode(MI));
-    Register RHSReg = MI.getOperand(2).getReg();
-    unsigned Val = getImmOrCImm(MI.getOperand(1));
-    LLVM_DEBUG(dbgs() << "Erase " << MI);
-    ++NumInstructionsErased;
-    MI.eraseFromParent();
-    return {true, RHSReg, -Multiplier * Val / Divisor};
-  }
-
-  // RI mul
-  // TODO: CPR-919 Make operand access more robust and readable.
-  unsigned Val = getImmOrCImm(MI.getOperand(2));
-  Register RHSReg = MI.getOperand(3).getReg();
-  MachineInstr &RHS = *RegInfo->getVRegDef(RHSReg);
-  return tryExtractConstant(RHS, Multiplier * Val, Divisor);
+  // If Base = VR + Disp, try to propagate const from VR and use Disp as Imm in
+  // Reg + Imm addressing mode.
+  assert(SyncVM::hasIRInAddressingMode(MI));
+  In1Reg = In1Res ? In1Res->Base : In1Reg;
+  unsigned Displacement =
+      getImmOrCImm(*In0) + (In1Res ? In1Res->Displacement : 0);
+  LLVM_DEBUG(dbgs() << "Erase " << MI);
+  ++NumInstructionsErased;
+  MI.eraseFromParent();
+  return PropagationResult{In1Reg, Displacement};
 }
 
 bool SyncVMStackAddressConstantPropagation::runOnMachineFunction(
@@ -202,28 +127,27 @@ bool SyncVMStackAddressConstantPropagation::runOnMachineFunction(
   assert(TII && "TargetInstrInfo must be a valid object");
 
   for (auto &BB : MF) {
-    for (auto II = BB.begin(); II != BB.end(); ++II) {
-      if (SyncVM::hasSRInAddressingMode(*II)) {
-        unsigned RegOpndNo = II->getNumExplicitDefs() + 1;
-        if (!II->getOperand(RegOpndNo).isReg())
-          continue;
-        Register Base = II->getOperand(RegOpndNo).getReg();
-        if (!RegInfo->hasOneNonDBGUse(Base))
-          continue;
-        MachineInstr *DefMI = RegInfo->getVRegDef(Base);
-        std::tuple<bool, Register, int64_t> extractionResult =
-            tryExtractConstant(*DefMI, 1, 1);
-        if (std::get<0>(extractionResult)) {
-          int64_t C = getImmOrCImm(II->getOperand(RegOpndNo + 1));
-          C += std::get<2>(extractionResult);
-          LLVM_DEBUG(dbgs() << "Replace " << *II);
-          II->getOperand(RegOpndNo).ChangeToRegister(
-              std::get<1>(extractionResult), 0);
-          II->getOperand(RegOpndNo + 1).ChangeToImmediate(C, 0);
-          LLVM_DEBUG(dbgs() << "  with " << *II);
-          Changed = true;
-        }
-      }
+    for (auto &MI : BB) {
+      if (!SyncVM::hasSRInAddressingMode(MI))
+        continue;
+      auto In0Reg = SyncVM::in0Iterator(MI) + 1;
+      auto In0Const = SyncVM::in0Iterator(MI) + 2;
+      if (!In0Reg->isReg())
+        continue;
+      Register Base = In0Reg->getReg();
+      if (!RegInfo->hasOneNonDBGUse(Base))
+        continue;
+      MachineInstr *DefMI = RegInfo->getVRegDef(Base);
+      auto ConstPropagationResult = tryPropagateConstant(*DefMI);
+      if (!ConstPropagationResult)
+        continue;
+      int64_t Displacement = getImmOrCImm(*In0Const);
+      Displacement += ConstPropagationResult->Displacement;
+      LLVM_DEBUG(dbgs() << "Replace " << MI);
+      In0Reg->ChangeToRegister(ConstPropagationResult->Base, 0);
+      In0Const->ChangeToImmediate(Displacement, 0);
+      LLVM_DEBUG(dbgs() << "  with " << MI);
+      Changed = true;
     }
   }
   LLVM_DEBUG(


### PR DESCRIPTION
* Implement machine operand accessors and other auxiliary functions that
  allow to work with ISA operand instead of raw machine operands.
* Refactor Stack Address Constant Propagation and Expand Select passes
  to remove unused code and switch to new interfaces.