### PR TITLE
LLVM Handle i256 length properly in memcpy optimizer

### DIFF
--- a/llvm/lib/Transforms/Scalar/MemCpyOptimizer.cpp
+++ b/llvm/lib/Transforms/Scalar/MemCpyOptimizer.cpp
@@ -836,6 +836,11 @@ bool MemCpyOptPass::processStore(StoreInst *SI, BasicBlock::iterator &BBI) {
 }
 
 bool MemCpyOptPass::processMemSet(MemSetInst *MSI, BasicBlock::iterator &BBI) {
+  // SyncVM local begin
+  if (isa<ConstantInt>(MSI->getLength()) &&
+      cast<ConstantInt>(MSI->getLength())->getValue().getSignificantBits() > 64)
+    return false;
+  // SyncVM local end
   // See if there is another memset or store neighboring this memset which
   // allows us to widen out the memset to do a single larger store.
   if (isa<ConstantInt>(MSI->getLength()) && !MSI->isVolatile())
@@ -1109,6 +1114,11 @@ bool MemCpyOptPass::performCallSlotOptzn(Instruction *cpyLoad,
 /// the memcpy 'MDep'. Try to simplify M to copy from MDep's input if we can.
 bool MemCpyOptPass::processMemCpyMemCpyDependence(MemCpyInst *M,
                                                   MemCpyInst *MDep) {
+  // SyncVM local begin
+  if (isa<ConstantInt>(M->getLength()) &&
+      cast<ConstantInt>(M->getLength())->getValue().getSignificantBits() > 64)
+    return false;
+  // SyncVM local end
   // We can only transforms memcpy's where the dest of one is the source of the
   // other.
   if (M->getSource() != MDep->getDest() || MDep->isVolatile())
@@ -1395,6 +1405,11 @@ bool MemCpyOptPass::performMemCpyToMemSetOptzn(MemCpyInst *MemCpy,
 /// circumstances). This allows later passes to remove the first memcpy
 /// altogether.
 bool MemCpyOptPass::processMemCpy(MemCpyInst *M, BasicBlock::iterator &BBI) {
+  // SyncVM local begin
+  if (isa<ConstantInt>(M->getLength()) &&
+      cast<ConstantInt>(M->getLength())->getValue().getSignificantBits() > 64)
+    return false;
+  // SyncVM local end
   // We can only optimize non-volatile memcpy's.
   if (M->isVolatile()) return false;
 
@@ -1499,6 +1514,11 @@ bool MemCpyOptPass::processMemCpy(MemCpyInst *M, BasicBlock::iterator &BBI) {
 /// Transforms memmove calls to memcpy calls when the src/dst are guaranteed
 /// not to alias.
 bool MemCpyOptPass::processMemMove(MemMoveInst *M) {
+  // SyncVM local begin
+  if (isa<ConstantInt>(M->getLength()) &&
+      cast<ConstantInt>(M->getLength())->getValue().getSignificantBits() > 64)
+    return false;
+  // SyncVM local end
   // See if the source could be modified by this memmove potentially.
   if (isModSet(AA->getModRefInfo(M, MemoryLocation::getForSource(M))))
     return false;
@@ -1546,6 +1566,10 @@ bool MemCpyOptPass::processByValArgument(CallBase &CB, unsigned ArgNo) {
 
   // The length of the memcpy must be larger or equal to the size of the byval.
   auto *C1 = dyn_cast<ConstantInt>(MDep->getLength());
+  // SyncVM local begin
+  if (C1 && C1->getValue().getSignificantBits() > 64)
+    return false;
+  // SyncVM local end
   if (!C1 || !TypeSize::isKnownGE(
                  TypeSize::getFixed(C1->getValue().getZExtValue()), ByValSize))
     return false;
@@ -1685,10 +1709,7 @@ bool MemCpyOptPass::runImpl(Function &F, TargetLibraryInfo *TLI_,
 
 /// This is the main transformation entry point for a function.
 bool MemCpyOptLegacyPass::runOnFunction(Function &F) {
-  // TODO: The pass should only be skipped for SyncVM.
-  // SyncVM local begin
-  if (true || skipFunction(F))
-  // SyncVM local end
+  if (skipFunction(F))
     return false;
 
   auto *TLI = &getAnalysis<TargetLibraryInfoWrapperPass>().getTLI(F);

--- a/llvm/test/Transforms/MemCpyOpt/i256length.ll
+++ b/llvm/test/Transforms/MemCpyOpt/i256length.ll
@@ -1,0 +1,24 @@
+; RUN: opt -S -memcpyopt < %s
+
+target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
+target triple = "syncvm-unknown-unknown"
+
+@ptr_calldata = private global ptr addrspace(3) null
+
+declare void @foo()
+
+; Function Attrs: argmemonly nocallback nofree nounwind willreturn
+declare void @llvm.memcpy.p1.p1.i256(ptr addrspace(1) noalias nocapture writeonly, ptr addrspace(1) noalias nocapture readonly, i256, i1 immarg)
+
+; Function Attrs: argmemonly nocallback nofree nounwind willreturn
+declare void @llvm.memcpy.p1.p3.i256(ptr addrspace(1) noalias nocapture writeonly, ptr addrspace(3) noalias nocapture readonly, i256, i1 immarg)
+
+; Function Attrs: nofree null_pointer_is_valid
+define private void @__deploy() {
+entry:
+  call void @foo()
+  %calldata_pointer = load ptr addrspace(3), ptr @ptr_calldata, align 32
+  %calldata_source_pointer = getelementptr i8, ptr addrspace(3) %calldata_pointer, i256 0
+  call void @llvm.memcpy.p1.p3.i256(ptr addrspace(1) align 1 null, ptr addrspace(3) align 1 %calldata_source_pointer, i256 32000000000000000000000000000000000000000000, i1 false)
+  unreachable
+}


### PR DESCRIPTION
LLVM doesn't assume memcpy lenght can exceed i64 max value, if it does don't perform optimization.