### PR TITLE
[SyncVM] Use jumps for Machine Outlining

### DIFF
--- a/.github/workflows/compiler-integration-tests.yml
+++ b/.github/workflows/compiler-integration-tests.yml
@@ -111,7 +111,8 @@ jobs:
           XFAILS:
             "CodeGen/SyncVM/memcpy-expansion.ll;\
              CodeGen/SyncVM/flag-setting-set-implicit-flags.ll;\
-             CodeGen/SyncVM/machine-outliner.mir"
+             CodeGen/SyncVM/machine-outliner.mir;\
+             CodeGen/SyncVM/machine-outliner-tail.mir"
 
         run: |
           BINDIR=$(target-llvm/build-final/bin/llvm-config --bindir)

--- a/llvm/include/llvm/CodeGen/TargetInstrInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetInstrInfo.h
@@ -1993,6 +1993,13 @@ public:
     return false;
   }
 
+  // SyncVM local begin
+  /// Do a fixup post outline.
+  virtual void fixupPostOutline(
+      std::vector<std::pair<MachineFunction *, std::vector<MachineFunction *>>>
+          &FixupFunctions) const {}
+  // SyncVM local end
+
   /// Produce the expression describing the \p MI loading a value into
   /// the physical register \p Reg. This hook should only be used with
   /// \p MIs belonging to VReg-less functions.

--- a/llvm/include/llvm/CodeGen/TargetInstrInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetInstrInfo.h
@@ -1983,6 +1983,11 @@ public:
                      "TargetInstrInfo::isFunctionSafeToOutlineFrom!");
   }
 
+  // SyncVM local begin
+  /// Return default number of outliner reruns.
+  virtual unsigned defaultOutlineReruns() const { return 0; }
+  // SyncVM local end
+
   /// Return true if the function should be outlined from by default.
   virtual bool shouldOutlineFromFunctionByDefault(MachineFunction &MF) const {
     return false;

--- a/llvm/lib/CodeGen/MachineOutliner.cpp
+++ b/llvm/lib/CodeGen/MachineOutliner.cpp
@@ -1011,13 +1011,30 @@ bool MachineOutliner::runOnModule(Module &M) {
   if (!doOutline(M, OutlinedFunctionNum))
     return false;
 
-  for (unsigned I = 0; I < OutlinerReruns; ++I) {
+  // SyncVM local begin
+  MachineModuleInfo &MMI = getAnalysis<MachineModuleInfoWrapperPass>().getMMI();
+  const TargetInstrInfo *TII = nullptr;
+  for (Function &F : M) {
+    if (MachineFunction *MF = MMI.getMachineFunction(F)) {
+      TII = MF->getSubtarget().getInstrInfo();
+      break;
+    }
+  }
+  assert(TII && "Didn't find target instruction info.");
+  unsigned Reruns = OutlinerReruns;
+  if (!OutlinerReruns.getNumOccurrences())
+    Reruns = TII->defaultOutlineReruns();
+
+  for (unsigned I = 0; I < Reruns; ++I) {
+  // SyncVM local end
     OutlinedFunctionNum = 0;
     OutlineRepeatedNum++;
     if (!doOutline(M, OutlinedFunctionNum)) {
       LLVM_DEBUG({
         dbgs() << "Did not outline on iteration " << I + 2 << " out of "
-               << OutlinerReruns + 1 << "\n";
+               // SyncVM local begin
+               << Reruns + 1 << "\n";
+               // SyncVM local end
       });
       break;
     }

--- a/llvm/lib/Target/SyncVM/SyncVM.h
+++ b/llvm/lib/Target/SyncVM/SyncVM.h
@@ -59,6 +59,18 @@ enum Context {
 };
 } // namespace SyncVMCTX
 
+/// This namespace holds all of the target specific flags that instruction info
+/// tracks.
+namespace SyncVMII {
+/// Target Operand Flags enum.
+enum TargetOperandFlags {
+  MO_NO_FLAG,
+
+  /// Immediate that represents stack slot index.
+  MO_STACK_SLOT_IDX,
+}; // enum TargetOperandFlags
+} // namespace SyncVMII
+
 inline unsigned getImmOrCImm(const llvm::MachineOperand &MO) {
   return MO.isImm() ? MO.getImm() : MO.getCImm()->getZExtValue();
 }

--- a/llvm/lib/Target/SyncVM/SyncVM.h
+++ b/llvm/lib/Target/SyncVM/SyncVM.h
@@ -68,6 +68,9 @@ enum TargetOperandFlags {
 
   /// Immediate that represents stack slot index.
   MO_STACK_SLOT_IDX,
+
+  /// Represents return address symbol.
+  MO_SYM_RET_ADDRESS,
 }; // enum TargetOperandFlags
 } // namespace SyncVMII
 

--- a/llvm/lib/Target/SyncVM/SyncVMInstrFormats.td
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrFormats.td
@@ -239,8 +239,8 @@ class ICondJump<bits<8> opcode, dag ins, string asmstr, list<dag> pattern>
   let Inst{16-31} = dest;
 }
 
-class IJump<bits<8> opcode, dag ins, string asmstr, list<dag> pattern>
-  : IConditional <opcode, SrcNone, DstNone, (outs), ins, asmstr, pattern> {
+class IJump<bits<8> opcode, SourceMode as, dag ins, string asmstr, list<dag> pattern>
+  : IConditional <opcode, as, DstNone, (outs), ins, asmstr, pattern> {
   bits<16> dest;
   let Inst{16-31} = dest;
   let cc = 0;

--- a/llvm/lib/Target/SyncVM/SyncVMInstrInfo.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrInfo.cpp
@@ -211,6 +211,16 @@ bool isSelect(unsigned Opcode) {
   return Members.count(Opcode);
 }
 
+bool hasInvalidRelativeStackAccess(MachineInstr::const_mop_iterator Op) {
+  auto SA = SyncVM::classifyStackAccess(Op);
+  if (SA == SyncVM::StackAccess::Invalid)
+    return true;
+
+  if (SA == SyncVM::StackAccess::Relative && !(Op + 2)->isImm())
+    return true;
+  return false;
+}
+
 } // namespace SyncVM
 } // namespace llvm
 
@@ -302,6 +312,10 @@ bool SyncVMInstrInfo::analyzeBranch(MachineBasicBlock &MBB,
     // A terminator that isn't a branch can't easily be handled
     // by this analysis.
     if (!I->isBranch())
+      return true;
+
+    // We can't analyze if target address is on stack.
+    if (I->getOpcode() == SyncVM::J_s)
       return true;
 
     if (I->getOpcode() == SyncVM::J) {
@@ -608,29 +622,71 @@ SyncVMCC::CondCodes SyncVMInstrInfo::getCCCode(const MachineInstr &MI) const {
   return SyncVMCC::COND_INVALID;
 }
 
-enum FlagsUsage { FlagsUseBeforeDef = 0, FlagsDef, NoFlags };
+/// Return true if the first instruction in a function is stack advance.
+static bool hasStackAdvanceInstruction(MachineFunction &MF) {
+  auto EntryBB = MF.begin();
+  auto FirstMI = EntryBB->getFirstNonDebugInstr();
+  return FirstMI != EntryBB->end() && FirstMI->getOpcode() == SyncVM::NOPSP;
+}
 
-/// Return how Flags register is used in [Start, End).
-static FlagsUsage getFlagsUsage(MachineBasicBlock::iterator Start,
-                                MachineBasicBlock::iterator End) {
-  for (MachineInstr &I : instructionsWithoutDebug(Start, End)) {
-    if (I.getDesc().hasImplicitDefOfPhysReg(SyncVM::Flags))
-      return FlagsDef;
+/// Sets the offsets on instructions in MBB which use SP, so that they will be
+/// valid post-outlining.
+static void fixupStackOffsetPostOutline(MachineBasicBlock &MBB,
+                                        int64_t FixupOffset) {
+  auto AdjustDisp = [FixupOffset](MachineInstr::mop_iterator It) {
+    if (SyncVM::classifyStackAccess(It) != SyncVM::StackAccess::Relative)
+      return;
 
-    if (I.readsRegister(SyncVM::Flags))
-      return FlagsUseBeforeDef;
+    auto DispIt = It + 2;
+    assert(DispIt->isImm() && "Displacement is not immediate.");
+    DispIt->setImm(DispIt->getImm() + FixupOffset);
+  };
+
+  for (MachineInstr &MI : MBB) {
+    if (SyncVM::hasSRInAddressingMode(MI))
+      AdjustDisp(SyncVM::in0Iterator(MI));
+    if (SyncVM::hasSROutAddressingMode(MI))
+      AdjustDisp(SyncVM::out0Iterator(MI));
+
+    // Adjust sub instruction that was generated from ADDframe during
+    // elimination of frame indices.
+    if (MI.getOpcode() == SyncVM::SUBxrr_s &&
+        MI.getOperand(1).getTargetFlags() == SyncVMII::MO_STACK_SLOT_IDX) {
+      auto &StackSlotOP = MI.getOperand(1);
+      StackSlotOP.setImm(StackSlotOP.getImm() - FixupOffset);
+    }
+  }
+}
+
+/// Since we are placing return address from the outlined function onto the top
+/// of the stack, we need to reserve stack slot for it and to adjust
+/// instructions which use SP in this function.
+void SyncVMInstrInfo::fixupPostOutline(MachineFunction &MF) const {
+  auto *SFI = MF.getInfo<SyncVMMachineFunctionInfo>();
+  if (SFI->isStackAdjustedPostOutline())
+    return;
+
+  // Reserve stack slot for return address from outlined function.
+  if (hasStackAdvanceInstruction(MF)) {
+    auto NopIt = MF.begin()->getFirstNonDebugInstr();
+    auto &StackAdvanceOp = NopIt->getOperand(0);
+    StackAdvanceOp.setImm(StackAdvanceOp.getImm() + 1 /* StackSlotSize */);
+  } else {
+    auto EntryBB = MF.begin();
+    BuildMI(*EntryBB, EntryBB->begin(), DebugLoc(), get(SyncVM::NOPSP))
+        .addImm(1 /* StackSlotSize */)
+        .addImm(SyncVMCC::COND_NONE);
   }
 
-  return NoFlags;
+  // Adjust instructions which use SP in this function.
+  for (MachineBasicBlock &MBB : MF)
+    fixupStackOffsetPostOutline(MBB, -1 /* FixupOffset */);
+
+  SFI->setStackAdjustedPostOutline();
 }
 
 /// Enum values indicating how an outlined call should be constructed.
 enum MachineOutlinerConstructionID { MachineOutlinerDefault };
-
-enum MachineOutlinerMBBFlags {
-  FlagsRegDead = 1 << 0,
-  OutlinerMBBFlagsMask = (1 << 1) - 1
-};
 
 // TODO: Enable this.
 // bool SyncVMInstrInfo::shouldOutlineFromFunctionByDefault(
@@ -651,73 +707,31 @@ bool SyncVMInstrInfo::isFunctionSafeToOutlineFrom(
   if (F.hasSection())
     return false;
 
+  // Don't outline from functions if there is non-adjustable stack relative
+  // addressing instruction.
+  for (MachineBasicBlock &MBB : MF) {
+    if (any_of(instructionsWithoutDebug(MBB.begin(), MBB.end()),
+               [](MachineInstr &MI) {
+                 if (SyncVM::hasSRInAddressingMode(MI) &&
+                     SyncVM::hasInvalidRelativeStackAccess(
+                         SyncVM::in0Iterator(MI)))
+                   return true;
+                 if (SyncVM::hasSROutAddressingMode(MI) &&
+                     SyncVM::hasInvalidRelativeStackAccess(
+                         SyncVM::out0Iterator(MI)))
+                   return true;
+                 return false;
+               }))
+      return false;
+  }
+
   // It's safe to outline from MF.
   return true;
 }
 
 bool SyncVMInstrInfo::isMBBSafeToOutlineFrom(MachineBasicBlock &MBB,
                                              unsigned &Flags) const {
-  if (!TargetInstrInfo::isMBBSafeToOutlineFrom(MBB, Flags))
-    return false;
-
-  bool SeenDef = false;
-  bool SeenUse = false;
-  bool HasFlagsInst = false;
-
-  // Check how Flags register is used in the MBB. We can't outline this MBB if
-  // we find use before def, or def without use.
-  for (MachineInstr &I : MBB) {
-    if (I.isCall()) {
-      SeenDef = false;
-    } else if (I.getDesc().hasImplicitDefOfPhysReg(SyncVM::Flags)) {
-      SeenDef = true;
-      SeenUse = false;
-      HasFlagsInst = true;
-    } else if (I.readsRegister(SyncVM::Flags)) {
-      // Return false if we find use before def.
-      if (!SeenDef)
-        return false;
-      SeenUse = true;
-      HasFlagsInst = true;
-    }
-  }
-
-  // Return false if we find def without use.
-  if (SeenDef && !SeenUse)
-    return false;
-
-  // If Flags register is not used in this MBB, we know we don't have to check
-  // it later.
-  if (!HasFlagsInst)
-    Flags |= MachineOutlinerMBBFlags::FlagsRegDead;
-
-  // Don't check for successors if this MBB has no predecessors
-  // and no Flags instructions.
-  if (MBB.pred_empty() && !HasFlagsInst)
-    return true;
-
-  SmallVector<MachineBasicBlock *, 4> Worklist{MBB.successors()};
-  SmallPtrSet<MachineBasicBlock *, 4> Visited{&MBB};
-
-  // Check if Flags register is propagated across MBBs.
-  while (!Worklist.empty()) {
-    MachineBasicBlock *SuccMBB = Worklist.pop_back_val();
-    if (!Visited.insert(SuccMBB).second)
-      continue;
-
-    auto Usage = getFlagsUsage(SuccMBB->begin(), SuccMBB->end());
-
-    // If Flags register is propagated across MBBs, we know outlining is
-    // unsafe.
-    if (Usage == FlagsUseBeforeDef)
-      return false;
-
-    // If there are no Flags usage in this MBB, we need to look further.
-    if (Usage == NoFlags)
-      append_range(Worklist, SuccMBB->successors());
-  }
-
-  return true;
+  return TargetInstrInfo::isMBBSafeToOutlineFrom(MBB, Flags);
 }
 
 outliner::InstrType
@@ -734,22 +748,10 @@ SyncVMInstrInfo::getOutliningType(MachineBasicBlock::iterator &MBBI,
   if (MI.isMetaInstruction())
     return outliner::InstrType::Invisible;
 
-  // TODO: Remove this once issue with heap growth is fixed in VM.
-  switch (MI.getOpcode()) {
-  case SyncVM::LD1:
-  case SyncVM::LD1Inc:
-  case SyncVM::LD1i:
-  case SyncVM::LD2:
-  case SyncVM::LD2Inc:
-  case SyncVM::LD2i:
-  case SyncVM::ST1:
-  case SyncVM::ST1Inc:
-  case SyncVM::ST1i:
-  case SyncVM::ST2:
-  case SyncVM::ST2Inc:
-  case SyncVM::ST2i:
+  // Don't outline context.gas_left instruction.
+  if (MI.getOpcode() == SyncVM::CTXr_se &&
+      getImmOrCImm(MI.getOperand(1)) == SyncVMCTX::GAS_LEFT)
     return outliner::InstrType::Illegal;
-  }
 
   // Positions generally can't safely be outlined.
   if (MI.isPosition())
@@ -772,27 +774,11 @@ SyncVMInstrInfo::getOutliningType(MachineBasicBlock::iterator &MBBI,
     if (MO.isMBB() || MO.isBlockAddress() || MO.isCPI() || MO.isJTI())
       return outliner::InstrType::Illegal;
 
-  // Since we don't outline branches, don't outline instruction that defines
-  // Flags register that is used by conditional branch.
-  if (!MI.isCall() && MI.getDesc().hasImplicitDefOfPhysReg(SyncVM::Flags)) {
-    auto TermIt = MI.getParent()->getFirstTerminator();
-
-    // If there is a conditional branch and there are no more instructions
-    // that define Flags register, don't outline this instruction.
-    if (TermIt != MI.getParent()->end() && TermIt->isConditionalBranch() &&
-        !any_of(instructionsWithoutDebug(std::next(MBBI), TermIt),
-                [](const MachineInstr &I) {
-                  return I.getDesc().hasImplicitDefOfPhysReg(SyncVM::Flags);
-                }))
-      return outliner::InstrType::Illegal;
-  }
-
   return outliner::InstrType::Legal;
 }
 
 outliner::OutlinedFunction SyncVMInstrInfo::getOutliningCandidateInfo(
     std::vector<outliner::Candidate> &RepeatedSequenceLocs) const {
-  constexpr unsigned MinCandidatesToOutline = 2;
   unsigned SequenceSize =
       std::accumulate(RepeatedSequenceLocs[0].front(),
                       std::next(RepeatedSequenceLocs[0].back()), 0,
@@ -800,49 +786,24 @@ outliner::OutlinedFunction SyncVMInstrInfo::getOutliningCandidateInfo(
                         return Sum + getInstSizeInBytes(MI);
                       });
 
-  // Properties about candidate MBBs that hold for all of them.
-  unsigned FlagsSetInAll = OutlinerMBBFlagsMask;
+  SmallPtrSet<MachineFunction *, 4> NoStackAdvance;
+  unsigned SaveRetSize = get(SyncVM::ADDcrs_s).getSize();
+  unsigned JumpSize = get(SyncVM::JCALL).getSize();
+  unsigned CallOverhead = SaveRetSize + JumpSize;
+  for (auto &C : RepeatedSequenceLocs) {
+    unsigned Overhead = CallOverhead;
+    MachineFunction *MF = C.getMF();
 
-  // Compute liveness information for each candidate, and set FlagsSetInAll.
-  for (outliner::Candidate &C : RepeatedSequenceLocs)
-    FlagsSetInAll &= C.Flags;
+    // If function doesn't have stack advance instruction, add overhead only
+    // once for each function.
+    if (!hasStackAdvanceInstruction(*MF) && NoStackAdvance.insert(MF).second)
+      Overhead += get(SyncVM::NOPSP).getSize();
 
-  // Are there any candidates where Flags register is live?
-  if (!(FlagsSetInAll & FlagsRegDead)) {
-    // Since Flags register is cleared on entry/exit from a function call,
-    // we can't outline any sequence of instructions where this register
-    // is live into/across it.
-    auto CantGuaranteeValueAcrossCall = [](outliner::Candidate &C) {
-      // If the unsafe register in this block is dead, then we don't need
-      // to compute liveness here.
-      if (C.Flags & FlagsRegDead)
-        return false;
-
-      // Check if Flags register is defined outside, but used in a sequence.
-      if (getFlagsUsage(C.front(), std::next(C.back())) == FlagsUseBeforeDef)
-        return true;
-
-      // Check if Flags register is propagated across a sequence.
-      if (getFlagsUsage(std::next(C.back()), C.getMBB()->end()) ==
-          FlagsUseBeforeDef)
-        return true;
-
-      return false;
-    };
-
-    // Erase every candidate that violates the restriction above.
-    llvm::erase_if(RepeatedSequenceLocs, CantGuaranteeValueAcrossCall);
-
-    // If the sequence doesn't have enough candidates left, then we're done.
-    if (RepeatedSequenceLocs.size() < MinCandidatesToOutline)
-      return outliner::OutlinedFunction();
+    C.setCallInfo(MachineOutlinerDefault, Overhead);
   }
 
-  unsigned CallOverhead = get(SyncVM::NEAR_CALL).getSize();
-  for (auto &C : RepeatedSequenceLocs)
-    C.setCallInfo(MachineOutlinerDefault, CallOverhead);
-
-  unsigned FrameOverhead = get(SyncVM::RET).getSize();
+  unsigned JumpSPSize = get(SyncVM::J_s).getSize();
+  unsigned FrameOverhead = JumpSPSize;
   return outliner::OutlinedFunction(RepeatedSequenceLocs, SequenceSize,
                                     FrameOverhead, MachineOutlinerDefault);
 }
@@ -850,25 +811,55 @@ outliner::OutlinedFunction SyncVMInstrInfo::getOutliningCandidateInfo(
 void SyncVMInstrInfo::buildOutlinedFrame(
     MachineBasicBlock &MBB, MachineFunction &MF,
     const outliner::OutlinedFunction &OF) const {
+  // Perform stack fixup only if we didn't do it in the original function from
+  // which we are outlining. Machine outliner algorithm is outlining from
+  // the first candidate, so take original function from it.
+  MachineFunction *OriginalMF = OF.Candidates.front().getMF();
+  auto *SFI = OriginalMF->getInfo<SyncVMMachineFunctionInfo>();
+  if (!SFI->isStackAdjustedPostOutline())
+    fixupStackOffsetPostOutline(MBB, -1 /* FixupOffset */);
+
   DebugLoc DL;
   if (!MBB.empty())
     DL = MBB.back().getDebugLoc();
 
-  // Add return instruction to the end of the outlined frame.
-  MBB.insert(MBB.end(), BuildMI(MF, DL, get(SyncVM::RET)));
+  // Add jump instruction to the end of the outlined frame.
+  MBB.insert(MBB.end(), BuildMI(MF, DL, get(SyncVM::J_s))
+                            .addReg(SyncVM::SP)
+                            .addImm(0 /* AMBase2 */)
+                            .addImm(-1 /* StackOffset */));
 }
 
 MachineBasicBlock::iterator SyncVMInstrInfo::insertOutlinedCall(
     Module &M, MachineBasicBlock &MBB, MachineBasicBlock::iterator &It,
-    MachineFunction &MF, outliner::Candidate &C) const {
+    MachineFunction &OutlinedMF, outliner::Candidate &C) const {
+  MachineFunction &MF = *C.getMF();
+  fixupPostOutline(MF);
+
   DebugLoc DL;
   if (It != MBB.end())
     DL = It->getDebugLoc();
 
-  // Add call instruction to the outlined function at the given location.
-  It = MBB.insert(It, BuildMI(MF, DL, get(SyncVM::NEAR_CALL))
-                          .addReg(SyncVM::R0)
-                          .addGlobalAddress(M.getNamedValue(MF.getName()))
-                          .addExternalSymbol("DEFAULT_UNWIND"));
+  // Add jump instruction to the outlined function at the given location.
+  It = MBB.insert(It,
+                  BuildMI(MF, DL, get(SyncVM::JCALL))
+                      .addGlobalAddress(M.getNamedValue(OutlinedMF.getName())));
+
+  // Add symbol just after the jump that will be used as a return address
+  // from the outlined function.
+  MCSymbol *RetSym =
+      MF.getContext().createTempSymbol("OUTLINED_FUNCTION_RET", true);
+  It->setPostInstrSymbol(MF, RetSym);
+
+  // Add instruction to store return address onto the top of the stack.
+  BuildMI(MBB, It, DL, get(SyncVM::ADDcrs_s))
+      .addSym(RetSym)
+      .addImm(0 /* RetSymOffset */)
+      .addReg(SyncVM::R0)
+      .addReg(SyncVM::SP)
+      .addImm(0 /* AMBase2 */)
+      .addImm(-1 /* StackOffset */)
+      .addImm(SyncVMCC::COND_NONE);
+
   return It;
 }

--- a/llvm/lib/Target/SyncVM/SyncVMInstrInfo.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrInfo.cpp
@@ -688,11 +688,10 @@ void SyncVMInstrInfo::fixupPostOutline(MachineFunction &MF) const {
 /// Enum values indicating how an outlined call should be constructed.
 enum MachineOutlinerConstructionID { MachineOutlinerDefault };
 
-// TODO: Enable this.
-// bool SyncVMInstrInfo::shouldOutlineFromFunctionByDefault(
-//     MachineFunction &MF) const {
-//   return MF.getFunction().hasOptSize();
-// }
+bool SyncVMInstrInfo::shouldOutlineFromFunctionByDefault(
+    MachineFunction &MF) const {
+  return MF.getFunction().hasMinSize();
+}
 
 bool SyncVMInstrInfo::isFunctionSafeToOutlineFrom(
     MachineFunction &MF, bool OutlineFromLinkOnceODRs) const {

--- a/llvm/lib/Target/SyncVM/SyncVMInstrInfo.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrInfo.cpp
@@ -13,6 +13,7 @@
 #include "SyncVMTargetMachine.h"
 #include "llvm/CodeGen/MachineFrameInfo.h"
 #include "llvm/CodeGen/MachineInstrBuilder.h"
+#include "llvm/CodeGen/MachineModuleInfo.h"
 #include "llvm/CodeGen/MachineRegisterInfo.h"
 #include "llvm/IR/Function.h"
 #include "llvm/MC/MCContext.h"
@@ -622,6 +623,54 @@ SyncVMCC::CondCodes SyncVMInstrInfo::getCCCode(const MachineInstr &MI) const {
   return SyncVMCC::COND_INVALID;
 }
 
+/// Return whether outlining candidate ends with a tail call. This is true only
+/// if it is a terminator that ends function, call to outlined function that
+/// ends with a tail call, or call to a no return function.
+static bool isOutliningCandidateTailCall(const MachineInstr &MI) {
+  const MachineBasicBlock *MBB = MI.getParent();
+  if (MI.isTerminator()) {
+    assert(MBB->succ_empty() && "Terminator is not ending a function.");
+    return true;
+  }
+
+  auto GetFunction = [](const MachineOperand &MO) -> const Function * {
+    if (!MO.isGlobal())
+      return nullptr;
+    return dyn_cast<Function>(MO.getGlobal());
+  };
+
+  // Check if outlined function ends with tail call.
+  if (MI.getOpcode() == SyncVM::JCALL) {
+    const Function *Callee = GetFunction(MI.getOperand(0));
+    if (!Callee)
+      return false;
+
+    MachineFunction *CalleeMF =
+        MBB->getParent()->getMMI().getMachineFunction(*Callee);
+    return CalleeMF &&
+           CalleeMF->getInfo<SyncVMMachineFunctionInfo>()->isOutlined() &&
+           CalleeMF->getInfo<SyncVMMachineFunctionInfo>()->isTailCall();
+  }
+
+  // Check if we have a call to a no return function.
+  if (MI.getOpcode() != SyncVM::NEAR_CALL)
+    return false;
+
+  const Function *Callee = GetFunction(MI.getOperand(1));
+  if (!Callee)
+    return false;
+
+  if (Callee->doesNotReturn())
+    return true;
+
+  // Sometimes, special functions are not marked as noreturn, so check
+  // if we are calling one, and do additional checks if it is a last
+  // instruction in an ending MBB.
+  return std::next(MI.getIterator()) == MBB->end() && MBB->succ_empty() &&
+         (Callee->getName() == "__exit_return" ||
+          Callee->getName() == "__exit_revert");
+}
+
 /// Return true if the first instruction in a function is stack advance.
 static bool hasStackAdvanceInstruction(MachineFunction &MF) {
   auto EntryBB = MF.begin();
@@ -629,10 +678,11 @@ static bool hasStackAdvanceInstruction(MachineFunction &MF) {
   return FirstMI != EntryBB->end() && FirstMI->getOpcode() == SyncVM::NOPSP;
 }
 
-/// Sets the offsets on instructions in MBB which use SP, so that they will be
-/// valid post-outlining.
-static void fixupStackOffsetPostOutline(MachineBasicBlock &MBB,
-                                        int64_t FixupOffset) {
+/// Sets the offsets on instructions in [Start, End) which use SP, so that they
+/// will be valid post-outlining.
+static void fixupStackAccessOffsetPostOutline(MachineBasicBlock::iterator Start,
+                                              MachineBasicBlock::iterator End,
+                                              int64_t FixupOffset) {
   auto AdjustDisp = [FixupOffset](MachineInstr::mop_iterator It) {
     if (SyncVM::classifyStackAccess(It) != SyncVM::StackAccess::Relative)
       return;
@@ -642,7 +692,14 @@ static void fixupStackOffsetPostOutline(MachineBasicBlock &MBB,
     DispIt->setImm(DispIt->getImm() + FixupOffset);
   };
 
-  for (MachineInstr &MI : MBB) {
+  for (MachineInstr &MI : make_range(Start, End)) {
+    // Skip adjusting instruction that is used to set return address
+    // from outlining function.
+    if (any_of(MI.operands(), [](const MachineOperand &MO) {
+          return MO.getTargetFlags() == SyncVMII::MO_SYM_RET_ADDRESS;
+        }))
+      continue;
+
     if (SyncVM::hasSRInAddressingMode(MI))
       AdjustDisp(SyncVM::in0Iterator(MI));
     if (SyncVM::hasSROutAddressingMode(MI))
@@ -661,7 +718,7 @@ static void fixupStackOffsetPostOutline(MachineBasicBlock &MBB,
 /// Since we are placing return address from the outlined function onto the top
 /// of the stack, we need to reserve stack slot for it and to adjust
 /// instructions which use SP in this function.
-void SyncVMInstrInfo::fixupPostOutline(MachineFunction &MF) const {
+void SyncVMInstrInfo::fixupStackPostOutline(MachineFunction &MF) const {
   auto *SFI = MF.getInfo<SyncVMMachineFunctionInfo>();
   if (SFI->isStackAdjustedPostOutline())
     return;
@@ -680,13 +737,49 @@ void SyncVMInstrInfo::fixupPostOutline(MachineFunction &MF) const {
 
   // Adjust instructions which use SP in this function.
   for (MachineBasicBlock &MBB : MF)
-    fixupStackOffsetPostOutline(MBB, -1 /* FixupOffset */);
+    fixupStackAccessOffsetPostOutline(MBB.begin(), MBB.end(),
+                                      -1 /* FixupOffset */);
 
   SFI->setStackAdjustedPostOutline();
 }
 
-/// Enum values indicating how an outlined call should be constructed.
-enum MachineOutlinerConstructionID { MachineOutlinerDefault };
+/// Constants defining how certain sequences should be outlined.
+/// This encompasses how an outlined function should be called, and what kind of
+/// frame should be emitted for that outlined function.
+///
+/// \p MachineOutlinerDefault implies that the function should be called with
+/// a save return address onto TOS and jump back from address on TOS.
+///
+/// That is,
+///
+/// I1     Save RET ADDR onto TOS     OUTLINED_FUNCTION:
+/// I2 --> J OUTLINED_FUNCTION        I1
+/// I3     RET ADDR SYM               I2
+///                                   I3
+///                                   J TOS
+///
+/// * Call construction overhead: 2 (save + J) + 1? (SP advance)
+/// * Frame construction overhead: 1 (J)
+/// * Requires stack fixups? Yes
+///
+/// \p MachineOutlinerTailCall implies that the function is being created from
+/// a sequence of instructions ending in a return.
+///
+/// That is,
+///
+/// I1                             OUTLINED_FUNCTION:
+/// I2 --> J OUTLINED_FUNCTION     I1
+/// RET                            I2
+///                                RET
+///
+/// * Call construction overhead: 1 (J)
+/// * Frame construction overhead: 0 (Return included in sequence)
+/// * Requires stack fixups? No, if all callers don't need to do stack fixup
+///
+enum MachineOutlinerConstructionID {
+  MachineOutlinerDefault, /// Emit save, jump and jump to return.
+  MachineOutlinerTailCall /// Only emit a jump.
+};
 
 bool SyncVMInstrInfo::shouldOutlineFromFunctionByDefault(
     MachineFunction &MF) const {
@@ -751,6 +844,50 @@ SyncVMInstrInfo::getOutliningType(MachineBasicBlock::iterator &MBBI,
   if (MI.isMetaInstruction())
     return outliner::InstrType::Invisible;
 
+  // Is this a terminator for a basic block?
+  if (MI.isTerminator()) {
+
+    // Is this the end of a function?
+    if (MI.getParent()->succ_empty())
+      return outliner::InstrType::Legal;
+
+    // It's not, so don't outline it.
+    return outliner::InstrType::Illegal;
+  }
+
+  // Don't outline jump instruction that is used to call non-tail outlined
+  // function.
+  if (MI.getOpcode() == SyncVM::JCALL) {
+    const MachineOperand &MO = MI.getOperand(0);
+
+    // If it's not a global, we can outline it.
+    if (!MO.isGlobal())
+      return outliner::InstrType::Legal;
+
+    const Function *Callee = dyn_cast<Function>(MO.getGlobal());
+
+    // Only check for functions.
+    if (!Callee)
+      return outliner::InstrType::Legal;
+
+    MachineFunction *CalleeMF =
+        MI.getMF()->getMMI().getMachineFunction(*Callee);
+
+    // We don't know what's going on with the callee at all. Don't touch it.
+    if (!CalleeMF)
+      return outliner::InstrType::Legal;
+
+    auto *SFI = CalleeMF->getInfo<SyncVMMachineFunctionInfo>();
+
+    // We can safely outline calls to non-outlined or tail outlined functions.
+    if (!SFI->isOutlined() || SFI->isTailCall())
+      return outliner::InstrType::Legal;
+
+    // Don't outline this, as it is paired with instruction that adds return
+    // address onto TOS.
+    return outliner::InstrType::Illegal;
+  }
+
   // Don't outline context.gas_left instruction.
   if (MI.getOpcode() == SyncVM::CTXr_se &&
       getImmOrCImm(MI.getOperand(1)) == SyncVMCTX::GAS_LEFT)
@@ -762,10 +899,6 @@ SyncVMInstrInfo::getOutliningType(MachineBasicBlock::iterator &MBBI,
 
   // Don't trust the user to write safe inline assembly.
   if (MI.isInlineAsm())
-    return outliner::InstrType::Illegal;
-
-  // We can't outline branches and return statements.
-  if (MI.isTerminator() || MI.isReturn())
     return outliner::InstrType::Illegal;
 
   // Don't outline instructions that set or modify SP.
@@ -783,40 +916,6 @@ SyncVMInstrInfo::getOutliningType(MachineBasicBlock::iterator &MBBI,
 
 outliner::OutlinedFunction SyncVMInstrInfo::getOutliningCandidateInfo(
     std::vector<outliner::Candidate> &RepeatedSequenceLocs) const {
-  // If candidates contain instructions that we need to adjust, do more
-  // checks in order to see whether outlining is safe.
-  if (any_of(make_range(RepeatedSequenceLocs[0].front(),
-                        std::next(RepeatedSequenceLocs[0].back())),
-             [](MachineInstr &MI) {
-               return (SyncVM::hasSRInAddressingMode(MI) &&
-                       SyncVM::classifyStackAccess(SyncVM::in0Iterator(MI)) ==
-                           SyncVM::StackAccess::Relative) ||
-                      (SyncVM::hasSROutAddressingMode(MI) &&
-                       SyncVM::classifyStackAccess(SyncVM::out0Iterator(MI)) ==
-                           SyncVM::StackAccess::Relative) ||
-                      (MI.getOpcode() == SyncVM::SUBxrr_s &&
-                       MI.getOperand(1).getTargetFlags() ==
-                           SyncVMII::MO_STACK_SLOT_IDX);
-             })) {
-    // Since we can't mix candidates from functions where we adjusted SP and
-    // from function where we didn't, partition them into two sets and remove
-    // candidates from the smaller set. This can happen when we run outliner
-    // more than once.
-    auto IsSPAdjusted =
-        llvm::partition(RepeatedSequenceLocs, [](const outliner::Candidate &C) {
-          auto *SFI = C.getMF()->getInfo<SyncVMMachineFunctionInfo>();
-          return SFI->isStackAdjustedPostOutline();
-        });
-    if (std::distance(RepeatedSequenceLocs.begin(), IsSPAdjusted) >
-        std::distance(IsSPAdjusted, RepeatedSequenceLocs.end()))
-      RepeatedSequenceLocs.erase(IsSPAdjusted, RepeatedSequenceLocs.end());
-    else
-      RepeatedSequenceLocs.erase(RepeatedSequenceLocs.begin(), IsSPAdjusted);
-
-    if (RepeatedSequenceLocs.size() < 2)
-      return outliner::OutlinedFunction();
-  }
-
   unsigned SequenceSize =
       std::accumulate(RepeatedSequenceLocs[0].front(),
                       std::next(RepeatedSequenceLocs[0].back()), 0,
@@ -824,9 +923,19 @@ outliner::OutlinedFunction SyncVMInstrInfo::getOutliningCandidateInfo(
                         return Sum + getInstSizeInBytes(MI);
                       });
 
-  SmallPtrSet<MachineFunction *, 4> NoStackAdvance;
+  unsigned FrameID = MachineOutlinerDefault;
   unsigned SaveRetSize = get(SyncVM::ADDcrs_s).getSize();
   unsigned JumpSize = get(SyncVM::JCALL).getSize();
+  unsigned JumpSPSize = get(SyncVM::J_s).getSize();
+
+  // For tail calls, we are just using jump.
+  if (isOutliningCandidateTailCall(*RepeatedSequenceLocs[0].back())) {
+    FrameID = MachineOutlinerTailCall;
+    SaveRetSize = 0;
+    JumpSPSize = 0;
+  }
+
+  SmallPtrSet<MachineFunction *, 4> NoStackAdvance;
   unsigned CallOverhead = SaveRetSize + JumpSize;
   for (auto &C : RepeatedSequenceLocs) {
     unsigned Overhead = CallOverhead;
@@ -834,48 +943,45 @@ outliner::OutlinedFunction SyncVMInstrInfo::getOutliningCandidateInfo(
 
     // If function doesn't have stack advance instruction, add overhead only
     // once for each function.
+    // Add this overhead also for tail calls, as we can end up adjusting stack
+    // in caller just to align stack accesses with other callers.
     if (!hasStackAdvanceInstruction(*MF) && NoStackAdvance.insert(MF).second)
       Overhead += get(SyncVM::NOPSP).getSize();
 
-    C.setCallInfo(MachineOutlinerDefault, Overhead);
+    C.setCallInfo(FrameID, Overhead);
   }
 
-  unsigned JumpSPSize = get(SyncVM::J_s).getSize();
   unsigned FrameOverhead = JumpSPSize;
   return outliner::OutlinedFunction(RepeatedSequenceLocs, SequenceSize,
-                                    FrameOverhead, MachineOutlinerDefault);
+                                    FrameOverhead, FrameID);
 }
 
 void SyncVMInstrInfo::buildOutlinedFrame(
     MachineBasicBlock &MBB, MachineFunction &MF,
     const outliner::OutlinedFunction &OF) const {
-  // Perform stack fixup only if we didn't do it in the original function from
-  // which we are outlining. Machine outliner algorithm is outlining from
-  // the first candidate, so take original function from it.
-  MachineFunction *OriginalMF = OF.Candidates.front().getMF();
-  auto *SFI = OriginalMF->getInfo<SyncVMMachineFunctionInfo>();
-  if (!SFI->isStackAdjustedPostOutline())
-    fixupStackOffsetPostOutline(MBB, -1 /* FixupOffset */);
-
-  DebugLoc DL;
-  if (!MBB.empty())
-    DL = MBB.back().getDebugLoc();
+  bool IsTailCall = OF.FrameConstructionID == MachineOutlinerTailCall;
 
   // Add jump instruction to the end of the outlined frame.
-  MBB.insert(MBB.end(), BuildMI(MF, DL, get(SyncVM::J_s))
-                            .addReg(SyncVM::SP)
-                            .addImm(0 /* AMBase2 */)
-                            .addImm(-1 /* StackOffset */));
+  if (!IsTailCall) {
+    DebugLoc DL;
+    if (!MBB.empty())
+      DL = MBB.back().getDebugLoc();
 
-  MF.getInfo<SyncVMMachineFunctionInfo>()->setIsOutlined();
+    MBB.insert(MBB.end(), BuildMI(MF, DL, get(SyncVM::J_s))
+                              .addReg(SyncVM::SP)
+                              .addImm(0 /* AMBase2 */)
+                              .addImm(-1 /* StackOffset */));
+  }
+
+  auto *SFI = MF.getInfo<SyncVMMachineFunctionInfo>();
+  SFI->setIsOutlined();
+  SFI->setIsTailCall(IsTailCall);
 }
 
 MachineBasicBlock::iterator SyncVMInstrInfo::insertOutlinedCall(
     Module &M, MachineBasicBlock &MBB, MachineBasicBlock::iterator &It,
     MachineFunction &OutlinedMF, outliner::Candidate &C) const {
   MachineFunction &MF = *C.getMF();
-  fixupPostOutline(MF);
-
   DebugLoc DL;
   if (It != MBB.end())
     DL = It->getDebugLoc();
@@ -885,21 +991,98 @@ MachineBasicBlock::iterator SyncVMInstrInfo::insertOutlinedCall(
                   BuildMI(MF, DL, get(SyncVM::JCALL))
                       .addGlobalAddress(M.getNamedValue(OutlinedMF.getName())));
 
-  // Add symbol just after the jump that will be used as a return address
-  // from the outlined function.
-  MCSymbol *RetSym =
-      MF.getContext().createTempSymbol("OUTLINED_FUNCTION_RET", true);
-  It->setPostInstrSymbol(MF, RetSym);
+  if (C.CallConstructionID != MachineOutlinerTailCall) {
+    // Add symbol just after the jump that will be used as a return address
+    // from the outlined function.
+    MCSymbol *RetSym =
+        MF.getContext().createTempSymbol("OUTLINED_FUNCTION_RET", true);
+    It->setPostInstrSymbol(MF, RetSym);
 
-  // Add instruction to store return address onto the top of the stack.
-  BuildMI(MBB, It, DL, get(SyncVM::ADDcrs_s))
-      .addSym(RetSym, SyncVMII::MO_SYM_RET_ADDRESS)
-      .addImm(0 /* RetSymOffset */)
-      .addReg(SyncVM::R0)
-      .addReg(SyncVM::SP)
-      .addImm(0 /* AMBase2 */)
-      .addImm(-1 /* StackOffset */)
-      .addImm(SyncVMCC::COND_NONE);
+    // Add instruction to store return address onto the top of the stack.
+    BuildMI(MBB, It, DL, get(SyncVM::ADDcrs_s))
+        .addSym(RetSym, SyncVMII::MO_SYM_RET_ADDRESS)
+        .addImm(0 /* RetSymOffset */)
+        .addReg(SyncVM::R0)
+        .addReg(SyncVM::SP)
+        .addImm(0 /* AMBase2 */)
+        .addImm(-1 /* StackOffset */)
+        .addImm(SyncVMCC::COND_NONE);
+  }
 
   return It;
+}
+
+void SyncVMInstrInfo::fixupPostOutline(
+    std::vector<std::pair<MachineFunction *, std::vector<MachineFunction *>>>
+        &FixupFunctions) const {
+  // First, adjust all outlined functions with MachineOutlinerDefault strategy.
+  for (auto [Outlined, Callers] : FixupFunctions) {
+    if (Outlined->getInfo<SyncVMMachineFunctionInfo>()->isTailCall())
+      continue;
+
+    // Skip adjusting last instruction which is jump that loads return address
+    // from the stack.
+    auto &OutlinedMBB = Outlined->front();
+    fixupStackAccessOffsetPostOutline(OutlinedMBB.begin(),
+                                      std::prev(OutlinedMBB.end()),
+                                      -1 /* FixupOffset */);
+    for (auto Caller : Callers)
+      fixupStackPostOutline(*Caller);
+  }
+
+  // Remove all functions that we don't need to process. These are outlined
+  // functions with MachineOutlinerDefault strategy, and tail call outlined
+  // functions that don't have stack relative access instructions.
+  erase_if(FixupFunctions, [](auto &Funcs) {
+    auto Outlined = Funcs.first;
+    if (!Outlined->template getInfo<SyncVMMachineFunctionInfo>()->isTailCall())
+      return true;
+    if (none_of(Outlined->front(), [](MachineInstr &MI) {
+          return (SyncVM::hasSRInAddressingMode(MI) &&
+                  SyncVM::classifyStackAccess(SyncVM::in0Iterator(MI)) ==
+                      SyncVM::StackAccess::Relative) ||
+                 (SyncVM::hasSROutAddressingMode(MI) &&
+                  SyncVM::classifyStackAccess(SyncVM::out0Iterator(MI)) ==
+                      SyncVM::StackAccess::Relative) ||
+                 (MI.getOpcode() == SyncVM::SUBxrr_s &&
+                  MI.getOperand(1).getTargetFlags() ==
+                      SyncVMII::MO_STACK_SLOT_IDX);
+        }))
+      return true;
+    return false;
+  });
+
+  // After that, adjust all outlined functions with MachineOutlinerTailCall
+  // strategy. Repeat this iteration as long as we are changing something,
+  // because it can happen that we first decide to not adjust some function
+  // because callers weren't adjusted, but in later iterations we adjust one
+  // of the callers. See this example in machine-outliner-tail.mir.
+  bool Changed;
+  do {
+    Changed = false;
+    for (auto [Outlined, Callers] : FixupFunctions) {
+      auto *SFI = Outlined->getInfo<SyncVMMachineFunctionInfo>();
+
+      // Skip outlined functions that we already adjusted.
+      if (SFI->isStackAdjustedPostOutline())
+        continue;
+
+      // Skip if there is no caller that adjusted sp.
+      if (none_of(Callers, [](MachineFunction *MF) {
+            return MF->getInfo<SyncVMMachineFunctionInfo>()
+                ->isStackAdjustedPostOutline();
+          }))
+        continue;
+
+      auto &OutlinedMBB = Outlined->front();
+      fixupStackAccessOffsetPostOutline(OutlinedMBB.begin(), OutlinedMBB.end(),
+                                        -1 /* FixupOffset */);
+      for (auto Caller : Callers)
+        fixupStackPostOutline(*Caller);
+
+      // Set that we adjusted this outlined function, so we can skip it.
+      SFI->setStackAdjustedPostOutline();
+      Changed = true;
+    }
+  } while (Changed);
 }

--- a/llvm/lib/Target/SyncVM/SyncVMInstrInfo.h
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrInfo.h
@@ -282,7 +282,7 @@ public:
 
   bool shouldOutlineFromFunctionByDefault(MachineFunction &MF) const override;
 
-  void fixupPostOutline(MachineFunction &MF) const;
+  void fixupStackPostOutline(MachineFunction &MF) const;
 
   /// Return true if the function can safely be outlined from.
   bool isFunctionSafeToOutlineFrom(MachineFunction &MF,
@@ -303,26 +303,44 @@ public:
 
   /// Insert a custom frame for outlined functions.
   /// Since for outlined functions we don't need to follow standard calling
-  /// convention ABI, we are using jump that loads return address from TOS that
-  /// was added just before the call, to return from it. Usually for this, we
-  /// would use ret instruction, but we would have some limitations w.r.t.
-  /// propagating flags. Also, in some cases, we need to adjust stack accesses
-  /// in the outlined function, as we are placing return address onto TOS.
+  /// convention ABI, in case we are returning from the outlined function we are
+  /// using jump that loads return address from TOS that was added just before
+  /// the call. Usually for this, we would use ret nstruction, but we would have
+  /// some limitations w.r.t. propagating flags. In case we are not returning
+  /// from a function, we are not adding any instruction.
   void buildOutlinedFrame(MachineBasicBlock &MBB, MachineFunction &MF,
                           const outliner::OutlinedFunction &OF) const override;
 
   /// Insert a call to an outlined function into a given basic block.
   /// Since for outlined functions we don't need to follow standard calling
-  /// convention ABI, we are using 2 instructions to generate call to it: first
-  /// to save return address onto TOS and second to jump to outlined function.
-  /// Usually for this, we would use near_call instruction, but we would have
-  /// some limitations w.r.t. propagating flags. Also, we need to adjust stack
-  /// accesses in function from which we are calling outlined function, as we
-  /// are placing return address onto TOS.
+  /// convention ABI, in case we are returning from the outlined function we are
+  /// using 2 instructions to generate call to it: first to save return address
+  /// onto TOS and second to jump to the outlined function. Usually for this, we
+  /// would use near_call instruction, but we would have some limitations w.r.t.
+  /// propagating flags. In other case where we are not returning from a
+  /// function, we just use jump to it.
   MachineBasicBlock::iterator
   insertOutlinedCall(Module &M, MachineBasicBlock &MBB,
                      MachineBasicBlock::iterator &It, MachineFunction &MF,
                      outliner::Candidate &C) const override;
+
+  /// Do a fixup post outline.
+  /// We are doing fixup in three phasses:
+  ///   1. Adjust outlined functions and callers that have to put return address
+  ///      onto the stack.
+  ///   2. Remove functions that we already adjusted or we don't need to, so we
+  ///      can simplify 3rd phase.
+  ///   3. Adjust outlined functions that don't return and their callers, and
+  ///      repeat it as long as we are changing something.
+  ///
+  /// This is done in order to detect cases where we have to adjust outlined
+  /// functions that don't return, so we can align relative stack addresses in
+  /// all their callers to preserve correctness. Also, doing like this, we could
+  /// end up saving 1 instruction in a frameless function if we don't need to
+  /// adjust it.
+  void fixupPostOutline(
+      std::vector<std::pair<MachineFunction *, std::vector<MachineFunction *>>>
+          &FixupFunctions) const override;
 };
 
 } // namespace llvm

--- a/llvm/lib/Target/SyncVM/SyncVMInstrInfo.h
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrInfo.h
@@ -278,9 +278,7 @@ public:
   bool isPredicatedInstr(const MachineInstr &MI) const;
   SyncVMCC::CondCodes getCCCode(const MachineInstr &MI) const;
 
-  // TODO: Enable this.
-  // bool shouldOutlineFromFunctionByDefault(MachineFunction &MF) const
-  // override;
+  bool shouldOutlineFromFunctionByDefault(MachineFunction &MF) const override;
 
   void fixupPostOutline(MachineFunction &MF) const;
 

--- a/llvm/lib/Target/SyncVM/SyncVMInstrInfo.h
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrInfo.h
@@ -278,6 +278,8 @@ public:
   bool isPredicatedInstr(const MachineInstr &MI) const;
   SyncVMCC::CondCodes getCCCode(const MachineInstr &MI) const;
 
+  unsigned defaultOutlineReruns() const override { return 5; }
+
   bool shouldOutlineFromFunctionByDefault(MachineFunction &MF) const override;
 
   void fixupPostOutline(MachineFunction &MF) const;

--- a/llvm/lib/Target/SyncVM/SyncVMInstrInfo.td
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrInfo.td
@@ -1238,10 +1238,16 @@ def JC: ICondJump<10, (ins jmptarget:$dest, cc:$cc), "jump$cc\t$dest",
              [(SyncVMbrcc bb:$dest, imm:$cc)]>;
 
 // Unconditional jump
-let isTerminator = 1, isBranch = 1, isBarrier = 1 in
-def J: IJump<10, (ins jmptarget:$dest), "jump\t$dest",
+let isTerminator = 1, isBranch = 1, isBarrier = 1 in {
+def J: IJump<10, SrcNone, (ins jmptarget:$dest), "jump\t$dest",
              [(SyncVMbrcc bb:$dest, 0)]>;
+def J_s: IJump<10, SrcStack, (ins stackop:$dest), "jump\t$dest", [] >;
+}
 def : Pat<(br bb:$dst), (J bb:$dst)>;
+
+// Dynamic jumps
+let isPseudo = 1, isCall = 1 in
+def JCALL: IJump<10, SrcNone, (ins jmptarget:$dest), "jump\t$dest", [] >;
 
 let isReturn = 1, isTerminator = 1, isBarrier = 1  in {
 def RET   : IRet<7, RFNone, (ins), "ret", [(SyncVMret)]>;

--- a/llvm/lib/Target/SyncVM/SyncVMMCInstLower.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMMCInstLower.cpp
@@ -162,6 +162,10 @@ void SyncVMMCInstLower::Lower(const MachineInstr *MI, MCInst &OutMI) const {
     case MachineOperand::MO_BlockAddress:
       MCOp = LowerSymbolOperand(MO, GetBlockAddressSymbol(MO));
       break;
+    case MachineOperand::MO_MCSymbol:
+      assert(MO.getTargetFlags() == 0 && "Unknown target flag on MCSymbol");
+      MCOp = LowerSymbolOperand(MO, MO.getMCSymbol());
+      break;
     case MachineOperand::MO_RegisterMask:
       continue;
     }

--- a/llvm/lib/Target/SyncVM/SyncVMMachineFunctionInfo.h
+++ b/llvm/lib/Target/SyncVM/SyncVMMachineFunctionInfo.h
@@ -34,6 +34,9 @@ class SyncVMMachineFunctionInfo : public MachineFunctionInfo {
   // Whether we adjusted stack after machine outline in this function.
   bool StackAdjustedPostOutline = false;
 
+  // Whether this function is outlined.
+  bool IsOutlined = false;
+
 public:
   SyncVMMachineFunctionInfo() = default;
 
@@ -54,6 +57,9 @@ public:
 
   bool isStackAdjustedPostOutline() const { return StackAdjustedPostOutline; }
   void setStackAdjustedPostOutline() { StackAdjustedPostOutline = true; }
+
+  bool isOutlined() const { return IsOutlined; }
+  void setIsOutlined() { IsOutlined = true; }
 };
 
 } // End llvm namespace

--- a/llvm/lib/Target/SyncVM/SyncVMMachineFunctionInfo.h
+++ b/llvm/lib/Target/SyncVM/SyncVMMachineFunctionInfo.h
@@ -37,6 +37,9 @@ class SyncVMMachineFunctionInfo : public MachineFunctionInfo {
   // Whether this function is outlined.
   bool IsOutlined = false;
 
+  // Whether this function ends with a tail call.
+  bool IsTailCall = false;
+
 public:
   SyncVMMachineFunctionInfo() = default;
 
@@ -60,6 +63,9 @@ public:
 
   bool isOutlined() const { return IsOutlined; }
   void setIsOutlined() { IsOutlined = true; }
+
+  bool isTailCall() const { return IsTailCall; }
+  void setIsTailCall(bool IsTC) { IsTailCall = IsTC; }
 };
 
 } // End llvm namespace

--- a/llvm/lib/Target/SyncVM/SyncVMMachineFunctionInfo.h
+++ b/llvm/lib/Target/SyncVM/SyncVMMachineFunctionInfo.h
@@ -31,6 +31,9 @@ class SyncVMMachineFunctionInfo : public MachineFunctionInfo {
   /// holds the virtual register into which the sret argument is passed.
   Register SRetReturnReg;
 
+  // Whether we adjusted stack after machine outline in this function.
+  bool StackAdjustedPostOutline = false;
+
 public:
   SyncVMMachineFunctionInfo() = default;
 
@@ -48,6 +51,9 @@ public:
 
   int getVarArgsFrameIndex() const { return VarArgsFrameIndex;}
   void setVarArgsFrameIndex(int Index) { VarArgsFrameIndex = Index; }
+
+  bool isStackAdjustedPostOutline() const { return StackAdjustedPostOutline; }
+  void setStackAdjustedPostOutline() { StackAdjustedPostOutline = true; }
 };
 
 } // End llvm namespace

--- a/llvm/lib/Target/SyncVM/SyncVMRegisterInfo.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMRegisterInfo.cpp
@@ -80,6 +80,9 @@ void SyncVMRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator II,
                  .addImm(SyncVMCC::COND_NONE)
                  .getInstr();
 
+    // Set that immediate represents stack slot index.
+    SPInst->getOperand(1).setTargetFlags(SyncVMII::MO_STACK_SLOT_IDX);
+
     BuildMI(MBB, II, DL, TII.get(SyncVM::MULirrr_s))
         .addDef(MI.getOperand(0).getReg())
         .addDef(SyncVM::R0)

--- a/llvm/lib/Target/SyncVM/SyncVMTargetMachine.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMTargetMachine.cpp
@@ -64,8 +64,7 @@ SyncVMTargetMachine::SyncVMTargetMachine(const Target &T, const Triple &TT,
       Subtarget(TT, std::string(CPU), std::string(FS), *this) {
   setRequiresStructuredCFG(true);
   setMachineOutliner(true);
-  // TODO: Enable this.
-  // setSupportsDefaultOutlining(true);
+  setSupportsDefaultOutlining(true);
   initAsmInfo();
 }
 

--- a/llvm/test/CodeGen/SyncVM/machine-outliner-tail.mir
+++ b/llvm/test/CodeGen/SyncVM/machine-outliner-tail.mir
@@ -1,0 +1,146 @@
+# RUN: llc -x mir -run-pass=machine-outliner -verify-machineinstrs < %s | FileCheck %s
+
+# This test ensures that we create outlined functions, and do SP adjustment in
+# all callers and outlined functions. This also shows why we have to iterate
+# over tailcall outlined functions more than once to align stack relative
+# accesses.
+# In this test, we are iterating to adjust functions like this:
+#
+#   - Adjust functions that need to place return address onto TOS
+#     1. Adjusted OUTLINED_FUNCTION_1 and adjusted caller foo.
+#
+#   - Adjust tailcall functions
+#     1. Didn't adjust OUTLINED_FUNCTION_0 as caller bar wasn't adjusted.
+#     2. Adjusted OUTLINED_FUNCTION_2 and adjusted caller bar because foo was previously adjusted.
+#     3. Adjusted OUTLINED_FUNCTION_0 as caller bar was adjusted in previous iteration.
+#
+
+--- |
+
+  define void @foo(i256 %a, i256 %b) { ret void }
+  define void @bar(i256 %a, i256 %b) { ret void }
+
+...
+---
+# CHECK-LABEL: foo
+# CHECK-LABEL: bb.0:
+# CHECK: NOPSP 2, 0, implicit-def $sp, implicit $sp
+# CHECK-NEXT: ADDcrs_s target-flags(<unknown>) <mcsymbol >, 0, $r0, $sp, 0, -1, 0
+# CHECK-NEXT: JCALL @OUTLINED_FUNCTION_1, implicit-def $r1, implicit $sp, implicit $r1, implicit $r2, post-instr-symbol <mcsymbol >
+
+# CHECK-LABEL: bb.1:
+# CHECK: ADDcrs_s target-flags(<unknown>) <mcsymbol >, 0, $r0, $sp, 0, -1, 0
+# CHECK-NEXT: JCALL @OUTLINED_FUNCTION_1, implicit-def $r1, implicit $sp, implicit $r1, implicit $r2, post-instr-symbol <mcsymbol >
+
+# CHECK-LABEL: bb.2:
+# CHECK: JCALL @OUTLINED_FUNCTION_2, implicit-def $r1, implicit $sp, implicit $r1, implicit $r2
+name:            foo
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    liveins: $r1, $r2
+    NOPSP 1, 0, implicit-def $sp, implicit $sp
+    ADDsrs_s $sp, 0, -1, $r1, $sp, 0, -1, 0
+    $r1 = ANDrrr_s $r1, $r2, 0
+    $r1 = ANDrrr_s $r1, $r2, 0
+    $r1 = ANDrrr_s $r1, $r2, 0
+    $r1 = ANDrrr_s $r1, $r2, 0
+    $r1 = ANDrrr_s $r1, $r2, 0
+    $r1 = ANDrrr_s $r1, $r2, 0
+    $r1 = ANDrrr_s $r1, $r2, 0
+  bb.1:
+    liveins: $r1, $r2
+    ADDsrs_s $sp, 0, -1, $r1, $sp, 0, -1, 0
+    $r1 = ANDrrr_s $r1, $r2, 0
+    $r1 = ANDrrr_s $r1, $r2, 0
+    $r1 = ANDrrr_s $r1, $r2, 0
+    $r1 = ANDrrr_s $r1, $r2, 0
+    $r1 = ANDrrr_s $r1, $r2, 0
+    $r1 = ANDrrr_s $r1, $r2, 0
+    $r1 = ANDrrr_s $r1, $r2, 0
+  bb.2:
+    liveins: $r1, $r2
+    ADDsrs_s $sp, 0, -1, $r1, $sp, 0, -1, 0
+    $r1 = ORrrr_s $r1, $r2, 0
+    $r1 = ORrrr_s $r1, $r2, 0
+    RET
+
+...
+---
+# CHECK-LABEL: bar
+# CHECK-LABEL: bb.0:
+# CHECK: NOPSP 2, 0, implicit-def $sp, implicit $sp
+# CHECK-NEXT: dead $r3 = SUBrrr_v $r1, $r2, i256 0, implicit-def $flags
+# CHECK-NEXT: JC %bb.2, i256 10, implicit $flags
+
+# CHECK-LABEL: bb.1:
+# CHECK: JCALL @OUTLINED_FUNCTION_2, implicit-def $r1, implicit $sp, implicit $r1, implicit $r2
+
+# CHECK-LABEL: bb.2:
+# CHECK: dead $r3 = SUBrrr_v $r1, $r0, i256 0, implicit-def $flags
+# CHECK-NEXT: JC %bb.4, 2, implicit $flags
+
+# CHECK-LABEL: bb.3:
+# CHECK: JCALL @OUTLINED_FUNCTION_0, implicit-def $r1, implicit $sp, implicit $r0, implicit $r1, implicit $r2
+
+# CHECK-LABEL: bb.4:
+# CHECK: JCALL @OUTLINED_FUNCTION_0, implicit-def $r1, implicit $sp, implicit $r0, implicit $r1, implicit $r2
+name:            bar
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    liveins: $r1, $r2
+    NOPSP 1, 0, implicit-def $sp, implicit $sp
+    dead $r3 = SUBrrr_v $r1, $r2, i256 0, implicit-def $flags
+    JC %bb.2, i256 10, implicit $flags
+  bb.1:
+    liveins: $r1, $r2
+    ADDsrs_s $sp, 0, -1, $r1, $sp, 0, -1, 0
+    $r1 = ORrrr_s $r1, $r2, 0
+    $r1 = ORrrr_s $r1, $r2, 0
+    RET
+  bb.2:
+    liveins: $r1, $r2
+    dead $r3 = SUBrrr_v $r1, $r0, i256 0, implicit-def $flags
+    JC %bb.4, 2, implicit $flags
+  bb.3:
+    liveins: $r1, $r2
+    ADDrrs_s $r1, $r0, $sp, 0, -1, 0
+    ADDrrs_s $r1, $r0, $sp, 0, -1, 0
+    ADDrrs_s $r1, $r0, $sp, 0, -1, 0
+    $r1 = XORrrr_s $r1, $r2, 0
+    RET
+  bb.4:
+    liveins: $r1, $r2
+    ADDrrs_s $r1, $r0, $sp, 0, -1, 0
+    ADDrrs_s $r1, $r0, $sp, 0, -1, 0
+    ADDrrs_s $r1, $r0, $sp, 0, -1, 0
+    $r1 = XORrrr_s $r1, $r2, 0
+    RET
+
+# CHECK-LABEL: name: OUTLINED_FUNCTION_0
+# CHECK-LABEL: bb.0:
+# CHECK: ADDrrs_s $r1, $r0, $sp, 0, -2, 0
+# CHECK-NEXT: ADDrrs_s $r1, $r0, $sp, 0, -2, 0
+# CHECK-NEXT: ADDrrs_s $r1, $r0, $sp, 0, -2, 0
+# CHECK-NEXT: $r1 = XORrrr_s $r1, $r2, 0
+# CHECK-NEXT: RET
+
+# CHECK-LABEL: name: OUTLINED_FUNCTION_1
+# CHECK-LABEL: bb.0:
+# CHECK: ADDsrs_s $sp, 0, -2, $r1, $sp, 0, -2, 0
+# CHECK-NEXT: $r1 = ANDrrr_s $r1, $r2, 0
+# CHECK-NEXT: $r1 = ANDrrr_s $r1, $r2, 0
+# CHECK-NEXT: $r1 = ANDrrr_s $r1, $r2, 0
+# CHECK-NEXT: $r1 = ANDrrr_s $r1, $r2, 0
+# CHECK-NEXT: $r1 = ANDrrr_s $r1, $r2, 0
+# CHECK-NEXT: $r1 = ANDrrr_s $r1, $r2, 0
+# CHECK-NEXT: $r1 = ANDrrr_s $r1, $r2, 0
+# CHECK-NEXT: J_s $sp, 0, -1
+
+# CHECK-LABEL: name: OUTLINED_FUNCTION_2
+# CHECK-LABEL: bb.0:
+# CHECK: ADDsrs_s $sp, 0, -2, $r1, $sp, 0, -2, 0
+# CHECK-NEXT: $r1 = ORrrr_s $r1, $r2, 0
+# CHECK-NEXT: $r1 = ORrrr_s $r1, $r2, 0
+# CHECK-NEXT: RET

--- a/llvm/test/CodeGen/SyncVM/machine-outliner.mir
+++ b/llvm/test/CodeGen/SyncVM/machine-outliner.mir
@@ -16,12 +16,12 @@
 # CHECK-LABEL: foo
 # CHECK-LABEL: bb.0:
 # CHECK: NOPSP 1, 0, implicit-def $sp, implicit $sp
-# CHECK-NEXT: ADDcrs_s <mcsymbol >, 0, $r0, $sp, 0, -1, 0
+# CHECK-NEXT: ADDcrs_s target-flags(<unknown>) <mcsymbol >, 0, $r0, $sp, 0, -1, 0
 # CHECK-NEXT: JCALL @OUTLINED_FUNCTION_2, implicit-def $r1, implicit-def $flags, implicit $r2, implicit $r1, post-instr-symbol <mcsymbol >
 # CHECK-NEXT: $r1 = ADDirr_s i256 1, $r0, 2, implicit $flags
 
 # CHECK-LABEL: bb.1:
-# CHECK: ADDcrs_s <mcsymbol >, 0, $r0, $sp, 0, -1, 0
+# CHECK: ADDcrs_s target-flags(<unknown>) <mcsymbol >, 0, $r0, $sp, 0, -1, 0
 # CHECK-NEXT: JCALL @OUTLINED_FUNCTION_2, implicit-def $r1, implicit-def $flags, implicit $r2, implicit $r1, post-instr-symbol <mcsymbol >
 # CHECK-NEXT: $r1 = ORrrr_s $r1, $r2, 0
 # CHECK-NEXT: $r1 = ADDirr_s i256 1, $r0, 2, implicit $flags
@@ -64,12 +64,12 @@ body:             |
 # CHECK-LABEL: bb.0:
 # CHECK: NOPSP 1, 0, implicit-def $sp, implicit $sp
 # CHECK-NEXT: $r3 = CTXr_se i256 6, i256 0
-# CHECK-NEXT: ADDcrs_s <mcsymbol >, 0, $r0, $sp, 0, -1, 0
+# CHECK-NEXT: ADDcrs_s target-flags(<unknown>) <mcsymbol >, 0, $r0, $sp, 0, -1, 0
 # CHECK-NEXT: JCALL @OUTLINED_FUNCTION_1, implicit-def $r1, implicit $r2, implicit $r1, post-instr-symbol <mcsymbol >
 
 # CHECK-LABEL: bb.1:
 # CHECK: $r3 = CTXr_se i256 6, i256 0
-# CHECK-NEXT: ADDcrs_s <mcsymbol >, 0, $r0, $sp, 0, -1, 0
+# CHECK-NEXT: ADDcrs_s target-flags(<unknown>) <mcsymbol >, 0, $r0, $sp, 0, -1, 0
 # CHECK-NEXT: JCALL @OUTLINED_FUNCTION_1, implicit-def $r1, implicit $r2, implicit $r1, post-instr-symbol <mcsymbol >
 # CHECK-NEXT: RET
 name:            bar
@@ -111,11 +111,11 @@ body:             |
 # CHECK-NEXT: ADDsrs_s $sp, 0, -2, $r1, $sp, 0, -2, 0
 # CHECK-NEXT: SHRxrs_s i256 224, $r2, $sp, i256 0, -2, 0
 # CHECK-NEXT: $r1 = SUBzrr_s $sp, i256 0, -2, $r2, 0
-# CHECK-NEXT: ADDcrs_s <mcsymbol >, 0, $r0, $sp, 0, -1, 0
+# CHECK-NEXT: ADDcrs_s target-flags(<unknown>) <mcsymbol >, 0, $r0, $sp, 0, -1, 0
 # CHECK-NEXT: JCALL @OUTLINED_FUNCTION_0, implicit-def $r2, implicit $sp, implicit $r0, implicit $r1, post-instr-symbol <mcsymbol >
 
 # CHECK-LABEL: bb.1:
-# CHECK: ADDcrs_s <mcsymbol >, 0, $r0, $sp, 0, -1, 0
+# CHECK: ADDcrs_s target-flags(<unknown>) <mcsymbol >, 0, $r0, $sp, 0, -1, 0
 # CHECK-NEXT: JCALL @OUTLINED_FUNCTION_0, implicit-def $r2, implicit $sp, implicit $r0, implicit $r1, post-instr-symbol <mcsymbol >
 # CHECK-NEXT: RET
 name:            baz

--- a/llvm/test/CodeGen/SyncVM/machine-outliner.mir
+++ b/llvm/test/CodeGen/SyncVM/machine-outliner.mir
@@ -5,29 +5,26 @@
   define void @foo(i256 %a, i256 %b) { ret void }
   define void @bar(i256 %a, i256 %b) { ret void }
   define void @baz(i256 %a, i256 %b) { ret void }
+  define void @zed(i256 %a, i256 %b) { ret void }
 
 ...
 ---
 # This test ensures that we
 # - Create outlined functions
-# - Don't outline candidates where Flags register is defined outside, but used in a sequence
+# - Outline candidates where Flags register is propagated across a sequence
 #
 # CHECK-LABEL: foo
 # CHECK-LABEL: bb.0:
-# CHECK: $r1 = ANDrrr_v $r1, $r2, 0, implicit-def $flags
-# CHECK-NEXT: $r1 = ORrrr_s $r1, $r2, 0
+# CHECK: NOPSP 1, 0, implicit-def $sp, implicit $sp
+# CHECK-NEXT: ADDcrs_s <mcsymbol >, 0, $r0, $sp, 0, -1, 0
+# CHECK-NEXT: JCALL @OUTLINED_FUNCTION_2, implicit-def $r1, implicit-def $flags, implicit $r2, implicit $r1, post-instr-symbol <mcsymbol >
 # CHECK-NEXT: $r1 = ADDirr_s i256 1, $r0, 2, implicit $flags
-# CHECK-NEXT: NEAR_CALL $r0, @OUTLINED_FUNCTION_[[F0:[0-9]+]], &DEFAULT_UNWIND
 
 # CHECK-LABEL: bb.1:
-# CHECK: $r1 = ANDrrr_v $r1, $r2, 0, implicit-def $flags
-# CHECK-NEXT: $r1 = ORrrr_s $r1, $r2, 0
+# CHECK: ADDcrs_s <mcsymbol >, 0, $r0, $sp, 0, -1, 0
+# CHECK-NEXT: JCALL @OUTLINED_FUNCTION_2, implicit-def $r1, implicit-def $flags, implicit $r2, implicit $r1, post-instr-symbol <mcsymbol >
 # CHECK-NEXT: $r1 = ORrrr_s $r1, $r2, 0
 # CHECK-NEXT: $r1 = ADDirr_s i256 1, $r0, 2, implicit $flags
-# CHECK-NEXT: NEAR_CALL $r0, @OUTLINED_FUNCTION_[[F0:[0-9]+]], &DEFAULT_UNWIND
-
-# CHECK-LABEL: bb.2:
-# CHECK: NEAR_CALL $r0, @OUTLINED_FUNCTION_[[F0:[0-9]+]], &DEFAULT_UNWIND
 # CHECK-NEXT: RET
 name:            foo
 tracksRegLiveness: true
@@ -35,114 +32,210 @@ body:             |
   bb.0:
     liveins: $r1, $r2
     $r1 = ANDrrr_v $r1, $r2, 0, implicit-def $flags
+    $r1 = ANDrrr_s $r1, $r2, 0
+    $r1 = ANDrrr_s $r1, $r2, 0
+    $r1 = ANDrrr_s $r1, $r2, 0
+    $r1 = ANDrrr_s $r1, $r2, 0
+    $r1 = ANDrrr_s $r1, $r2, 0
+    $r1 = ANDrrr_s $r1, $r2, 0
     $r1 = ORrrr_s $r1, $r2, 0
     $r1 = ADDirr_s i256 1, $r0, 2, implicit $flags
-    $r1 = ANDrrr_s $r1, $r2, 0
-    $r1 = ANDrrr_s $r1, $r2, 0
-    $r1 = ANDrrr_s $r1, $r2, 0
   bb.1:
     liveins: $r1, $r2
     $r1 = ANDrrr_v $r1, $r2, 0, implicit-def $flags
+    $r1 = ANDrrr_s $r1, $r2, 0
+    $r1 = ANDrrr_s $r1, $r2, 0
+    $r1 = ANDrrr_s $r1, $r2, 0
+    $r1 = ANDrrr_s $r1, $r2, 0
+    $r1 = ANDrrr_s $r1, $r2, 0
+    $r1 = ANDrrr_s $r1, $r2, 0
     $r1 = ORrrr_s $r1, $r2, 0
     $r1 = ORrrr_s $r1, $r2, 0
     $r1 = ADDirr_s i256 1, $r0, 2, implicit $flags
-    $r1 = ANDrrr_s $r1, $r2, 0
-    $r1 = ANDrrr_s $r1, $r2, 0
-    $r1 = ANDrrr_s $r1, $r2, 0
-  bb.2:
-    liveins: $r1, $r2
-    $r1 = ANDrrr_s $r1, $r2, 0
-    $r1 = ANDrrr_s $r1, $r2, 0
-    $r1 = ANDrrr_s $r1, $r2, 0
     RET
 
 ...
 ---
 # This test ensures that we
-# - Can't create outlined functions becuase Flags register is defined in a sequence, but used outside
+# - Create outlined functions
+# - We don't outline context.gas_left instruction
 #
 # CHECK-LABEL: bar
 # CHECK-LABEL: bb.0:
-# CHECK: $r1 = ORrrr_s $r1, $r2, 0
-# CHECK-NEXT: $r1 = ORrrr_s $r1, $r2, 0
-# CHECK-NEXT: $r1 = ANDrrr_v $r1, $r2, 0, implicit-def $flags
-# CHECK-NEXT: $r1 = ORrrr_s $r1, $r2, 0
-# CHECK-NEXT: $r1 = ANDrrr_s $r1, $r2, 0
-# CHECK-NEXT: $r1 = ADDirr_s i256 1, $r0, 2, implicit $flags
+# CHECK: NOPSP 1, 0, implicit-def $sp, implicit $sp
+# CHECK-NEXT: $r3 = CTXr_se i256 6, i256 0
+# CHECK-NEXT: ADDcrs_s <mcsymbol >, 0, $r0, $sp, 0, -1, 0
+# CHECK-NEXT: JCALL @OUTLINED_FUNCTION_1, implicit-def $r1, implicit $r2, implicit $r1, post-instr-symbol <mcsymbol >
 
 # CHECK-LABEL: bb.1:
-# CHECK: $r1 = ORrrr_s $r1, $r2, 0
-# CHECK-NEXT: $r1 = ORrrr_s $r1, $r2, 0
-# CHECK-NEXT: $r1 = ANDrrr_v $r1, $r2, 0, implicit-def $flags
-# CHECK-NEXT: $r1 = ORrrr_s $r1, $r2, 0
-# CHECK-NEXT: $r1 = ADDirr_s i256 1, $r0, 2, implicit $flags
+# CHECK: $r3 = CTXr_se i256 6, i256 0
+# CHECK-NEXT: ADDcrs_s <mcsymbol >, 0, $r0, $sp, 0, -1, 0
+# CHECK-NEXT: JCALL @OUTLINED_FUNCTION_1, implicit-def $r1, implicit $r2, implicit $r1, post-instr-symbol <mcsymbol >
 # CHECK-NEXT: RET
 name:            bar
 tracksRegLiveness: true
 body:             |
   bb.0:
     liveins: $r1, $r2
+    $r3 = CTXr_se i256 6, i256 0
     $r1 = ORrrr_s $r1, $r2, 0
     $r1 = ORrrr_s $r1, $r2, 0
-    $r1 = ANDrrr_v $r1, $r2, 0, implicit-def $flags
     $r1 = ORrrr_s $r1, $r2, 0
-    $r1 = ANDrrr_s $r1, $r2, 0
-    $r1 = ADDirr_s i256 1, $r0, 2, implicit $flags
+    $r1 = ORrrr_s $r1, $r2, 0
+    $r1 = ORrrr_s $r1, $r2, 0
+    $r1 = ORrrr_s $r1, $r2, 0
+    $r1 = ORrrr_s $r1, $r2, 0
+    $r1 = ORrrr_s $r1, $r2, 0
   bb.1:
     liveins: $r1, $r2
+    $r3 = CTXr_se i256 6, i256 0
     $r1 = ORrrr_s $r1, $r2, 0
     $r1 = ORrrr_s $r1, $r2, 0
-    $r1 = ANDrrr_v $r1, $r2, 0, implicit-def $flags
     $r1 = ORrrr_s $r1, $r2, 0
-    $r1 = ADDirr_s i256 1, $r0, 2, implicit $flags
+    $r1 = ORrrr_s $r1, $r2, 0
+    $r1 = ORrrr_s $r1, $r2, 0
+    $r1 = ORrrr_s $r1, $r2, 0
+    $r1 = ORrrr_s $r1, $r2, 0
+    $r1 = ORrrr_s $r1, $r2, 0
     RET
 
 ...
 ---
 # This test ensures that we
-# - Can't create outlined functions becuase Flags are propagated across MBBs
+# - Create outlined functions
+# - Properly adjust stack offsets
 #
 # CHECK-LABEL: baz
 # CHECK-LABEL: bb.0:
-# CHECK: $r1 = ANDrrr_v $r1, $r2, 0, implicit-def $flags
-# CHECK-NEXT: $r1 = ADDirr_s i256 1, $r0, 2, implicit $flags
-# CHECK-NEXT: $r1 = ANDrrr_s $r1, $r2, 0
-# CHECK-NEXT: $r1 = ANDrrr_s $r1, $r2, 0
-# CHECK-NEXT: $r1 = ANDrrr_s $r1, $r2, 0
+# CHECK: NOPSP 2, 0, implicit-def $sp, implicit $sp
+# CHECK-NEXT: ADDsrs_s $sp, 0, -2, $r1, $sp, 0, -2, 0
+# CHECK-NEXT: SHRxrs_s i256 224, $r2, $sp, i256 0, -2, 0
+# CHECK-NEXT: $r1 = SUBzrr_s $sp, i256 0, -2, $r2, 0
+# CHECK-NEXT: ADDcrs_s <mcsymbol >, 0, $r0, $sp, 0, -1, 0
+# CHECK-NEXT: JCALL @OUTLINED_FUNCTION_0, implicit-def $r2, implicit $sp, implicit $r0, implicit $r1, post-instr-symbol <mcsymbol >
 
 # CHECK-LABEL: bb.1:
-# CHECK: $r1 = ANDrrr_s $r1, $r2, 0
-# CHECK-NEXT: $r1 = ANDrrr_s $r1, $r2, 0
-# CHECK-NEXT: $r1 = ANDrrr_s $r1, $r2, 0
-
-# CHECK-LABEL: bb.2:
-# CHECK: $r1 = ANDrrr_s $r1, $r2, 0
-# CHECK-NEXT: $r1 = ANDrrr_s $r1, $r2, 0
-# CHECK-NEXT: $r1 = ANDrrr_s $r1, $r2, 0
-
-# CHECK-LABEL: bb.3:
-# CHECK: $r1 = ADDirr_s i256 1, $r0, 2, implicit $flags
+# CHECK: ADDcrs_s <mcsymbol >, 0, $r0, $sp, 0, -1, 0
+# CHECK-NEXT: JCALL @OUTLINED_FUNCTION_0, implicit-def $r2, implicit $sp, implicit $r0, implicit $r1, post-instr-symbol <mcsymbol >
 # CHECK-NEXT: RET
 name:            baz
 tracksRegLiveness: true
 body:             |
   bb.0:
     liveins: $r1, $r2
-    $r1 = ANDrrr_v $r1, $r2, 0, implicit-def $flags
-    $r1 = ADDirr_s i256 1, $r0, 2, implicit $flags
-    $r1 = ANDrrr_s $r1, $r2, 0
-    $r1 = ANDrrr_s $r1, $r2, 0
-    $r1 = ANDrrr_s $r1, $r2, 0
+    NOPSP 1, 0, implicit-def $sp, implicit $sp
+    ADDsrs_s $sp, 0, -1, $r1, $sp, 0, -1, 0
+    SHRxrs_s i256 224, $r2, $sp, i256 0, -1, 0
+    $r1 = SUBzrr_s $sp, i256 0, -1, $r2, 0
+    ADDrrs_s $r1, $r0, $sp, 0, -1, 0
+    ADDrrs_s $r1, $r0, $sp, 0, -1, 0
+    ADDrrs_s $r1, $r0, $sp, 0, -1, 0
+    ADDrrs_s $r1, $r0, $sp, 0, -1, 0
+    ADDsrs_s $sp, 0, -1, $r1, $sp, 0, -1, 0
+    $r2 = ADDsrr_s $sp, 0, -1, $r0, 0
+    $r2 = ADDsrr_s $sp, 0, -1, $r0, 0
+    $r2 = ADDsrr_s $sp, 0, -1, $r0, 0
+    $r2 = ADDsrr_s $sp, 0, -1, $r0, 0
   bb.1:
     liveins: $r1, $r2
-    $r1 = ANDrrr_s $r1, $r2, 0
-    $r1 = ANDrrr_s $r1, $r2, 0
-    $r1 = ANDrrr_s $r1, $r2, 0
+    ADDrrs_s $r1, $r0, $sp, 0, -1, 0
+    ADDrrs_s $r1, $r0, $sp, 0, -1, 0
+    ADDrrs_s $r1, $r0, $sp, 0, -1, 0
+    ADDrrs_s $r1, $r0, $sp, 0, -1, 0
+    ADDsrs_s $sp, 0, -1, $r1, $sp, 0, -1, 0
+    $r2 = ADDsrr_s $sp, 0, -1, $r0, 0
+    $r2 = ADDsrr_s $sp, 0, -1, $r0, 0
+    $r2 = ADDsrr_s $sp, 0, -1, $r0, 0
+    $r2 = ADDsrr_s $sp, 0, -1, $r0, 0
+    RET
+
+...
+---
+# This test ensures that we
+# - Don't outline, because it is not beneficial as we need to add stack advance instruction
+#
+# Cost model is calculated like this:
+#   Outlined cost:     2 (call overhead) * 3 (candidates) +
+#                      4 (sequence size) + 1 (jump to return) +
+#                      1 (stack advance instruction) = 12 instructions
+#
+#   Non-Outlined cost: 3 (candidates) * 4 (sequence size) = 12 instructions
+#
+# CHECK-LABEL: zed
+# CHECK-LABEL: bb.0:
+# CHECK: $r1 = XORrrr_s $r1, $r2, 0
+# CHECK-NEXT: $r1 = XORrrr_s $r1, $r2, 0
+# CHECK-NEXT: $r1 = XORrrr_s $r1, $r2, 0
+# CHECK-NEXT: $r1 = XORrrr_s $r1, $r2, 0
+
+# CHECK-LABEL: bb.1:
+# CHECK: $r1 = XORrrr_s $r1, $r2, 0
+# CHECK-NEXT: $r1 = XORrrr_s $r1, $r2, 0
+# CHECK-NEXT: $r1 = XORrrr_s $r1, $r2, 0
+# CHECK-NEXT: $r1 = XORrrr_s $r1, $r2, 0
+
+# CHECK-LABEL: bb.2:
+# CHECK: $r1 = XORrrr_s $r1, $r2, 0
+# CHECK-NEXT: $r1 = XORrrr_s $r1, $r2, 0
+# CHECK-NEXT: $r1 = XORrrr_s $r1, $r2, 0
+# CHECK-NEXT: $r1 = XORrrr_s $r1, $r2, 0
+# CHECK-NEXT: RET
+name:            zed
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    liveins: $r1, $r2
+    $r1 = XORrrr_s $r1, $r2, 0
+    $r1 = XORrrr_s $r1, $r2, 0
+    $r1 = XORrrr_s $r1, $r2, 0
+    $r1 = XORrrr_s $r1, $r2, 0
+  bb.1:
+    liveins: $r1, $r2
+    $r1 = XORrrr_s $r1, $r2, 0
+    $r1 = XORrrr_s $r1, $r2, 0
+    $r1 = XORrrr_s $r1, $r2, 0
+    $r1 = XORrrr_s $r1, $r2, 0
   bb.2:
     liveins: $r1, $r2
-    $r1 = ANDrrr_s $r1, $r2, 0
-    $r1 = ANDrrr_s $r1, $r2, 0
-    $r1 = ANDrrr_s $r1, $r2, 0
-  bb.3:
-    $r1 = ADDirr_s i256 1, $r0, 2, implicit $flags
+    $r1 = XORrrr_s $r1, $r2, 0
+    $r1 = XORrrr_s $r1, $r2, 0
+    $r1 = XORrrr_s $r1, $r2, 0
+    $r1 = XORrrr_s $r1, $r2, 0
     RET
+
+# CHECK-LABEL: name: OUTLINED_FUNCTION_0
+# CHECK-LABEL: bb.0:
+# CHECK: ADDrrs_s $r1, $r0, $sp, 0, -2, 0
+# CHECK-NEXT: ADDrrs_s $r1, $r0, $sp, 0, -2, 0
+# CHECK-NEXT: ADDrrs_s $r1, $r0, $sp, 0, -2, 0
+# CHECK-NEXT: ADDrrs_s $r1, $r0, $sp, 0, -2, 0
+# CHECK-NEXT: ADDsrs_s $sp, 0, -2, $r1, $sp, 0, -2, 0
+# CHECK-NEXT: $r2 = ADDsrr_s $sp, 0, -2, $r0, 0
+# CHECK-NEXT: $r2 = ADDsrr_s $sp, 0, -2, $r0, 0
+# CHECK-NEXT: $r2 = ADDsrr_s $sp, 0, -2, $r0, 0
+# CHECK-NEXT: $r2 = ADDsrr_s $sp, 0, -2, $r0, 0
+# CHECK-NEXT: J_s $sp, 0, -1
+
+# CHECK-LABEL: name: OUTLINED_FUNCTION_1
+# CHECK-LABEL: bb.0:
+# CHECK: $r1 = ORrrr_s $r1, $r2, 0
+# CHECK-NEXT: $r1 = ORrrr_s $r1, $r2, 0
+# CHECK-NEXT: $r1 = ORrrr_s $r1, $r2, 0
+# CHECK-NEXT: $r1 = ORrrr_s $r1, $r2, 0
+# CHECK-NEXT: $r1 = ORrrr_s $r1, $r2, 0
+# CHECK-NEXT: $r1 = ORrrr_s $r1, $r2, 0
+# CHECK-NEXT: $r1 = ORrrr_s $r1, $r2, 0
+# CHECK-NEXT: $r1 = ORrrr_s $r1, $r2, 0
+# CHECK-NEXT: J_s $sp, 0, -1
+
+# CHECK-LABEL: name: OUTLINED_FUNCTION_2
+# CHECK-LABEL: bb.0:
+# CHECK: $r1 = ANDrrr_v $r1, $r2, 0, implicit-def $flags
+# CHECK-NEXT: $r1 = ANDrrr_s $r1, $r2, 0
+# CHECK-NEXT: $r1 = ANDrrr_s $r1, $r2, 0
+# CHECK-NEXT: $r1 = ANDrrr_s $r1, $r2, 0
+# CHECK-NEXT: $r1 = ANDrrr_s $r1, $r2, 0
+# CHECK-NEXT: $r1 = ANDrrr_s $r1, $r2, 0
+# CHECK-NEXT: $r1 = ANDrrr_s $r1, $r2, 0
+# CHECK-NEXT: $r1 = ORrrr_s $r1, $r2, 0
+# CHECK-NEXT: J_s $sp, 0, -1


### PR DESCRIPTION
Use jumps for Machine Outlining instead of using near_call and ret.