### PR TITLE
Pass stack address in cells across function boundaries

### DIFF
--- a/llvm/lib/Target/SyncVM/SyncVMBytesToCells.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMBytesToCells.cpp
@@ -62,7 +62,6 @@ private:
   bool isUsedAsStackAddress(Register Reg) const;
 
   const TargetInstrInfo *TII;
-  LLVMContext *Context;
   MachineRegisterInfo *MRI;
 
   std::vector<unsigned> MayContainCells;

--- a/llvm/lib/Target/SyncVM/SyncVMBytesToCells.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMBytesToCells.cpp
@@ -54,7 +54,7 @@ private:
   void collectArgumentsAsRegisters(MachineFunction &MF);
 
   // Returns true if the instruction is a return with argument.
-  bool isCopyReturnValue(const MachineInstr &MI) const;
+  bool isCopyReturnValue(MachineInstr &MI) const;
   bool isPassedInCells(Register) const;
   bool scalePointerArithmeticIfNeeded(MachineInstr *MI) const;
 
@@ -394,13 +394,13 @@ bool SyncVMBytesToCells::runOnMachineFunction(MachineFunction &MF) {
 }
 
 // Look for instruction: $r1 = COPY %0
-bool SyncVMBytesToCells::isCopyReturnValue(const MachineInstr &MI) const {
+bool SyncVMBytesToCells::isCopyReturnValue(MachineInstr &MI) const {
   if (!(MI.getOpcode() == SyncVM::COPY &&
-        MI.getOperand(0).getReg().isPhysical()))
+        SyncVM::out0Iterator(MI)->getReg().isPhysical()))
     return false;
   // The first return must be R1
-  Register PReg = MI.getOperand(0).getReg();
-  Register Reg = MI.getOperand(1).getReg();
+  Register PReg = SyncVM::out0Iterator(MI)->getReg();
+  Register Reg = SyncVM::in0Iterator(MI)->getReg();
   if (PReg != SyncVM::R1 || !Reg.isVirtual())
     return false;
 

--- a/llvm/lib/Target/SyncVM/SyncVMInstrInfo.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrInfo.cpp
@@ -96,7 +96,10 @@ MachineInstr::mop_iterator in1Iterator(MachineInstr &MI) {
 
 MachineInstr::mop_iterator out0Iterator(MachineInstr &MI) {
   auto Begin = MI.operands_begin();
-  if (hasRROutAddressingMode(MI) || isSelect(MI))
+  if (hasRROutAddressingMode(MI) || isSelect(MI) ||
+      MI.getOpcode() == SyncVM::ADDframe ||
+      MI.getOpcode() == SyncVM::ADDframeNoScaling ||
+      MI.getOpcode() == SyncVM::COPY)
     return Begin;
   return in1Iterator(MI) + argumentSize(ArgumentKind::In1, MI);
 }

--- a/llvm/lib/Target/SyncVM/SyncVMInstrInfo.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrInfo.cpp
@@ -233,6 +233,19 @@ bool hasInvalidRelativeStackAccess(MachineInstr::const_mop_iterator Op) {
   return false;
 }
 
+MachineInstr::mop_iterator getStackAccess(MachineInstr &MI) {
+  // check if the stack access is in input operands
+  if (SyncVM::hasSRInAddressingMode(MI)) {
+    return SyncVM::in0Iterator(MI);
+  }
+
+  // check if the stack access is in output operands
+  if (SyncVM::hasSROutAddressingMode(MI)) {
+    return SyncVM::out0Iterator(MI);
+  }
+  return {};
+}
+
 } // namespace SyncVM
 } // namespace llvm
 

--- a/llvm/lib/Target/SyncVM/SyncVMInstrInfo.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrInfo.cpp
@@ -246,6 +246,13 @@ MachineInstr::mop_iterator getStackAccess(MachineInstr &MI) {
   return {};
 }
 
+MachineInstr::mop_iterator getSecondStackAccess(MachineInstr &MI) {
+  if (SyncVM::hasSRInAddressingMode(MI) && SyncVM::hasSROutAddressingMode(MI)) {
+    return SyncVM::out0Iterator(MI);
+  }
+  return {};
+}
+
 } // namespace SyncVM
 } // namespace llvm
 

--- a/llvm/lib/Target/SyncVM/SyncVMInstrInfo.h
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrInfo.h
@@ -23,6 +23,8 @@ namespace SyncVM {
 int getPseudoMapOpcode(uint16_t);
 int getFlagSettingOpcode(uint16_t);
 int getNonFlagSettingOpcode(uint16_t);
+int withRegisterResult(uint16_t);
+int withStackResult(uint16_t);
 
 /// Return opcode of the instruction with RR input addressing mode otherwise
 /// identical to \p Opcode.

--- a/llvm/lib/Target/SyncVM/SyncVMInstrInfo.h
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrInfo.h
@@ -191,6 +191,11 @@ bool hasInvalidRelativeStackAccess(MachineInstr::const_mop_iterator Op);
 /// accesses, return an empty iterator.
 MachineInstr::mop_iterator getStackAccess(MachineInstr &MI);
 
+
+/// return iterator to the second stack access operand of \p MI. If there is no
+/// second stack access, return an empty iterator.
+MachineInstr::mop_iterator getSecondStackAccess(MachineInstr &MI);
+
 } // namespace SyncVM
 
 class SyncVMInstrInfo : public SyncVMGenInstrInfo {

--- a/llvm/lib/Target/SyncVM/SyncVMInstrInfo.h
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrInfo.h
@@ -187,6 +187,10 @@ inline StackAccess classifyStackAccess(MachineInstr::const_mop_iterator Op) {
 
 bool hasInvalidRelativeStackAccess(MachineInstr::const_mop_iterator Op);
 
+/// return iterator to the stack access operand of \p MI. If there is no stack
+/// accesses, return an empty iterator.
+MachineInstr::mop_iterator getStackAccess(MachineInstr &MI);
+
 } // namespace SyncVM
 
 class SyncVMInstrInfo : public SyncVMGenInstrInfo {

--- a/llvm/lib/Target/SyncVM/SyncVMInstrInfo.td
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrInfo.td
@@ -256,6 +256,9 @@ def ADJCALLSTACKUP   : Pseudo<(outs), (ins i256imm:$amt1, i256imm:$amt2),
 let isCodeGenOnly = 1, Defs = [Flags], Uses = [SP] in {
 def ADDframe : Pseudo<(outs GR256:$dst), (ins i256imm:$base, i256imm:$offset),
                       "# ADDframe PSEUDO", []>;
+// Same as ADDFrame, but do not scale the result.
+def ADDframeNoScaling : Pseudo<(outs GR256:$dst), (ins i256imm:$base, i256imm:$offset),
+                      "# ADDframe PSEUDO", []>;
 }
 
 let isCodeGenOnly = 1, isPseudo = 1, Uses = [Flags] in {

--- a/llvm/lib/Target/SyncVM/SyncVMRegisterInfo.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMRegisterInfo.cpp
@@ -84,14 +84,13 @@ void SyncVMRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator II,
     // Set that immediate represents stack slot index.
     SPInst->getOperand(1).setTargetFlags(SyncVMII::MO_STACK_SLOT_IDX);
 
-    if (MI.getOpcode() == SyncVM::ADDframe) {
+    if (MI.getOpcode() == SyncVM::ADDframe)
       BuildMI(MBB, II, DL, TII.get(SyncVM::MULirrr_s))
           .addDef(MI.getOperand(0).getReg())
           .addDef(SyncVM::R0)
           .addImm(32)
           .addReg(SPInst->getOperand(0).getReg())
           .addImm(SyncVMCC::COND_NONE);
-    }
     MI.eraseFromParent();
     return;
   }

--- a/llvm/lib/Target/SyncVM/SyncVMRegisterInfo.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMRegisterInfo.cpp
@@ -66,7 +66,8 @@ void SyncVMRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator II,
   int Offset = MF.getFrameInfo().getObjectOffset(FrameIndex);
   Offset -= MF.getFrameInfo().getStackSize();
 
-  if (MI.getOpcode() == SyncVM::ADDframe) {
+  if (MI.getOpcode() == SyncVM::ADDframe ||
+      MI.getOpcode() == SyncVM::ADDframeNoScaling) {
     auto SPInst = BuildMI(MBB, II, DL, TII.get(SyncVM::CTXr_se))
                       .addDef(MI.getOperand(0).getReg())
                       .addImm(SyncVMCTX::SP)
@@ -83,12 +84,14 @@ void SyncVMRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator II,
     // Set that immediate represents stack slot index.
     SPInst->getOperand(1).setTargetFlags(SyncVMII::MO_STACK_SLOT_IDX);
 
-    BuildMI(MBB, II, DL, TII.get(SyncVM::MULirrr_s))
-        .addDef(MI.getOperand(0).getReg())
-        .addDef(SyncVM::R0)
-        .addImm(32)
-        .addReg(SPInst->getOperand(0).getReg())
-        .addImm(SyncVMCC::COND_NONE);
+    if (MI.getOpcode() == SyncVM::ADDframe) {
+      BuildMI(MBB, II, DL, TII.get(SyncVM::MULirrr_s))
+          .addDef(MI.getOperand(0).getReg())
+          .addDef(SyncVM::R0)
+          .addImm(32)
+          .addReg(SPInst->getOperand(0).getReg())
+          .addImm(SyncVMCC::COND_NONE);
+    }
     MI.eraseFromParent();
     return;
   }

--- a/llvm/lib/Target/SyncVM/SyncVMRegisterInfo.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMRegisterInfo.cpp
@@ -84,6 +84,9 @@ void SyncVMRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator II,
     // Set that immediate represents stack slot index.
     SPInst->getOperand(1).setTargetFlags(SyncVMII::MO_STACK_SLOT_IDX);
 
+    // We do not do conversion to bytes for `ADDframeNoScaling`, because
+    // if there is a such node, we know that the use of it will see its 
+    // value as cells.
     if (MI.getOpcode() == SyncVM::ADDframe)
       BuildMI(MBB, II, DL, TII.get(SyncVM::MULirrr_s))
           .addDef(MI.getOperand(0).getReg())
@@ -91,6 +94,7 @@ void SyncVMRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator II,
           .addImm(32)
           .addReg(SPInst->getOperand(0).getReg())
           .addImm(SyncVMCC::COND_NONE);
+
     MI.eraseFromParent();
     return;
   }

--- a/llvm/lib/Target/SyncVM/SyncVMStackAddressConstantPropagation.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMStackAddressConstantPropagation.cpp
@@ -166,7 +166,7 @@ Register
 SyncVMStackAddressConstantPropagation::matchADDframe(MachineInstr &MI) const {
   if (MI.getOpcode() != SyncVM::ADDframe)
     return {};
-  return MI.getOperand(0).getReg();
+  return SyncVM::out0Iterator(MI)->getReg();
 }
 
 std::optional<PropagationResult>
@@ -254,11 +254,12 @@ bool SyncVMStackAddressConstantPropagation::foldAddFrame(
     return false;
 
   MachineInstr *DivDefMI = RegInfo->getVRegDef(DivReg);
+  assert(DivDefMI);
   Register FrameReg = matchADDframe(*DivDefMI);
   if (!FrameReg)
     return false;
 
-  Register AddFrameReturnReg = DivDefMI->getOperand(0).getReg();
+  Register AddFrameReturnReg = SyncVM::out0Iterator(*DivDefMI)->getReg();
   RegInfo->replaceRegWith(ScaledAndDescaledReg, AddFrameReturnReg);
 
   MI->eraseFromParent();

--- a/llvm/lib/Target/SyncVM/SyncVMStackAddressConstantPropagation.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMStackAddressConstantPropagation.cpp
@@ -51,87 +51,40 @@ private:
   // TODO: When FE start to produce LLVM arrays, it make sense to support
   // propagation through mul.
   std::optional<PropagationResult> tryPropagateConstant(MachineInstr &MI);
-  
 
+  // match an instruction pattern:
+  // %dst, $r0 = MULirrr_s 32, %src
+  // If it matches, return the register that are being scaled (%src)
+  Register matchScalingBy32(MachineInstr &MI) const;
 
-  // If an instruction takes a stack operand (either in or out), return the iterator
-  // for that stack access.
-  std::optional<std::pair<MopIter, MopIter>>
+  // If an instruction takes a stack operand (either in or out), return the
+  // iterators for that stack access (base and displacement iterators)
+  std::optional<
+      std::pair<MachineInstr::mop_iterator, MachineInstr::mop_iterator>>
   getStackAccess(MachineInstr &MI) const;
 
-  // fold ADDframe with DIV into AddframeNoScaling, which does not do cells to
+  // fold ADDframe with DIV into ADDframeNoScaling, which does not do cells to
   // bytes conversion
   bool foldAddFrame(MachineInstr* MI) const;
 
-  // match an instruction pattern:
-  // %dst, $r0 = MULirrr_s 32, %src 
-  // If it matches, return the register that are being scaled (%src)
-  Register matchScalingBy32(MachineInstr &MI) const {
-    if (MI.getOpcode() != SyncVM::MULirrr_s)
-      return {};
-    auto In0Const = SyncVM::in0Iterator(MI);
-    auto In1Reg = SyncVM::in1Iterator(MI)->getReg();
 
-    if (getImmOrCImm(*In0Const) != 32 ||
-        SyncVM::out1Iterator(MI)->getReg() != SyncVM::R0 || !In1Reg.isVirtual())
-      return {};
-    return In1Reg;
-  }
-  
-  Register isScaledBy32(Register Reg) const {
-    if (!Reg.isVirtual() || !RegInfo->hasOneDef(Reg))
-      return false;
-    MachineInstr* DefMI = RegInfo->getVRegDef(Reg);
-    if (matchScalingBy32(*DefMI))
-      return SyncVM::in1Iterator(*DefMI)->getReg();
-    else
-      return {};
-  }
+  // match pattern: %dst, $r0 = MULirrr_s 32, %src, where %dst is the input reg
+  // if it matches, return the register that are being scaled (%src)
+  Register isScaledBy32(Register Reg) const;
   
   // match an instruction pattern:
   // %dst, $r0 = DIVxrrr_s 32, %src 
   // If it matches, return the register that are being scaled (%src)
-  Register matchDescalingBy32(MachineInstr &MI) const {
-    if (MI.getOpcode() != SyncVM::DIVxrrr_s ||
-       getImmOrCImm(*SyncVM::in0Iterator(MI)) != 32)
-      return {};
-    auto In1Reg = SyncVM::in1Iterator(MI)->getReg();
-    if (!In1Reg.isVirtual() || 
-        SyncVM::out1Iterator (MI)->getReg() != SyncVM::R0 ||
-        !RegInfo->hasOneNonDBGUse(In1Reg))
-      return {};
-    return In1Reg;
-  }
+  Register matchDescalingBy32(MachineInstr &MI) const;
 
   // match and return the output result of ADDframe
-  Register matchADDframe(MachineInstr &MI) const {
-    if (MI.getOpcode() != SyncVM::ADDframe)
-      return {};
-    return MI.getOperand(0).getReg();
-  }
+  Register matchADDframe(MachineInstr &MI) const;
 
-  std::pair<Register, unsigned>
-  matchAddWithMultipleOf32(MachineInstr &MI) const {
-    if (MI.getOpcode() != SyncVM::ADDirr_s)
-      return {{}, 0};
-    auto In0Const = SyncVM::in0Iterator(MI);
-    
-    unsigned ConstAddValue = getImmOrCImm(*In0Const);
-    if (ConstAddValue % 32 != 0)
-      return {{}, 0};
-    auto In1Reg = SyncVM::in1Iterator(MI)->getReg();
-    if (!In1Reg.isVirtual())
-      return {{}, 0};
-    if (!RegInfo->hasOneNonDBGUse(In1Reg))
-      return {{}, 0};
-    return {In1Reg, ConstAddValue / 32};
-  }
+  // if match a = %reg + 32*b, return the %reg and the constant b
+  std::optional<std::pair<Register, unsigned>>
+  matchAddWithMultipleOf32(MachineInstr &MI) const;
 
-  MachineInstr* getDefOfRegister(Register Reg) const {
-    if (!Reg.isVirtual() || !RegInfo->hasOneDef(Reg))
-      return nullptr;
-    return RegInfo->getVRegDef(Reg);
-  }
+  MachineInstr* getDefOfRegister(Register Reg) const;
 
   const SyncVMInstrInfo *TII;
   MachineRegisterInfo *RegInfo;
@@ -143,6 +96,78 @@ char SyncVMStackAddressConstantPropagation::ID = 0;
 
 INITIALIZE_PASS(SyncVMStackAddressConstantPropagation, DEBUG_TYPE,
                 SYNCVM_STACK_ADDRESS_CONSTANT_PROPAGATION_NAME, false, false)
+
+// match an instruction pattern:
+// %dst, $r0 = MULirrr_s 32, %src
+// If it matches, return the register that are being scaled (%src)
+Register SyncVMStackAddressConstantPropagation::matchScalingBy32(
+    MachineInstr &MI) const {
+  if (MI.getOpcode() != SyncVM::MULirrr_s)
+    return {};
+  auto In0Const = SyncVM::in0Iterator(MI);
+  auto In1Reg = SyncVM::in1Iterator(MI)->getReg();
+
+  if (getImmOrCImm(*In0Const) != 32 ||
+      SyncVM::out1Iterator(MI)->getReg() != SyncVM::R0 || !In1Reg.isVirtual())
+    return {};
+  return In1Reg;
+}
+
+Register
+SyncVMStackAddressConstantPropagation::isScaledBy32(Register Reg) const {
+  if (!Reg.isVirtual() || !RegInfo->hasOneDef(Reg))
+    return false;
+  MachineInstr *DefMI = RegInfo->getVRegDef(Reg);
+  if (matchScalingBy32(*DefMI))
+    return SyncVM::in1Iterator(*DefMI)->getReg();
+  else
+    return {};
+}
+
+Register SyncVMStackAddressConstantPropagation::matchDescalingBy32(
+    MachineInstr &MI) const {
+  if (MI.getOpcode() != SyncVM::DIVxrrr_s ||
+      getImmOrCImm(*SyncVM::in0Iterator(MI)) != 32)
+    return {};
+  auto In1Reg = SyncVM::in1Iterator(MI)->getReg();
+  if (!In1Reg.isVirtual() || SyncVM::out1Iterator(MI)->getReg() != SyncVM::R0 ||
+      !RegInfo->hasOneNonDBGUse(In1Reg))
+    return {};
+  return In1Reg;
+}
+
+// if match a = %reg + 32*b, return the %reg and the constant b
+std::optional<std::pair<Register, unsigned>>
+SyncVMStackAddressConstantPropagation::matchAddWithMultipleOf32(
+    MachineInstr &MI) const {
+  if (MI.getOpcode() != SyncVM::ADDirr_s)
+    return std::nullopt;
+  auto In0Const = SyncVM::in0Iterator(MI);
+
+  unsigned ConstAddValue = getImmOrCImm(*In0Const);
+  if (ConstAddValue % 32 != 0)
+    return std::nullopt;
+  auto In1Reg = SyncVM::in1Iterator(MI)->getReg();
+  if (!In1Reg.isVirtual())
+    return std::nullopt;
+  if (!RegInfo->hasOneNonDBGUse(In1Reg))
+    return std::nullopt;
+  return std::make_pair(In1Reg, ConstAddValue / 32);
+}
+
+MachineInstr *
+SyncVMStackAddressConstantPropagation::getDefOfRegister(Register Reg) const {
+  if (!Reg.isVirtual() || !RegInfo->hasOneDef(Reg))
+    return nullptr;
+  return RegInfo->getVRegDef(Reg);
+}
+
+Register
+SyncVMStackAddressConstantPropagation::matchADDframe(MachineInstr &MI) const {
+  if (MI.getOpcode() != SyncVM::ADDframe)
+    return {};
+  return MI.getOperand(0).getReg();
+}
 
 std::optional<PropagationResult>
 SyncVMStackAddressConstantPropagation::tryPropagateConstant(MachineInstr &MI) {
@@ -197,7 +222,7 @@ SyncVMStackAddressConstantPropagation::tryPropagateConstant(MachineInstr &MI) {
   return PropagationResult{In1Reg, Displacement};
 }
 
-std::optional<std::pair<MopIter, MopIter>>
+std::optional<std::pair<MachineInstr::mop_iterator, MachineInstr::mop_iterator>>
 SyncVMStackAddressConstantPropagation::getStackAccess(MachineInstr &MI) const {
   // check if the stack access is in input operands
   if (SyncVM::hasSRInAddressingMode(MI)) {
@@ -298,13 +323,14 @@ bool SyncVMStackAddressConstantPropagation::runOnMachineFunction(
     if (!AddMI)
       return false;
 
-    auto [ScaledBaseReg, ScalingFactor] = matchAddWithMultipleOf32(*AddMI);
-    if (!ScaledBaseReg)
+    auto MatchedResult = matchAddWithMultipleOf32(*AddMI);
+    if (!MatchedResult)
       return false;
+    auto [ScaledBaseReg, ScalingFactor] = *MatchedResult;
     Register UnscaledReg = isScaledBy32(ScaledBaseReg);
-    MachineInstr *MulMI = RegInfo->getVRegDef(ScaledBaseReg);
     if (!UnscaledReg)
       return false;
+    MachineInstr *MulMI = RegInfo->getVRegDef(ScaledBaseReg);
 
     // now we can safely replace the register with the unscaled one, and add
     // offset

--- a/llvm/lib/Target/SyncVM/SyncVMStackAddressConstantPropagation.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMStackAddressConstantPropagation.cpp
@@ -257,15 +257,30 @@ bool SyncVMStackAddressConstantPropagation::runOnMachineFunction(
         Changed = true;
       }
     }
-  
-  for (auto &BB : MF)
-    for (auto &MI : BB) {
-      if (!SyncVM::hasSRInAddressingMode(MI))
-        continue;
+
+  auto getStackAccess = [&](MachineInstr &MI) {
+    if (SyncVM::hasSRInAddressingMode(MI)) {
       auto In0Reg = SyncVM::in0Iterator(MI) + 1;
       auto In0Const = SyncVM::in0Iterator(MI) + 2;
-      if (!In0Reg->isReg())
+      if (In0Reg->isReg())
+        return std::make_pair(In0Reg, In0Const);
+    }
+    // TODO: fix it
+    if (MI.getOpcode() == SyncVM::ADDirs_s) {
+      auto In0Reg = SyncVM::out0Iterator(MI) + 1;
+      auto In0Const = SyncVM::out0Iterator(MI) + 2;
+      if (In0Reg->isReg())
+        return std::make_pair(In0Reg, In0Const);
+    }
+    return std::make_pair(MI.operands_end(), MI.operands_end());
+  };
+
+  for (auto &BB : MF)
+    for (auto &MI : BB) {
+      auto [In0Reg, In0Const] = getStackAccess(MI);
+      if (In0Reg == MI.operands_end())
         continue;
+
       Register Base = In0Reg->getReg();
       MachineInstr *DivMI = RegInfo->getVRegDef(Base);
       

--- a/llvm/lib/Target/SyncVM/SyncVMTargetMachine.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMTargetMachine.cpp
@@ -152,8 +152,8 @@ bool SyncVMPassConfig::addInstSelector() {
 
 void SyncVMPassConfig::addPreRegAlloc() {
   addPass(createSyncVMAddConditionsPass());
-  addPass(createSyncVMStackAddressConstantPropagationPass());
   addPass(createSyncVMBytesToCellsPass());
+  addPass(createSyncVMStackAddressConstantPropagationPass());
   if (TM->getOptLevel() != CodeGenOpt::None) {
     // The pass combines sub.s! 0, x, y with x definition. It assumes only one
     // usage of every definition of Flags. This is guaranteed by the selection

--- a/llvm/test/CodeGen/SyncVM/array.ll
+++ b/llvm/test/CodeGen/SyncVM/array.ll
@@ -120,7 +120,7 @@ define i256 @alloca_const_loading(i256 %val) {
 
 ; CHECK-LABEL: arg_array_loading
 define i256 @arg_array_loading([10 x i256]* %array) {
-  ; CHECK:  div.s   32, r1, r1, r0
+  ; CHECK-NOT:  div.s   32, r1, r1, r0
   ; CHECK:  add     stack[5 + r1], r0, r1
   %idx_slot = getelementptr inbounds [10 x i256], [10 x i256]* %array, i256 0, i256 5
   %rv = load i256, i256* %idx_slot
@@ -140,7 +140,7 @@ define i256 @arg_array_loading2([10 x i256]* %array, i256 %idx) {
 
 ; CHECK-LABEL: arg_ptr_loading
 define i256 @arg_ptr_loading(i256* %array) {
-  ; CHECK:  div.s   32, r1, r1, r0
+  ; CHECK-NOT:  div.s   32, r1, r1, r0
   ; CHECK:  add     stack[5 + r1], r0, r1
   %idx_slot = getelementptr i256, i256* %array, i256 5
   %rv = load i256, i256* %idx_slot
@@ -164,6 +164,7 @@ define void @stack_array_passing() {
   ; CHECK:  context.sp      r[[REG3:[0-9]+]]
   ; CHECK:  sub.s   10, r[[REG3]], r[[REG4:[0-9]+]]
   ; CHECK:  mul     32, r[[REG4]], r1, r0
+  ; CHECK:  div
   ; CHECK:  near_call       r0, @array_arg, @DEFAULT_UNWIND
   %array = alloca [10 x i256], align 32
   call void @array_arg([10 x i256]* %array)

--- a/llvm/test/CodeGen/SyncVM/array.ll
+++ b/llvm/test/CodeGen/SyncVM/array.ll
@@ -163,8 +163,8 @@ define void @stack_array_passing() {
   ; CHECK:  nop     stack+=[10]
   ; CHECK:  context.sp      r[[REG3:[0-9]+]]
   ; CHECK:  sub.s   10, r[[REG3]], r[[REG4:[0-9]+]]
-  ; CHECK:  mul     32, r[[REG4]], r1, r0
-  ; CHECK:  div
+  ; CHECK-NOT:  mul
+  ; CHECK-NOT:  div
   ; CHECK:  near_call       r0, @array_arg, @DEFAULT_UNWIND
   %array = alloca [10 x i256], align 32
   call void @array_arg([10 x i256]* %array)
@@ -189,7 +189,7 @@ define void @stack_pointer_passing2() {
   ; CHECK: nop     stack+=[10]
   ; CHECK: context.sp      r[[REG6:[0-9]+]]
   ; CHECK: sub.s   10, r[[REG6]], r[[REG6]]
-  ; CHECK: mul     32, r[[REG6]], r1, r0
+  ; CHECK-NOT: mul
   %array = alloca [10 x i256], align 32
   call void @array_arg([10 x i256]* %array)
   ret void

--- a/llvm/test/CodeGen/SyncVM/bytes2cells.ll
+++ b/llvm/test/CodeGen/SyncVM/bytes2cells.ll
@@ -1,0 +1,205 @@
+; RUN: llc < %s | FileCheck %s
+target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
+target triple = "syncvm-unknown-unknown"
+
+; check that when base pointer is a stack address (passed down as argument in cells),
+; it is scaled for pointer arithmetics.
+; CHECK-LABEL: return_elem_var
+define ptr @return_elem_var(ptr %array, i256 %i) {
+; CHECK:      shl.s   5, r2, r2
+;	CHECK-NEXT: mul	    32, r1, r[[REG:[0-9]+]], r0
+; CHECK-NEXT: add     r[[REG]], r2
+  %addri = getelementptr inbounds [10 x i256], ptr %array, i256 0, i256 %i
+  store i256 0, ptr %addri
+  ret ptr %array
+}
+
+; pointer arithmetic result as return value
+; CHECK-LABEL: return_elem_var_2
+define ptr @return_elem_var_2(i256* %array) nounwind {
+  %addri = getelementptr inbounds [10 x i256], ptr %array, i256 0, i256 7
+  store i256 0, ptr %addri
+; CHECK:      mul	32, r1, r1, r0
+; CHECK-NEXT: add	224, r1, r1
+; CHECK-NOT: div.s 32, r1, r1, r0
+; CHECK-NEXT: ret
+  ret ptr %addri
+}
+
+; return stack pointer. return cell pointer as is
+; CHECK-LABEL: return_ptr
+define ptr @return_ptr(i256* %array) nounwind {
+  ; CHECK-NOT: mul
+  ret ptr %array
+}
+
+declare void @foo(ptr %val);
+
+; passing stack pointer in cells as argument
+; CHECK-LABEL: call_foo
+define void @call_foo() nounwind {
+; CHECK: context.sp      [[REG:r[0-9]+]]
+; CHECK: sub.s   1, [[REG]], [[REG2:r[0-9]+]]
+; CHECK: mul     32, [[REG2]], [[REG3:r[0-9]+]], r0
+; CHECK: div.s   32, [[REG3]], [[REG4:r[0-9]+]], r0
+; CHECK: near_call
+  %p = alloca i256
+  call void @foo(ptr %p)
+  ret void
+}
+
+declare ptr @bar();
+
+; passing stack pointer in cells as argument
+; CHECK-LABEL: call_bar
+define ptr @call_bar() nounwind {
+; CHECK-NOT: mul
+; CHECK-NOT: div
+  %p = call ptr @bar();
+  ret ptr %p
+}
+
+; passing stack pointer in cells as argument
+; CHECK-LABEL: call_bar2
+define ptr @call_bar2() nounwind {
+  %p = call ptr @bar();
+  %p2 = getelementptr inbounds [10 x i256], ptr %p, i256 0, i256 7
+; CHECK-NOT: div.s   32, [[REG_BAR:r[0-9]+]], r1, r0
+  store i256 0, ptr %p2
+  ret ptr %p2
+}
+
+; passing stack pointer
+; CHECK-LABEL: call_bar3
+define ptr @call_bar3() nounwind {
+; CHECK-NOT:      mul 32, r1, r1, r0
+; CHECK: add 224, r1, r1
+; CHECK-NOT: div.s 32, r1, r1, r0
+; CHECK: ret
+  %p = call ptr @bar();
+  %p2 = getelementptr inbounds [10 x i256], ptr %p, i256 0, i256 7
+  ret ptr %p2
+}
+
+
+; complicated case of pointer arithmetics, and return values
+; CHECK-LABEL: ZKSYNC_NEAR_CALL_16_args_tuple20
+define ptr @ZKSYNC_NEAR_CALL_16_args_tuple20(ptr %0, i256 %1, i256 %2, i256 %3, i256 %4, i256 %5, i256 %6, i256 %7, i256 %8, i256 %9, i256 %10, i256 %11, i256 %12, i256 %13, i256 %14, i256 %15, i256 %16) {
+entry:
+  %return_0_gep_pointer = getelementptr { i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256 }, ptr %0, i256 0, i32 0
+  store i256 0, ptr %return_0_gep_pointer, align 32
+  %return_1_gep_pointer = getelementptr { i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256 }, ptr %0, i256 0, i32 1
+  store i256 0, ptr %return_1_gep_pointer, align 32
+  %return_2_gep_pointer = getelementptr { i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256 }, ptr %0, i256 0, i32 2
+  store i256 0, ptr %return_2_gep_pointer, align 32
+  %return_3_gep_pointer = getelementptr { i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256 }, ptr %0, i256 0, i32 3
+  store i256 0, ptr %return_3_gep_pointer, align 32
+  %return_4_gep_pointer = getelementptr { i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256 }, ptr %0, i256 0, i32 4
+  store i256 0, ptr %return_4_gep_pointer, align 32
+  %return_5_gep_pointer = getelementptr { i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256 }, ptr %0, i256 0, i32 5
+  store i256 0, ptr %return_5_gep_pointer, align 32
+  %return_6_gep_pointer = getelementptr { i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256 }, ptr %0, i256 0, i32 6
+  store i256 0, ptr %return_6_gep_pointer, align 32
+  %return_7_gep_pointer = getelementptr { i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256 }, ptr %0, i256 0, i32 7
+  store i256 0, ptr %return_7_gep_pointer, align 32
+  %return_8_gep_pointer = getelementptr { i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256 }, ptr %0, i256 0, i32 8
+  store i256 0, ptr %return_8_gep_pointer, align 32
+  %return_9_gep_pointer = getelementptr { i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256 }, ptr %0, i256 0, i32 9
+  store i256 0, ptr %return_9_gep_pointer, align 32
+  %return_10_gep_pointer = getelementptr { i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256 }, ptr %0, i256 0, i32 10
+  store i256 0, ptr %return_10_gep_pointer, align 32
+  %return_11_gep_pointer = getelementptr { i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256 }, ptr %0, i256 0, i32 11
+  store i256 0, ptr %return_11_gep_pointer, align 32
+  %return_12_gep_pointer = getelementptr { i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256 }, ptr %0, i256 0, i32 12
+  store i256 0, ptr %return_12_gep_pointer, align 32
+  %return_13_gep_pointer = getelementptr { i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256 }, ptr %0, i256 0, i32 13
+  store i256 0, ptr %return_13_gep_pointer, align 32
+  %return_14_gep_pointer = getelementptr { i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256 }, ptr %0, i256 0, i32 14
+  store i256 0, ptr %return_14_gep_pointer, align 32
+  %return_15_gep_pointer = getelementptr { i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256 }, ptr %0, i256 0, i32 15
+  store i256 0, ptr %return_15_gep_pointer, align 32
+  %return_16_gep_pointer = getelementptr { i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256 }, ptr %0, i256 0, i32 16
+  store i256 0, ptr %return_16_gep_pointer, align 32
+  %return_17_gep_pointer = getelementptr { i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256 }, ptr %0, i256 0, i32 17
+  store i256 0, ptr %return_17_gep_pointer, align 32
+  %return_18_gep_pointer = getelementptr { i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256 }, ptr %0, i256 0, i32 18
+  store i256 0, ptr %return_18_gep_pointer, align 32
+  %return_19_gep_pointer = getelementptr { i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256 }, ptr %0, i256 0, i32 19
+  store i256 0, ptr %return_19_gep_pointer, align 32
+  %arg1 = alloca i256, align 32
+  store i256 %1, ptr %arg1, align 32
+  %arg2 = alloca i256, align 32
+  store i256 %2, ptr %arg2, align 32
+  %arg3 = alloca i256, align 32
+  store i256 %3, ptr %arg3, align 32
+  %arg4 = alloca i256, align 32
+  store i256 %4, ptr %arg4, align 32
+  %arg5 = alloca i256, align 32
+  store i256 %5, ptr %arg5, align 32
+  %arg6 = alloca i256, align 32
+  store i256 %6, ptr %arg6, align 32
+  %arg7 = alloca i256, align 32
+  store i256 %7, ptr %arg7, align 32
+  %arg8 = alloca i256, align 32
+  store i256 %8, ptr %arg8, align 32
+  %arg9 = alloca i256, align 32
+  store i256 %9, ptr %arg9, align 32
+  %arg10 = alloca i256, align 32
+  store i256 %10, ptr %arg10, align 32
+  %arg11 = alloca i256, align 32
+  store i256 %11, ptr %arg11, align 32
+  %arg12 = alloca i256, align 32
+  store i256 %12, ptr %arg12, align 32
+  %arg13 = alloca i256, align 32
+  store i256 %13, ptr %arg13, align 32
+  %arg14 = alloca i256, align 32
+  store i256 %14, ptr %arg14, align 32
+  %arg15 = alloca i256, align 32
+  store i256 %15, ptr %arg15, align 32
+  %arg16 = alloca i256, align 32
+  store i256 %16, ptr %arg16, align 32
+  br label %invoke_success_block
+
+return:                                           ; preds = %invoke_success_block
+  ret ptr %0
+
+invoke_success_block:                             ; preds = %entry
+  %arg17 = load i256, ptr %arg1, align 32
+  store i256 %arg17, ptr %return_0_gep_pointer, align 32
+  %arg28 = load i256, ptr %arg2, align 32
+  store i256 %arg28, ptr %return_1_gep_pointer, align 32
+  %arg39 = load i256, ptr %arg3, align 32
+  store i256 %arg39, ptr %return_2_gep_pointer, align 32
+  %arg410 = load i256, ptr %arg4, align 32
+  store i256 %arg410, ptr %return_3_gep_pointer, align 32
+  %arg511 = load i256, ptr %arg5, align 32
+  store i256 %arg511, ptr %return_4_gep_pointer, align 32
+  %arg612 = load i256, ptr %arg6, align 32
+  store i256 %arg612, ptr %return_5_gep_pointer, align 32
+  %arg713 = load i256, ptr %arg7, align 32
+  store i256 %arg713, ptr %return_6_gep_pointer, align 32
+  %arg814 = load i256, ptr %arg8, align 32
+  store i256 %arg814, ptr %return_7_gep_pointer, align 32
+  %arg915 = load i256, ptr %arg9, align 32
+  store i256 %arg915, ptr %return_8_gep_pointer, align 32
+  %arg1016 = load i256, ptr %arg10, align 32
+  store i256 %arg1016, ptr %return_9_gep_pointer, align 32
+  %arg1117 = load i256, ptr %arg11, align 32
+  store i256 %arg1117, ptr %return_10_gep_pointer, align 32
+  %arg1218 = load i256, ptr %arg12, align 32
+  store i256 %arg1218, ptr %return_11_gep_pointer, align 32
+  %arg1319 = load i256, ptr %arg13, align 32
+  store i256 %arg1319, ptr %return_12_gep_pointer, align 32
+  %arg1420 = load i256, ptr %arg14, align 32
+  store i256 %arg1420, ptr %return_13_gep_pointer, align 32
+  %arg1521 = load i256, ptr %arg15, align 32
+  store i256 %arg1521, ptr %return_14_gep_pointer, align 32
+  %arg1622 = load i256, ptr %arg16, align 32
+  store i256 %arg1622, ptr %return_15_gep_pointer, align 32
+  store i256 17, ptr %return_16_gep_pointer, align 32
+  store i256 18, ptr %return_17_gep_pointer, align 32
+  store i256 19, ptr %return_18_gep_pointer, align 32
+  store i256 20, ptr %return_19_gep_pointer, align 32
+  br label %return
+}
+

--- a/llvm/test/CodeGen/SyncVM/bytes2cells.ll
+++ b/llvm/test/CodeGen/SyncVM/bytes2cells.ll
@@ -40,8 +40,8 @@ declare void @foo(ptr %val);
 define void @call_foo() nounwind {
 ; CHECK: context.sp      [[REG:r[0-9]+]]
 ; CHECK: sub.s   1, [[REG]], [[REG2:r[0-9]+]]
-; CHECK: mul     32, [[REG2]], [[REG3:r[0-9]+]], r0
-; CHECK: div.s   32, [[REG3]], [[REG4:r[0-9]+]], r0
+; CHECK-NOT: mul
+; CHECK-NOT: div.s
 ; CHECK: near_call
   %p = alloca i256
   call void @foo(ptr %p)

--- a/llvm/test/CodeGen/SyncVM/compound.ll
+++ b/llvm/test/CodeGen/SyncVM/compound.ll
@@ -12,7 +12,7 @@ define void @array_ldst_to_parameter([10 x i256]* %array, i256 %val) {
   %2 = add i256 %1, %val
   %idx2 = getelementptr inbounds [10 x i256], [10 x i256]* %array, i256 0, i256 2
   store i256 %2, i256* %idx2
-; CHECK: div.s 32, r1, r1, r0
+; CHECK-NOT: div.s 32, r1, r1, r0
 ; CHECK: add stack[6 + r1], r2, stack[2 + r1]
   ret void
 }

--- a/llvm/test/CodeGen/SyncVM/memintrinsics.ll
+++ b/llvm/test/CodeGen/SyncVM/memintrinsics.ll
@@ -12,8 +12,10 @@ define fastcc void @huge-copysize0(i256 addrspace(0)* %dest, i256 addrspace(0)* 
 ; CHECK:   add     r0, r0, [[INDEX0:r[0-9]+]]
 ; CHECK: .BB0_1:
 ; CHECK:   shl.s   5, [[INDEX0]], [[SHIFTED_OFFSET0_SRC:r[0-9]+]]
-; CHECK:   add     r1, [[SHIFTED_OFFSET0_SRC]], [[SHIFTED_OFFSET0_DST:r[0-9]+]]
-; CHECK:   add     r2, [[SHIFTED_OFFSET0_SRC]], [[SHIFTED_OFFSET0_SRC]]
+; CHECK:   mul     32, r1, [[SCALED_R1:r[0-9]+]], r0
+; CHECK:   add     [[SCALED_R1]], [[SHIFTED_OFFSET0_SRC]], [[SHIFTED_OFFSET0_DST:r[0-9]+]]
+; CHECK:   mul     32, r2, [[SCALED_R2:r[0-9]+]], r0
+; CHECK:   add     [[SCALED_R2]], [[SHIFTED_OFFSET0_SRC]], [[SHIFTED_OFFSET0_SRC]]
 ; CHECK:   div.s   32, [[SHIFTED_OFFSET0_SRC]], [[SHIFTED_OFFSET0_SRC]], r0
 ; CHECK:   add     stack[[[SHIFTED_OFFSET0_SRC]]], r0, [[LOADED_VALUE0:r[0-9]+]]
 ; CHECK:   div.s   32, [[SHIFTED_OFFSET0_DST]], [[SHIFTED_OFFSET0_DST]], r0
@@ -89,8 +91,10 @@ define fastcc void @normal-known-size(i256* %dest, i256* %src) {
 ; CHECK:   add     r0, r0, [[INDEX3:r[3-9]+]]
 ; CHECK: .BB3_1:
 ; CHECK:   shl.s   5, [[INDEX3]], [[SHIFTED_OFFSET3_SRC:r[3-9]+]]
-; CHECK:   add     r1, [[SHIFTED_OFFSET3_SRC]], [[SHIFTED_OFFSET3_DST:r[3-9]+]]
-; CHECK:   add     r2, [[SHIFTED_OFFSET3_SRC]], [[SHIFTED_OFFSET3_SRC]]
+; CHECK:   mul     32, r1, [[SCALED_R1:r[3-9]+]], r0
+; CHECK:   add     [[SCALED_R1]], [[SHIFTED_OFFSET3_SRC]], [[SHIFTED_OFFSET3_DST:r[3-9]+]]
+; CHECK:   mul     32, r2, [[SCALED_R2:r[3-9]+]], r0 
+; CHECK:   add     [[SCALED_R2]], [[SHIFTED_OFFSET3_SRC]], [[SHIFTED_OFFSET3_SRC]]
 ; CHECK:   div.s   32, [[SHIFTED_OFFSET3_SRC]], [[SHIFTED_OFFSET3_SRC]], r0
 ; CHECK:   add     stack[[[SHIFTED_OFFSET3_SRC]]], r0, [[LOADED_VALUE3:r[3-9]+]]
 ; CHECK:   div.s   32, [[SHIFTED_OFFSET3_DST]], [[SHIFTED_OFFSET3_DST]], r0
@@ -108,8 +112,10 @@ define fastcc void @normal-known-size-2(i256* %dest, i256* %src) {
 ; CHECK:   add     r0, r0, [[INDEX4:r[3-9]+]]
 ; CHECK: .BB4_1:
 ; CHECK:   shl.s   5, [[INDEX4]], [[SHIFTED_OFFSET4_SRC:r[3-9]+]]
-; CHECK:   add     r1, [[SHIFTED_OFFSET4_SRC]], [[SHIFTED_OFFSET4_DST:r[3-9]+]]
-; CHECK:   add     r2, [[SHIFTED_OFFSET4_SRC]], [[SHIFTED_OFFSET4_SRC]]
+; CHECK:   mul     32, r1, [[SCALED_R1:r[3-9]+]], r0
+; CHECK:   add     [[SCALED_R1]], [[SHIFTED_OFFSET4_SRC]], [[SHIFTED_OFFSET4_DST:r[3-9]+]]
+; CHECK:   mul     32, r2, [[SCALED_R2:r[3-9]+]], r0
+; CHECK:   add     [[SCALED_R2]], [[SHIFTED_OFFSET4_SRC]], [[SHIFTED_OFFSET4_SRC]]
 ; CHECK:   div.s   32, [[SHIFTED_OFFSET4_SRC]], [[SHIFTED_OFFSET4_SRC]], r0
 ; CHECK:   add     stack[[[SHIFTED_OFFSET4_SRC]]], r0, [[LOADED_VALUE4:r[3-9]+]]
 ; CHECK:   div.s   32, [[SHIFTED_OFFSET4_DST]], [[SHIFTED_OFFSET4_DST]], r0
@@ -118,10 +124,10 @@ define fastcc void @normal-known-size-2(i256* %dest, i256* %src) {
 ; CHECK:   sub.s!  33, [[INDEX4]], r{{[0-9]+}}
 ; CHECK:   jump.lt @.BB4_1
 ; CHECK:   add     @CPI4_0[0], r0, [[SRCMASK4:r[0-9]+]]
-; CHECK:   div.s   32, r2, r2, r0
+; CHECK-NOT:   div.s   32, r2, r2, r0
 ; CHECK:   and     stack[33 + r2], [[SRCMASK4]], [[SRCMASKED_VALUE4:r[0-9]+]]
 ; CHECK:   add     @CPI4_1[0], r0, [[DSTMASK4:r[0-9]+]]
-; CHECK:   div.s   32, r1, r1, r0
+; CHECK-NOT:   div.s   32, r1, r1, r0
 ; CHECK:   and     stack[33 + r1], [[DSTMASK4]], [[DSTMASKED_VALUE4:r[0-9]+]]
 ; CHECK:   or      [[SRCMASKED_VALUE4]], [[DSTMASKED_VALUE4]], stack[33 + r1]
   call void @llvm.memcpy.p0i256.p0i256.i256(i256* %dest, i256* %src, i256 1060, i1 false)

--- a/llvm/test/CodeGen/SyncVM/stack-address.ll
+++ b/llvm/test/CodeGen/SyncVM/stack-address.ll
@@ -1,5 +1,5 @@
 ; RUN: llc < %s | FileCheck %s
-; RUN: llc --early-bytes-to-cells-conversion < %s | FileCheck %s --check-prefix=EARLY-BTC
+; RUN: llc --early-bytes-to-cells-conversion -opaque-pointers < %s | FileCheck %s --check-prefix=EARLY-BTC
 
 target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "syncvm"
@@ -31,22 +31,19 @@ entry:
   %gep1 = getelementptr [4 x i256], [4 x i256]* %ptr.arr, i256 0, i256 1
   %gep2 = getelementptr [4 x i256], [4 x i256]* %ptr.arr, i256 0, i256 2
   %gep3 = getelementptr [4 x i256], [4 x i256]* %ptr.arr, i256 0, i256 3
-; EARLY-BTC: div.s 32, r3, r{{[0-9]*}}, r0
-; EARLY-BTC: div.s 32, r2, r{{[0-9]*}}, r0
-; EARLY-BTC: div.s 32, r1, r{{[0-9]*}}, r0
 ; EARLY-BTC: jump.eq @.BB1_2
   %x = icmp eq i256* %ptr.i256, null
   br i1 %x, label %fail, label %bb
 bb:
 ; CHECK: jump.eq @.BB1_2
 ; CHECK: add stack[r2], r0, r{{[0-9]*}}
-; CHECK: div.s 32, r1, r1, r0
+; CHECK-NOT: div.s 32
 ; CHECK: add stack[r1], r4, r1
 ; CHECK: add stack[1 + r2], r1, r1
 ; CHECK: add stack[2 + r2], r1, r1
 ; CHECK: add stack[3 + r2], r1, r1
-; CHECK: div.s 32, r3, r2, r0
-; CHECK: add stack[r2], r1, r1
+; CHECK-NOT: div.s 32
+; CHECK: add stack[r3], r1, r1
   %v1 = load i256, i256* %ptr.i256
   %v2 = load i256, i256* %gep0
   %v3 = load i256, i256* %gep1
@@ -100,4 +97,18 @@ define void @store_fat_ptr(i8 addrspace(3)** %ptr) {
   %val = load i8 addrspace(3)*, i8 addrspace(3)** @fatptr, align 32
   store i8 addrspace(3)* %val, i8 addrspace(3)** %ptr
   ret void
+}
+
+; check that when we are returning a stack address (passed down as argument in cells)
+; it is returned in bytes.
+; CHECK-LABEL: return_stack_address
+define i256* @return_stack_address(i256* %0) {
+entry:
+  %return_0_gep_pointer = getelementptr i256, i256* %0, i256 0
+  store i256 0, i256* %return_0_gep_pointer, align 32
+  %return_1_gep_pointer = getelementptr i256, i256* %0, i32 1
+  store i256 0, i256* %return_1_gep_pointer, align 32
+; CHECK:      mul     32, r1, r1, r0
+; CHECK-NEXT: ret
+  ret i256* %0
 }

--- a/llvm/test/CodeGen/SyncVM/stack-address.ll
+++ b/llvm/test/CodeGen/SyncVM/stack-address.ll
@@ -69,13 +69,13 @@ define i256 @stack.obj.passing() {
   %elem = getelementptr [2 x i256], [2 x i256]* %elem.cont, i256 0, i256 0
 ; CHECK: context.sp r1
 ; CHECK: sub.s 7, r1, r1
-; CHECK: mul 32, r1, r1, r0
+; CHECK-NOT: mul
 ; CHECK: context.sp r2
 ; CHECK: sub.s 4, r2, r2
-; CHECK: mul 32, r2, r2, r0
+; CHECK-NOT: mul
 ; CHECK: context.sp r3
 ; CHECK: sub.s 6, r3, r3
-; CHECK: mul 32, r3, r3, r0
+; CHECK-NOT: mul
 ; CHECK: near_call	r0, @stack.obj.accessing, @DEFAULT_UNWIND
   %res = call i256 @stack.obj.accessing(i256* %par1, [4 x i256]* %arr, i256* %elem)
   ret i256 %res

--- a/llvm/test/CodeGen/SyncVM/uma.ll
+++ b/llvm/test/CodeGen/SyncVM/uma.ll
@@ -70,7 +70,7 @@ define void @umai.store_heapaux(i256 %val) nounwind {
 ; CHECK-LABEL: st1inc
 define void @st1inc(i256 addrspace(1)* %addr, i256 %val) nounwind {
  store i256 %val, i256 addrspace(1)* %addr
-; CHECK: st.1.inc r1, r2, r1
+; TODO: st.1.inc r1, r2, r1
 ; CHECK: st.1 r1, r2
  %newaddr1 = getelementptr i256, i256 addrspace(1)* %addr, i256 1
  %na1 = add i256 %val, 1024
@@ -81,7 +81,7 @@ define void @st1inc(i256 addrspace(1)* %addr, i256 %val) nounwind {
 ; CHECK-LABEL: st2inc
 define void @st2inc(i256 addrspace(2)* %addr, i256 %val) nounwind {
  store i256 %val, i256 addrspace(2)* %addr
-; CHECK: st.2.inc r1, r2, r1
+; TODO: st.2.inc r1, r2, r1
 ; CHECK: st.2 r1, r2
  %newaddr1 = getelementptr i256, i256 addrspace(2)* %addr, i256 1
  %na1 = add i256 %val, 1024
@@ -102,8 +102,8 @@ define i256 @ldinc(i256 addrspace(3)* %addr) nounwind {
 
 ; CHECK-LABEL: ld1inc
 define i256 @ld1inc(i256 addrspace(1)* %addr) nounwind {
-; CHECK: ld.1.inc r1, r1, r2
-; CHECK: ld.1 r2, r2
+; TODO: ld.1.inc r1, r1, r2
+; TODO: ld.1 r2, r2
  %val = load i256, i256 addrspace(1)* %addr
  %newaddr1 = getelementptr i256, i256 addrspace(1)* %addr, i256 1
  %val1 = load i256, i256 addrspace(1)* %newaddr1
@@ -113,8 +113,8 @@ define i256 @ld1inc(i256 addrspace(1)* %addr) nounwind {
 
 ; CHECK-LABEL: ld2inc
 define i256 @ld2inc(i256 addrspace(2)* %addr) nounwind {
-; CHECK: ld.2.inc r1, r1, r2
-; CHECK: ld.2 r2, r2
+; TODO: ld.2.inc r1, r1, r2
+; TODO: ld.2 r2, r2
  %val = load i256, i256 addrspace(2)* %addr
  %newaddr1 = getelementptr i256, i256 addrspace(2)* %addr, i256 1
  %val1 = load i256, i256 addrspace(2)* %newaddr1

--- a/llvm/test/CodeGen/SyncVM/uma.ll
+++ b/llvm/test/CodeGen/SyncVM/uma.ll
@@ -70,7 +70,7 @@ define void @umai.store_heapaux(i256 %val) nounwind {
 ; CHECK-LABEL: st1inc
 define void @st1inc(i256 addrspace(1)* %addr, i256 %val) nounwind {
  store i256 %val, i256 addrspace(1)* %addr
-; TODO: st.1.inc r1, r2, r1
+; CHECK: st.1.inc r1, r2, r1
 ; CHECK: st.1 r1, r2
  %newaddr1 = getelementptr i256, i256 addrspace(1)* %addr, i256 1
  %na1 = add i256 %val, 1024
@@ -81,7 +81,7 @@ define void @st1inc(i256 addrspace(1)* %addr, i256 %val) nounwind {
 ; CHECK-LABEL: st2inc
 define void @st2inc(i256 addrspace(2)* %addr, i256 %val) nounwind {
  store i256 %val, i256 addrspace(2)* %addr
-; TODO: st.2.inc r1, r2, r1
+; CHECK: st.2.inc r1, r2, r1
 ; CHECK: st.2 r1, r2
  %newaddr1 = getelementptr i256, i256 addrspace(2)* %addr, i256 1
  %na1 = add i256 %val, 1024
@@ -102,8 +102,8 @@ define i256 @ldinc(i256 addrspace(3)* %addr) nounwind {
 
 ; CHECK-LABEL: ld1inc
 define i256 @ld1inc(i256 addrspace(1)* %addr) nounwind {
-; TODO: ld.1.inc r1, r1, r2
-; TODO: ld.1 r2, r2
+; CHECK: ld.1.inc r1, r1, r2
+; CHECK: ld.1 r2, r2
  %val = load i256, i256 addrspace(1)* %addr
  %newaddr1 = getelementptr i256, i256 addrspace(1)* %addr, i256 1
  %val1 = load i256, i256 addrspace(1)* %newaddr1
@@ -113,8 +113,8 @@ define i256 @ld1inc(i256 addrspace(1)* %addr) nounwind {
 
 ; CHECK-LABEL: ld2inc
 define i256 @ld2inc(i256 addrspace(2)* %addr) nounwind {
-; TODO: ld.2.inc r1, r1, r2
-; TODO: ld.2 r2, r2
+; CHECK: ld.2.inc r1, r1, r2
+; CHECK: ld.2 r2, r2
  %val = load i256, i256 addrspace(2)* %addr
  %newaddr1 = getelementptr i256, i256 addrspace(2)* %addr, i256 1
  %val1 = load i256, i256 addrspace(2)* %newaddr1


### PR DESCRIPTION
This patch changes some part of the calling convention: if we are passing stack pointers to function calls, pass the pointer values in bytes. The return values are still in bytes.
