### PR TITLE
Prevent combining predicated uses of a reloaded value

### DIFF
--- a/llvm/lib/Target/SyncVM/SyncVMCombineReloadUse.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMCombineReloadUse.cpp
@@ -273,8 +273,13 @@ bool SyncVMCombineReloadUse::combineReloadUse(MachineFunction &MF) {
                     return false;
                 if (!SyncVM::hasRRInAddressingMode(*Use))
                   return false;
+                // After IfConversion is done, some uses could be predicated,
+                // thus require more in-depth analysis to combine. Ignore such
+                // cases as unlikely to worth the effort.
+                if (getImmOrCImm(*SyncVM::ccIterator(*Use)) != SyncVMCC::COND_NONE)
+                  return false;
                 // Can't use the same stack slot twice because stack-stack is
-                // not a valid addressing mode.
+                // not a valid addressing mode with an unpredicated reload.
                 if (SyncVM::in0Iterator(*Use)->getReg() == Def &&
                     SyncVM::in1Iterator(*Use)->getReg() != Def)
                   return true;

--- a/llvm/test/CodeGen/SyncVM/reload-use.ll
+++ b/llvm/test/CodeGen/SyncVM/reload-use.ll
@@ -470,6 +470,24 @@ define void @swapinv(i256 %a) nounwind {
   ret void
 }
 
+; CHECK-LABEL: dont_combine_predicated_use
+define i256 @dont_combine_predicated_use(i256 %a, i1 %cond) nounwind {
+  %slot1 = alloca i256
+  %b = call i256 @foo()
+  %s1val = load i256, i256* %slot1
+  br i1 %cond, label %ltrue, label %lfalse
+; CHECK: add stack-[2], r0, r2
+; CHECK: sub! stack-[1], r0, r3
+; TODO: In that particular case we can combine, but it isn't analyzed in the pass.
+; CHECK: add.eq r2, r0, r1
+; CHECK: add.ne r2, r1, r1
+ltrue:
+  %res = add i256 %s1val, %b
+  ret i256 %res
+lfalse:
+  ret i256 %s1val
+}
+
 declare i8 addrspace(3)* @llvm.syncvm.ptr.add(i8 addrspace(3)*, i256)
 declare i8 addrspace(3)* @llvm.syncvm.ptr.pack(i8 addrspace(3)*, i256)
 declare i8 addrspace(3)* @llvm.syncvm.ptr.shrink(i8 addrspace(3)*, i256)


### PR DESCRIPTION
IfConvertion made possible to have predicated values before SEL
unrolling. The patch fixes broken invariant in SyncVMCombineReloadUse.