### PR TITLE
[MachineOutliner] Don't cache TII and change name of fixupPostOutline

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetInstrInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetInstrInfo.h
@@ -1994,8 +1994,8 @@ public:
   }
 
   // SyncVM local begin
-  /// Do a fixup post outline.
-  virtual void fixupPostOutline(
+  /// Do a fixup post outlining.
+  virtual void fixupPostOutlining(
       std::vector<std::pair<MachineFunction *, std::vector<MachineFunction *>>>
           &FixupFunctions) const {}
   // SyncVM local end

--- a/llvm/lib/Target/SyncVM/SyncVMInstrInfo.cpp
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrInfo.cpp
@@ -998,7 +998,7 @@ MachineBasicBlock::iterator SyncVMInstrInfo::insertOutlinedCall(
   return It;
 }
 
-void SyncVMInstrInfo::fixupPostOutline(
+void SyncVMInstrInfo::fixupPostOutlining(
     std::vector<std::pair<MachineFunction *, std::vector<MachineFunction *>>>
         &FixupFunctions) const {
   // First, adjust all outlined functions with MachineOutlinerDefault strategy.

--- a/llvm/lib/Target/SyncVM/SyncVMInstrInfo.h
+++ b/llvm/lib/Target/SyncVM/SyncVMInstrInfo.h
@@ -356,7 +356,7 @@ public:
                      MachineBasicBlock::iterator &It, MachineFunction &MF,
                      outliner::Candidate &C) const override;
 
-  /// Do a fixup post outline.
+  /// Do a fixup post outlining.
   /// We are doing fixup in three phasses:
   ///   1. Adjust outlined functions and callers that have to put return address
   ///      onto the stack.
@@ -370,7 +370,7 @@ public:
   /// all their callers to preserve correctness. Also, doing like this, we could
   /// end up saving 1 instruction in a frameless function if we don't need to
   /// adjust it.
-  void fixupPostOutline(
+  void fixupPostOutlining(
       std::vector<std::pair<MachineFunction *, std::vector<MachineFunction *>>>
           &FixupFunctions) const override;
 


### PR DESCRIPTION
Don't cache TII objects because they may change during compilation and since AArch64 and Arm instruction info have fixupPostOutline method, change name to fixupPostOutlining to fix compiler warnings.