### PR TITLE
[SyncVM] Fix exponent constant folding implementation for 0^0 case.

### DIFF
--- a/llvm/include/llvm/Analysis/TargetLibraryInfo.def
+++ b/llvm/include/llvm/Analysis/TargetLibraryInfo.def
@@ -301,6 +301,11 @@ TLI_DEFINE_STRING_INTERNAL("__cxa_guard_acquire")
 /// void __cxa_guard_release(guard_t *guard);
 TLI_DEFINE_ENUM_INTERNAL(cxa_guard_release)
 TLI_DEFINE_STRING_INTERNAL("__cxa_guard_release")
+// SyncVM local begin
+// i256 __exp(i255, i256, i256)
+TLI_DEFINE_ENUM_INTERNAL(xvm_exp)
+TLI_DEFINE_STRING_INTERNAL("__exp")
+// SyncVM local end
 /// double __exp10_finite(double x);
 TLI_DEFINE_ENUM_INTERNAL(exp10_finite)
 TLI_DEFINE_STRING_INTERNAL("__exp10_finite")
@@ -328,11 +333,6 @@ TLI_DEFINE_STRING_INTERNAL("__expf_finite")
 /// long double __expl_finite(long double x);
 TLI_DEFINE_ENUM_INTERNAL(expl_finite)
 TLI_DEFINE_STRING_INTERNAL("__expl_finite")
-// SyncVM local begin
-// i256 __exponent(i255, i256, i256)
-TLI_DEFINE_ENUM_INTERNAL(xvm_exponent)
-TLI_DEFINE_STRING_INTERNAL("__exponent")
-// SyncVM local end
 /// int __isoc99_scanf (const char *format, ...)
 TLI_DEFINE_ENUM_INTERNAL(dunder_isoc99_scanf)
 TLI_DEFINE_STRING_INTERNAL("__isoc99_scanf")

--- a/llvm/lib/Analysis/TargetLibraryInfo.cpp
+++ b/llvm/lib/Analysis/TargetLibraryInfo.cpp
@@ -824,7 +824,7 @@ static void initialize(TargetLibraryInfoImpl &TLI, const Triple &T,
   if (T.isSyncVM()) {
     TLI.disableAllFunctions();
     TLI.setAvailable(llvm::LibFunc_xvm_addmod);
-    TLI.setAvailable(llvm::LibFunc_xvm_exponent);
+    TLI.setAvailable(llvm::LibFunc_xvm_exp);
     TLI.setAvailable(llvm::LibFunc_xvm_mulmod);
     TLI.setAvailable(llvm::LibFunc_xvm_signextend);
     return;
@@ -1559,7 +1559,7 @@ bool TargetLibraryInfoImpl::isValidProtoForLibFunc(const FunctionType &FTy,
     return (NumParams == 1 && FTy.getParamType(0)->isPointerTy());
 
   // SyncVM local begin
-  case LibFunc_xvm_exponent:
+  case LibFunc_xvm_exp:
   case LibFunc_xvm_signextend:
     return (NumParams == 2 && FTy.getParamType(0)->isIntegerTy(256) &&
             FTy.getParamType(1)->isIntegerTy(256) &&

--- a/llvm/lib/Target/SyncVM/syncvm-stdlib.ll
+++ b/llvm/lib/Target/SyncVM/syncvm-stdlib.ll
@@ -205,7 +205,7 @@ define i256 @__signextend(i256 %numbyte, i256 %value) #0 {
   ret i256 %result
 }
 
-define i256 @__exponent(i256 %value, i256 %exp) #0 {
+define i256 @__exp(i256 %value, i256 %exp) #0 {
 entry:
   %exp_is_non_zero = icmp eq i256 %exp, 0
   br i1 %exp_is_non_zero, label %return, label %exponent_loop_body
@@ -237,4 +237,4 @@ define void @__cxa_throw(i8* %addr, i8*, i8*) noinline {
 declare {i256, i1} @llvm.uadd.with.overflow.i256(i256, i256)
 declare void @llvm.syncvm.throw(i256)
 
-attributes #0 = { mustprogress nounwind readnone willreturn}
+attributes #0 = { mustprogress nounwind readnone willreturn }

--- a/llvm/lib/Transforms/Utils/BuildLibCalls.cpp
+++ b/llvm/lib/Transforms/Utils/BuildLibCalls.cpp
@@ -1095,7 +1095,7 @@ bool llvm::inferNonMandatoryLibFuncAttrs(Function &F,
     break;
   // SyncVM local begin
   case LibFunc_xvm_addmod:
-  case LibFunc_xvm_exponent:
+  case LibFunc_xvm_exp:
   case LibFunc_xvm_mulmod:
   case LibFunc_xvm_signextend:
     Changed |= setDoesNotThrow(F);

--- a/llvm/test/CodeGen/SyncVM/array.ll
+++ b/llvm/test/CodeGen/SyncVM/array.ll
@@ -9,9 +9,8 @@ target triple = "syncvm"
 
 ; CHECK-LABEL: consti_loadconst_storeglobal
 define void @consti_loadconst_storeglobal() nounwind {
-  ; CHECK: add	@const[1], r0, r1
+  ; CHECK: add @const[1], r0, stack[@val+1]
   %1 = load i256, ptr addrspace(4) getelementptr inbounds ([10 x i256], ptr addrspace(4) @const, i256 0, i256 1), align 32
-  ; CHECK: add @const+32[0], r0, stack[@val+1]
   store i256 %1, ptr getelementptr inbounds ([10 x i256], ptr @val, i256 0, i256 1), align 32
   ret void
 }

--- a/llvm/test/CodeGen/SyncVM/constant-folding-earlycse.ll
+++ b/llvm/test/CodeGen/SyncVM/constant-folding-earlycse.ll
@@ -5,7 +5,7 @@ target triple = "syncvm"
 declare i256 @__addmod(i256, i256, i256) #0
 declare i256 @__mulmod(i256, i256, i256) #0
 declare i256 @__signextend(i256, i256) #0
-declare i256 @__exponent(i256, i256) #0
+declare i256 @__exp(i256, i256) #0
 
 define i256 @test_addmod1() {
 ; CHECK-LABEL: @test_addmod1
@@ -141,7 +141,7 @@ define i256 @test_exponent1() {
 ; CHECK-LABEL: @test_exponent1
 ; CHECK-NEXT: ret i256 0
 
-  %res = call i256 @__exponent(i256 0, i256 10)
+  %res = call i256 @__exp(i256 0, i256 10)
   ret i256 %res
 }
 
@@ -149,7 +149,7 @@ define i256 @test_exponent2() {
 ; CHECK-LABEL: @test_exponent2
 ; CHECK-NEXT: ret i256 1
 
-  %res = call i256 @__exponent(i256 2, i256 undef)
+  %res = call i256 @__exp(i256 2, i256 undef)
   ret i256 %res
 }
 
@@ -157,7 +157,7 @@ define i256 @test_exponent3() {
 ; CHECK-LABEL: @test_exponent3
 ; CHECK-NEXT: ret i256 -57896044618658097711785492504343953926634992332820282019728792003956564819968
 
-  %res = call i256 @__exponent(i256 2, i256 255)
+  %res = call i256 @__exp(i256 2, i256 255)
   ret i256 %res
 }
 
@@ -165,7 +165,7 @@ define i256 @test_exponent4() {
 ; CHECK-LABEL: @test_exponent4
 ; CHECK-NEXT: ret i256 -26400738010602378953627016196889292963087978848325315750873680393886838386559
 
-  %res = call i256 @__exponent(i256 307, i256 32)
+  %res = call i256 @__exp(i256 307, i256 32)
   ret i256 %res
 }
 
@@ -173,7 +173,170 @@ define i256 @test_exponent5() {
 ; CHECK-LABEL: @test_exponent5
 ; CHECK-NEXT: ret i256 0
 
-  %res = call i256 @__exponent(i256 undef, i256 2)
+  %res = call i256 @__exp(i256 undef, i256 2)
+  ret i256 %res
+}
+
+define i256 @test_exponent6() {
+; CHECK-LABEL: @test_exponent6
+; CHECK-NEXT: ret i256 1
+
+  %res = call i256 @__exp(i256 0, i256 0)
+  ret i256 %res
+}
+
+define i256 @test_exponent7() {
+; CHECK-LABEL: @test_exponent7
+; CHECK-NEXT: ret i256 1
+
+  %res = call i256 @__exp(i256 1, i256 0)
+  ret i256 %res
+}
+
+define i256 @test_exponent7.1() {
+; CHECK-LABEL: @test_exponent7.1
+; CHECK-NEXT: ret i256 1
+
+  %res = call i256 @__exp(i256 1, i256 1)
+  ret i256 %res
+}
+
+define i256 @test_exponent8() {
+; CHECK-LABEL: @test_exponent8
+; CHECK-NEXT: ret i256 0
+
+  %res = call i256 @__exp(i256 0, i256 433478394034343)
+  ret i256 %res
+}
+
+define i256 @test_exponent9() {
+; CHECK-LABEL: @test_exponent9
+; CHECK-NEXT: ret i256 1
+
+  %res = call i256 @__exp(i256 121563127839120, i256 0)
+  ret i256 %res
+}
+
+define i256 @test_exponent10() {
+; CHECK-LABEL: @test_exponent10
+; CHECK-NEXT: ret i256 1
+
+  %res = call i256 @__exp(i256 1, i256 433478394034343)
+  ret i256 %res
+}
+
+define i256 @test_exponent11() {
+; CHECK-LABEL: @test_exponent11
+; CHECK-NEXT: ret i256 121563127839120
+
+  %res = call i256 @__exp(i256 121563127839120, i256 1)
+  ret i256 %res
+}
+
+define i256 @test_exponent12() {
+; CHECK-LABEL: @test_exponent12
+; CHECK-NEXT: ret i256 569381465857367090636427305760163241950353347303833610101782245331441
+
+  %res = call i256 @__exp(i256 21, i256 52)
+  ret i256 %res
+}
+
+define i256 @test_exponent13() {
+; CHECK-LABEL: @test_exponent13
+; CHECK-NEXT: ret i256 -680564733841876926926749214863536422911
+
+  ; 0x00000000000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF ^ 2 ->
+  ; 0xfffffffffffffffffffffffffffffffe00000000000000000000000000000001
+  %res = call i256 @__exp(i256 340282366920938463463374607431768211455, i256 2)
+  ret i256 %res
+}
+
+define i256 @test_exponent14() {
+; CHECK-LABEL: @test_exponent14
+; CHECK-NEXT: ret i256 0
+
+  ; 0x0000000000000000000000000000000000000000000000000000000000010000 ^ 16 ->  0
+  %res = call i256 @__exp(i256 65536, i256 16)
+  ret i256 %res
+}
+
+define i256 @test_exponent15() {
+; CHECK-LABEL: @test_exponent15
+; CHECK-NEXT: ret i256 46756260758475007021788099943083655901358133181480408838873172916982662561791
+
+  ; 0x2fff1ffffffffff5ffffff0fffffffff2ffffffafffafffcffff1ff234ffffff ^
+  ; 0xef231ffffffffff4f12fff34ffffffff2fffffbbfffafffdffff22f538ffffff ->
+  ; 46756260758475007021788099943083655901358133181480408838873172916982662561791
+  %res = call i256 @__exp(i256 21709470740815105492860156599188632070735699051917406219058709325770546741247, i256 108164831314551007501389766781044785045182831393737867957367412557260901056511)
+  ret i256 %res
+}
+
+define i256 @test_exponent16() {
+; CHECK-LABEL: @test_exponent16
+; CHECK-NEXT: ret i256 0
+
+  ; 0 ^ 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff -> 0
+  %res = call i256 @__exp(i256 0, i256 115792089237316195423570985008687907853269984665640564039457584007913129639935)
+  ret i256 %res
+}
+
+define i256 @test_exponent17() {
+; CHECK-LABEL: @test_exponent17
+; CHECK-NEXT: ret i256 1
+
+  ; 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff ^ 0 - > 1
+  %res = call i256 @__exp(i256 115792089237316195423570985008687907853269984665640564039457584007913129639935, i256 0)
+  ret i256 %res
+}
+
+define i256 @test_exponent18() {
+; CHECK-LABEL: @test_exponent18
+; CHECK-NEXT: ret i256 1
+
+  ; 1 ^ 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff -> 1
+  %res = call i256 @__exp(i256 1, i256 115792089237316195423570985008687907853269984665640564039457584007913129639935)
+  ret i256 %res
+}
+
+define i256 @test_exponent19() {
+; CHECK-LABEL: @test_exponent19
+; CHECK-NEXT: ret i256 -1
+
+  ; 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff ^ 1 - >
+  ; 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  %res = call i256 @__exp(i256 115792089237316195423570985008687907853269984665640564039457584007913129639935, i256 1)
+  ret i256 %res
+}
+
+define i256 @test_exponent20() {
+; CHECK-LABEL: @test_exponent20
+; CHECK-NEXT: ret i256 0
+
+  ; 7437834752357434334343423343443375834785783474 ^
+  ; 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff - > 0
+  %res = call i256 @__exp(i256 7437834752357434334343423343443375834785783474, i256 115792089237316195423570985008687907853269984665640564039457584007913129639935)
+  ret i256 %res
+}
+
+define i256 @test_exponent21() {
+; CHECK-LABEL: @test_exponent21
+; CHECK-NEXT: ret i256 -1
+
+  ; 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff ^
+  ; 23784273472384723848213821342323233223 - >
+  ; 115792089237316195423570985008687907853269984665640564039457584007913129639935
+  %res = call i256 @__exp(i256 115792089237316195423570985008687907853269984665640564039457584007913129639935, i256 23784273472384723848213821342323233223)
+  ret i256 %res
+}
+
+define i256 @test_exponent22() {
+; CHECK-LABEL: @test_exponent22
+; CHECK-NEXT: ret i256 -1
+
+  ; 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff ^
+  ; 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff ->
+  ; 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  %res = call i256 @__exp(i256 115792089237316195423570985008687907853269984665640564039457584007913129639935, i256 115792089237316195423570985008687907853269984665640564039457584007913129639935)
   ret i256 %res
 }
 

--- a/llvm/unittests/Analysis/TargetLibraryInfoTest.cpp
+++ b/llvm/unittests/Analysis/TargetLibraryInfoTest.cpp
@@ -596,7 +596,7 @@ TEST_F(TargetLibraryInfoTest, ValidProto) {
       // SyncVM local begin
       // These functions are SyncVM/EVM routines
       "declare i256 @__addmod(i256, i256, i256)\n"
-      "declare i256 @__exponent(i256, i256)\n"
+      "declare i256 @__exp(i256, i256)\n"
       "declare i256 @__mulmod(i256, i256, i256)\n"
       "declare i256 @__signextend(i256, i256)\n");
       // SyncVM local end


### PR DESCRIPTION
Fix exponent constant folding implementation for 0^0 case.
Adding more LIT tests for the exponent.