### PR TITLE
[CI][testing] Hot-fix: Unbreak Compiler Integration Test by updating to clang-tidy-15

### DIFF
--- a/.github/workflows/compiler-integration-tests.yml
+++ b/.github/workflows/compiler-integration-tests.yml
@@ -53,7 +53,7 @@ jobs:
           git config --global --add url."https://${{ secrets.ZKSYNC_ADMIN_BOT_ORG_REPO_WRITE }}:x-oauth-basic@github.com/".insteadOf ssh://git@github.com/
           git config --global --add url."https://${{ secrets.ZKSYNC_ADMIN_BOT_ORG_REPO_WRITE }}:x-oauth-basic@github.com/".insteadOf https://github.com/
           git config --global --add url."https://${{ secrets.ZKSYNC_ADMIN_BOT_ORG_REPO_WRITE }}:x-oauth-basic@github.com/".insteadOf git@github.com:
-          apt install -y ninja-build clang-tidy-13
+          apt install -y ninja-build clang-tidy-15
 
       - name: Preparing LLVM.lock (pull request)
         if: github.event_name == 'pull_request'

--- a/.github/workflows/compiler-integration-tests.yml
+++ b/.github/workflows/compiler-integration-tests.yml
@@ -94,11 +94,11 @@ jobs:
           pwd
           echo $SHELL
           $SHELL --version
-          clang-tidy-13  --version
+          clang-tidy-15  --version
           git status
           git branch
           set -euxo pipefail
-          git diff -U0 remotes/origin/${{ env.COMPILER_LLVM_DEFAULT_BRANCH_NAME }} | ./clang-tools-extra/clang-tidy/tool/clang-tidy-diff_Zegar.py -p1 -clang-tidy-binary /usr/bin/clang-tidy-13   -path ../target-llvm/build-final/compile_commands.json
+          git diff -U0 remotes/origin/${{ env.COMPILER_LLVM_DEFAULT_BRANCH_NAME }} | ./clang-tools-extra/clang-tidy/tool/clang-tidy-diff_Zegar.py -p1 -clang-tidy-binary /usr/bin/clang-tidy-15   -path ../target-llvm/build-final/compile_commands.json
 
       - name: Running Lit tests with default options
         working-directory: compiler-tester


### PR DESCRIPTION
The Compiler Integration Test was broken by last night’s merge of an old [compiler-infra PR](https://github.com/matter-labs/compiler-infra/pull/33).  This change fixes two breakages, installation after about 30s and [clang-tidy execution after about 8m](https://github.com/matter-labs/compiler-llvm/actions/runs/6276803396/job/17047270294#step:13:36).  The [full test](https://github.com/matter-labs/compiler-llvm/actions/runs/6276803396) won’t be complete for several hours, but it seems unlikely that this change could break the test any earlier or further.

Adding reviewers whose Slack status indicates that they’re present.