### PR TITLE
[WIP][EraVM] Add a pass to recognize mem-ops for their indexed version

### DIFF
--- a/llvm/lib/Target/EraVM/CMakeLists.txt
+++ b/llvm/lib/Target/EraVM/CMakeLists.txt
@@ -51,6 +51,7 @@ add_llvm_target(EraVMCodeGen
   EraVMSubtarget.cpp
   EraVMTargetMachine.cpp
   EraVMTargetTransformInfo.cpp
+  EraVMIndexedMemOpsPrepare.cpp
 
   LINK_COMPONENTS
   Analysis

--- a/llvm/lib/Target/EraVM/EraVM.h
+++ b/llvm/lib/Target/EraVM/EraVM.h
@@ -11,6 +11,7 @@
 #include "MCTargetDesc/EraVMMCTargetDesc.h"
 #include "llvm/CodeGen/MachineOperand.h"
 #include "llvm/IR/Constants.h"
+#include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/Pass.h"
 #include "llvm/Passes/OptimizationLevel.h"
@@ -109,6 +110,7 @@ ImmutablePass *createEraVMExternalAAWrapperPass();
 ModulePass *createEraVMAlwaysInlinePass();
 FunctionPass *createEraVMSHA3ConstFoldingPass();
 FunctionPass *createEraVMOptimizeSelectPass();
+Pass *createEraVMIndexedMemOpsPreparePass();
 
 void initializeEraVMLowerIntrinsicsPass(PassRegistry &);
 void initializeEraVMAddConditionsPass(PassRegistry &);
@@ -129,6 +131,7 @@ void initializeEraVMExternalAAWrapperPass(PassRegistry &);
 void initializeEraVMAlwaysInlinePass(PassRegistry &);
 void initializeEraVMSHA3ConstFoldingPass(PassRegistry &);
 void initializeEraVMOptimizeSelectPass(PassRegistry &);
+void initializeEraVMIndexedMemOpsPreparePass(PassRegistry &);
 
 struct EraVMLinkRuntimePass : PassInfoMixin<EraVMLinkRuntimePass> {
   EraVMLinkRuntimePass(OptimizationLevel Level) : Level(Level) {}

--- a/llvm/lib/Target/EraVM/EraVMIndexedMemOpsPrepare.cpp
+++ b/llvm/lib/Target/EraVM/EraVMIndexedMemOpsPrepare.cpp
@@ -1,0 +1,272 @@
+//===--- EraVMIndexedMemOpsPrepare.cpp - Prepare for indexed MemOps -------===//
+//
+// \file
+// This pass intends to utilize the SCEV info to find load/store that can be
+// optimized to indexed load/store provided by EraVM.
+//
+// Please be noted:
+//   We don't generated indexed ld/st in current pass. We just re-write the IR
+//   to favor the subsequent EraVMCombineToIndexedMemops pass which will
+//   generate indexed ld/st in return.
+//
+// The algorithm contains two steps: the first step is to search the qualified
+// load/store instructions and the second step is to re-write them to favor
+// the subsequent EraVMCombineToIndexedMemops pass.
+//
+// In the first step, looking for pattern:
+//
+// loop-preheader:
+//   ......
+//   ......
+// loop-body:
+//   %PtrInc = phi [ %InitVal, loop-prehead ], [ %Val, loop-body]
+//   %BasePtr = GEP %BaseAddr, %index0, ..., %PtrInc
+//   %LSVal = load/store %BasePtr
+//   ......
+//
+// the requirements are:
+//   1). The BasePtr of load/store instruction will be increased by one cell per
+//       iteration.
+//   2). The BasePtr is defined by a GEP instruction of which the last index
+//       operand is defined by a PHI node.
+//
+// After find the pattern, re-write the instructions into below formats:
+//
+// loop-preheader:
+//   ......
+//   %BasePtrInit = GEP %BaseAddr, %index0, ..., %InitVal
+//   ......
+// loop-body:
+//    %BasePtrNew = phi [%BasePtrInit, loop-prehead], [%BasePtrInc, loop-body]
+//    %BasePtrInc = GEP %BasePtrNew, i256 1
+//    %LSVal = load/store %BasePtrNew
+//    ......
+//
+// Notes to the algorithm:
+//
+//   1). The BasePtr can be increased by one cell via loop index or a seperated
+//       instruction.
+//   2). The GEP instruction used to define BasePtr can contain one or more
+//       index operands. If it contains only one index operand and
+//       the initial value of this index operand is zero, then we don't need
+//       to insert BasePtrInit instruction in preheader, otherwise we have to
+//       add.
+//   3). The memory intrinsic expansion pass will generate loops to fulfill the
+//       functions of memory intrinsic, hence this pass is supposed to be run
+//       after the memory intrinsic expansion pass, the generated loops can
+//       benefit from this pass.
+//
+// TODO: CPR-1421 Remove loop index
+//       The pointers inside the loop will be increased per iteration.
+//       We can use them to judge whether loop should exit. In this way, if
+//       loop index isn't used by any other places, we can optimize out loop
+//       index along with instruction used to increase its value.
+//============================================================================//
+
+#include "EraVM.h"
+
+#include "EraVMSubtarget.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/Statistic.h"
+#include "llvm/Analysis/LoopInfo.h"
+#include "llvm/Analysis/LoopPass.h"
+#include "llvm/Analysis/ScalarEvolution.h"
+#include "llvm/Analysis/ScalarEvolutionExpressions.h"
+#include "llvm/Analysis/TargetLibraryInfo.h"
+#include "llvm/Analysis/TargetTransformInfo.h"
+#include "llvm/CodeGen/TargetInstrInfo.h"
+#include "llvm/CodeGen/TargetPassConfig.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/InitializePasses.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Debug.h"
+
+using namespace llvm;
+
+#define DEBUG_TYPE "eravm-indexed-memops-prepare"
+#define ERAVM_PREPARE_INDEXED_MEMOPS_NAME                                      \
+  "EraVM recognize and rewrite instructions for indexed memory operations"
+
+namespace {
+
+class EraVMIndexedMemOpsPrepare : public LoopPass {
+
+  ScalarEvolution *SE = nullptr;
+  LLVMContext *Ctx = nullptr;
+  Loop *CurrentLoop = nullptr;
+
+public:
+  static char ID;
+
+  EraVMIndexedMemOpsPrepare() : LoopPass(ID) {}
+
+  bool runOnLoop(Loop *L, LPPassManager &) override;
+
+  StringRef getPassName() const override {
+    return "EraVM Recognize Indexed Load/Store";
+  }
+
+  void getAnalysisUsage(AnalysisUsage &AU) const override {
+    AU.addRequired<ScalarEvolutionWrapperPass>();
+    AU.addRequired<LoopInfoWrapperPass>();
+    AU.addRequired<TargetPassConfig>();
+    AU.addRequired<TargetTransformInfoWrapperPass>();
+    AU.addPreserved<LoopInfoWrapperPass>();
+    AU.setPreservesCFG();
+  }
+
+private:
+  /// Check whether \p BasePtr is valid and increased by one cell.
+  bool isValidGEPAndIncByOneCell(GetElementPtrInst *BasePtr) const;
+
+  /// The \p BasePtr is defined by a GEP instruction. The \p MemOpInst
+  /// is the load or store instruction that uses \p BasePtr as a base
+  /// address. If this \p BasePtr matches our requirements, then this
+  /// function will rewrite it into patterns that can be recognized by
+  /// the subsequent Combine pass to generate indexed load/store.
+  bool rewriteToFavorIndexedMemOps(GetElementPtrInst *BasePtr,
+                                   Instruction *MemOpInst);
+};
+
+} // end namespace
+
+bool EraVMIndexedMemOpsPrepare::rewriteToFavorIndexedMemOps(
+    GetElementPtrInst *BasePtr, Instruction *MemOpInst) {
+
+  Type *TypeOfCopyLen = IntegerType::getInt256Ty(*Ctx);
+  BasicBlock *LoopPreheader = CurrentLoop->getLoopPreheader();
+
+  Value *SrcOperand = getPointerOperand(BasePtr);
+  Type *RstType = BasePtr->getResultElementType();
+  Type *GEPType = BasePtr->getType();
+  const bool IsGEPInBounds = BasePtr->isInBounds();
+  const unsigned GEPElementSize =
+      BasePtr->getResultElementType()->getPrimitiveSizeInBits();
+
+  // Create a new PHI node to represent the change of BasePtr.
+  IRBuilder<> Builder(BasePtr);
+  Builder.SetInsertPoint(CurrentLoop->getHeader()->getFirstNonPHI());
+  auto *NewBasePtr = Builder.CreatePHI(GEPType, 2);
+  BasePtr->replaceAllUsesWith(NewBasePtr);
+
+  // If the BasePtr GEP inst has only one index operand and its initial value is
+  // zero. Then we can use GEP's source operand as NewBasePtr's initial
+  // value. No need to add instruction to initialize NewBasePtr in loop
+  // preheader. Otherwise we need to initialize NewBasePtr in loop preheader.
+  const unsigned LastIndexOperandId = BasePtr->getNumOperands() - 1;
+  const auto *PHI = cast<PHINode>(BasePtr->getOperand(LastIndexOperandId));
+  Value *GEPLastIndexOperandInitValue =
+      PHI->getIncomingValueForBlock(LoopPreheader);
+  const auto *IndexVal = dyn_cast<ConstantInt>(GEPLastIndexOperandInitValue);
+
+  if ((LastIndexOperandId == 1) && IndexVal && IndexVal->isZero()) {
+    NewBasePtr->addIncoming(SrcOperand, LoopPreheader);
+    BasePtr->eraseFromParent();
+  } else {
+    // Turn BasePtr GEP inst into a plain initialization inst
+    // and move it into loop preheader.
+    BasePtr->setOperand(LastIndexOperandId, GEPLastIndexOperandInitValue);
+    BasePtr->moveBefore(LoopPreheader->getTerminator());
+    NewBasePtr->addIncoming(BasePtr, LoopPreheader);
+  }
+
+  // Add GEP instruction to increase the NewBasePtr by one cell.
+  Builder.SetInsertPoint(MemOpInst);
+  auto *IncNewBasePtr = Builder.CreateInBoundsGEP(
+      RstType, NewBasePtr,
+      ConstantInt::get(TypeOfCopyLen, (TypeOfCopyLen->getScalarSizeInBits() /
+                                       GEPElementSize)));
+  if (!IsGEPInBounds)
+    cast<GetElementPtrInst>(IncNewBasePtr)->setIsInBounds(false);
+
+  // Add to the PHI
+  NewBasePtr->addIncoming(IncNewBasePtr, MemOpInst->getParent());
+
+  return true;
+}
+
+bool EraVMIndexedMemOpsPrepare::isValidGEPAndIncByOneCell(
+    GetElementPtrInst *BasePtr) const {
+  // FIXME: Once we support address space generic, we can remove it.
+  if (BasePtr->getPointerAddressSpace() == EraVMAS::AS_GENERIC)
+    return false;
+
+  // Use SCEV info to check whether this BasePtr is increased
+  // by one cell per iteration.
+  const SCEV *SCEVPtr = SE->getSCEVAtScope(BasePtr, CurrentLoop);
+
+  if (SCEVPtr) {
+    const SCEVAddRecExpr *AddRec = dyn_cast<SCEVAddRecExpr>(SCEVPtr);
+    if (!AddRec)
+      return false;
+    const SCEVConstant *Step =
+        dyn_cast<SCEVConstant>(AddRec->getStepRecurrence(*SE));
+    if (!Step)
+      return false;
+    const APInt StrideVal = Step->getAPInt();
+    if (StrideVal != 32)
+      return false;
+  }
+
+  // The last index operand of this BasePtr GEP instruction must be
+  // defined by a PHI node. Only via this PHI node, the BasePtr
+  // can be increased along with loop iteration.
+  const unsigned LastIndexOperandId = BasePtr->getNumOperands() - 1;
+  Value *LastIndexOperand = BasePtr->getOperand(LastIndexOperandId);
+  const PHINode *PHI = dyn_cast<PHINode>(LastIndexOperand);
+  if (!PHI)
+    return false;
+
+  return true;
+}
+
+bool EraVMIndexedMemOpsPrepare::runOnLoop(Loop *L, LPPassManager &) {
+  bool Changed = false;
+
+  if (skipLoop(L))
+    return false;
+
+  if (!L->isLoopSimplifyForm())
+    return false;
+
+  SE = &getAnalysis<ScalarEvolutionWrapperPass>().getSE();
+  Ctx = &L->getLoopPreheader()->getContext();
+  CurrentLoop = L;
+
+  for (auto *const BB : L->blocks()) {
+    for (auto &I : *BB) {
+      GetElementPtrInst *BasePtrValue = nullptr;
+      if (LoadInst *LMemI = dyn_cast<LoadInst>(&I)) {
+        BasePtrValue = dyn_cast<GetElementPtrInst>(LMemI->getPointerOperand());
+      } else if (StoreInst *SMemI = dyn_cast<StoreInst>(&I)) {
+        BasePtrValue = dyn_cast<GetElementPtrInst>(SMemI->getPointerOperand());
+      } else {
+        continue; // Skip if current inst isn't load nor store inst.
+      }
+
+      if (!BasePtrValue)
+        continue;
+
+      // Use SCEV info to check whether baseptr is increased by one cell
+      if (!isValidGEPAndIncByOneCell(BasePtrValue))
+        continue;
+
+      // Let's try to rewrite the GEP instruction in a way that will
+      // favor the subsequent CombineToIndexedMemops pass.
+      Changed |= rewriteToFavorIndexedMemOps(BasePtrValue, &I);
+    }
+  }
+
+  return Changed;
+}
+
+Pass *llvm::createEraVMIndexedMemOpsPreparePass() {
+  return new EraVMIndexedMemOpsPrepare();
+}
+
+char EraVMIndexedMemOpsPrepare::ID = 0;
+
+INITIALIZE_PASS_BEGIN(EraVMIndexedMemOpsPrepare, DEBUG_TYPE,
+                      ERAVM_PREPARE_INDEXED_MEMOPS_NAME, false, false)
+INITIALIZE_PASS_END(EraVMIndexedMemOpsPrepare, DEBUG_TYPE,
+                    ERAVM_PREPARE_INDEXED_MEMOPS_NAME, false, false)

--- a/llvm/lib/Target/EraVM/EraVMTargetMachine.cpp
+++ b/llvm/lib/Target/EraVM/EraVMTargetMachine.cpp
@@ -45,6 +45,7 @@ extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeEraVMTarget() {
   initializeEraVMExternalAAWrapperPass(PR);
   initializeEraVMLinkRuntimePass(PR);
   initializeEraVMLowerIntrinsicsPass(PR);
+  initializeEraVMIndexedMemOpsPreparePass(PR);
   initializeEraVMOptimizeStdLibCallsPass(PR);
   initializeEraVMSHA3ConstFoldingPass(PR);
   initializeEraVMStackAddressConstantPropagationPass(PR);
@@ -193,6 +194,7 @@ TargetPassConfig *EraVMTargetMachine::createPassConfig(PassManagerBase &PM) {
 
 void EraVMPassConfig::addIRPasses() {
   addPass(createEraVMLowerIntrinsicsPass());
+  addPass(createEraVMIndexedMemOpsPreparePass());
   addPass(createEraVMLinkRuntimePass(true));
   addPass(createEraVMCodegenPreparePass());
   addPass(createGlobalDCEPass());

--- a/llvm/test/CodeGen/EraVM/indexed-memops.ll
+++ b/llvm/test/CodeGen/EraVM/indexed-memops.ll
@@ -1,0 +1,149 @@
+; RUN: llc -O3 < %s | FileCheck %s
+target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
+target triple = "eravm"
+
+; TODO: CPR-1421 Remove loop index
+; The register r2 and r1 are pointers and will be increased per iteration,
+; we can use them to judge whether loop should exit, the add instruction used
+; to increase loop index r4 can be optimized out.
+define void @loop1(i256 addrspace(1)* %dest, i256 addrspace(1)* %src, i256 %size) {
+; CHECK:        add     r0, r0, r4
+; CHECK-NEXT: .BB0_1:
+; CHECK:        ld.1.inc   r2, r5, r2
+; CHECK-NEXT:   st.1.inc   r1, r5, r1
+; CHECK-NEXT:   add        1, r4, r4
+; CHECK-NEXT:   sub!       r4, r3, r5
+; CHECK-NEXT:   jump.lt @.BB0_1
+; CHECK:        ret
+
+  br label %load-store-loop
+
+load-store-loop:                                  ; preds = %load-store-loop, %0
+  %loop-index = phi i256 [ 0, %0 ], [ %4, %load-store-loop ]
+  %1 = getelementptr inbounds i256, i256 addrspace(1)* %src, i256 %loop-index
+  %2 = load i256, i256 addrspace(1)* %1, align 1
+  %3 = getelementptr inbounds i256, i256 addrspace(1)* %dest, i256 %loop-index
+  store i256 %2, i256 addrspace(1)* %3, align 1
+  %4 = add i256 %loop-index, 1
+  %5 = icmp ult i256 %4, %size
+  br i1 %5, label %load-store-loop, label %memcpy-split
+
+memcpy-split:                                     ; preds = %load-store-loop
+  ret void
+}
+
+define void @loop2(i256 addrspace(1)* %dest, i256 addrspace(1)* %src, i256 %size) {
+; CHECK:        add     10, r0, r4
+; CHECK-NEXT:   add     320, r1, r1
+; CHECK-NEXT:   add     320, r2, r2
+; CHECK-NEXT: .BB1_1:
+; CHECK:        ld.1.inc   r2, r5, r2
+; CHECK-NEXT:   st.1.inc   r1, r5, r1
+; CHECK-NEXT:   add        1, r4, r4
+; CHECK-NEXT:   sub!       r4, r3, r5
+; CHECK-NEXT:   jump.lt @.BB1_1
+; CHECK:        ret
+
+entry:
+  br label %load-store-loop
+
+load-store-loop:                                  ; preds = %load-store-loop, %entry
+  %loop-index = phi i256 [ 10, %entry ], [ %3, %load-store-loop ]
+  %0 = getelementptr inbounds i256, i256 addrspace(1)* %src, i256 %loop-index
+  %1 = load i256, i256 addrspace(1)* %0, align 1
+  %2 = getelementptr inbounds i256, i256 addrspace(1)* %dest, i256 %loop-index
+  store i256 %1, i256 addrspace(1)* %2, align 1
+  %3 = add i256 %loop-index, 1
+  %4 = icmp ult i256 %3, %size
+  br i1 %4, label %load-store-loop, label %memcpy-split
+
+memcpy-split:                                     ; preds = %load-store-loop
+  ret void
+}
+
+define void @loop3(i256 addrspace(1)* %dest, i256 addrspace(1)* %src, i256 %size, i256 %pos) {
+; CHECK:        shl.s   5, r4, r4
+; CHECK-NEXT:   add     r2, r4, r4
+; CHECK-NEXT:   add     10, r0, r2
+; CHECK-NEXT:   add     32, r4, r4
+; CHECK-NEXT: .BB2_1:
+; CHECK:        shl.s      5,  r2, r5
+; CHECK-NEXT:   add        r1, r5, r5
+; CHECK-NEXT:   ld.1.inc   r4, r6, r4
+; CHECK-NEXT:   st.1       r5, r6
+; CHECK-NEXT:   add        2, r2, r2
+; CHECK-NEXT:   sub!       r2, r3, r5
+; CHECK-NEXT:   jump.lt @.BB2_1
+; CHECK:        ret
+
+entry:
+  %src-index-init = add i256 %pos, 1
+  br label %load-store-loop
+
+load-store-loop:                                  ; preds = %load-store-loop, %entry
+  %loop-index = phi i256 [ 10, %entry ], [ %3, %load-store-loop ]
+  %src-index = phi i256 [ %src-index-init, %entry ], [ %src-index-inc, %load-store-loop ]
+  %0 = getelementptr inbounds i256, i256 addrspace(1)* %src, i256 %src-index
+  %1 = load i256, i256 addrspace(1)* %0, align 1
+  %2 = getelementptr inbounds i256, i256 addrspace(1)* %dest, i256 %loop-index
+  store i256 %1, i256 addrspace(1)* %2, align 1
+  %src-index-inc = add i256 %src-index, 1
+  %3 = add i256 %loop-index, 2
+  %4 = icmp ult i256 %3, %size
+  br i1 %4, label %load-store-loop, label %memcpy-split
+
+memcpy-split:                                     ; preds = %load-store-loop
+  ret void
+}
+
+define void @loop4([10 x i256] addrspace(1)* %dest, [10 x i256] addrspace(1)* %src, i256 %size) {
+; CHECK:        add     r0, r0, r4
+; CHECK-NEXT: .BB3_1:
+; CHECK:        ld.1.inc   r2, r5, r2
+; CHECK-NEXT:   st.1.inc   r1, r5, r1
+; CHECK-NEXT:   add        1, r4, r4
+; CHECK-NEXT:   sub!       r4, r3, r5
+; CHECK-NEXT:   jump.lt @.BB3_1
+; CHECK:        ret
+  br label %load-store-loop
+
+load-store-loop:                                  ; preds = %load-store-loop, %0
+  %loop-index = phi i256 [ 0, %0 ], [ %4, %load-store-loop ]
+  %1 = getelementptr [10 x i256], [10 x i256] addrspace(1)* %src, i256 0, i256 %loop-index
+  %2 = load i256, i256 addrspace(1)* %1, align 1
+  %3 = getelementptr [10 x i256], [10 x i256] addrspace(1)* %dest, i256 0, i256 %loop-index
+  store i256 %2, i256 addrspace(1)* %3, align 1
+  %4 = add i256 %loop-index, 1
+  %5 = icmp ult i256 %4, %size
+  br i1 %5, label %load-store-loop, label %memcpy-split
+
+memcpy-split:                                     ; preds = %load-store-loop
+  ret void
+}
+
+define void @loop5([10 x i256] addrspace(1)* %dest, [10 x i256] addrspace(1)* %src, i256 %size) {
+; CHECK:        add     320, r1, r1
+; CHECK-NEXT:   add     320, r2, r2
+; CHECK-NEXT:   add     r0, r0, r4
+; CHECK-NEXT: .BB4_1:
+; CHECK:        ld.1.inc   r2, r5, r2
+; CHECK-NEXT:   st.1.inc   r1, r5, r1
+; CHECK-NEXT:   add        1, r4, r4
+; CHECK-NEXT:   sub!       r4, r3, r5
+; CHECK-NEXT:   jump.lt @.BB4_1
+; CHECK:        ret
+  br label %load-store-loop
+
+load-store-loop:                                  ; preds = %load-store-loop, %0
+  %loop-index = phi i256 [ 0, %0 ], [ %4, %load-store-loop ]
+  %1 = getelementptr [10 x i256], [10 x i256] addrspace(1)* %src, i256 1, i256 %loop-index
+  %2 = load i256, i256 addrspace(1)* %1, align 1
+  %3 = getelementptr [10 x i256], [10 x i256] addrspace(1)* %dest, i256 1, i256 %loop-index
+  store i256 %2, i256 addrspace(1)* %3, align 1
+  %4 = add i256 %loop-index, 1
+  %5 = icmp ult i256 %4, %size
+  br i1 %5, label %load-store-loop, label %memcpy-split
+
+memcpy-split:                                     ; preds = %load-store-loop
+  ret void
+}

--- a/llvm/test/CodeGen/EraVM/memintrinsics.ll
+++ b/llvm/test/CodeGen/EraVM/memintrinsics.ll
@@ -11,12 +11,9 @@ declare void @llvm.memcpy.p2i256.p2i256.i256(i256 addrspace(2)* noalias nocaptur
 define fastcc void @huge-copysize0(i256 addrspace(0)* %dest, i256 addrspace(0)* %src) {
 ; CHECK:   add     r0, r0, [[INDEX0:r[0-9]+]]
 ; CHECK: .BB0_1:
-; CHECK:   shl.s   5, [[INDEX0]], [[SHIFTED_OFFSET0_SRC:r[0-9]+]]
-; CHECK:   add     r1, [[SHIFTED_OFFSET0_SRC]], [[SHIFTED_OFFSET0_DST:r[0-9]+]]
-; CHECK:   add     r2, [[SHIFTED_OFFSET0_SRC]], [[SHIFTED_OFFSET0_SRC]]
-; CHECK:   shr.s   5, [[SHIFTED_OFFSET0_SRC]], [[SHIFTED_OFFSET0_SRC]]
+; CHECK:   shr.s   5, r2, [[SHIFTED_OFFSET0_SRC:r[0-9]+]]
 ; CHECK:   add     stack[[[SHIFTED_OFFSET0_SRC]]], r0, [[LOADED_VALUE0:r[0-9]+]]
-; CHECK:   shr.s   5, [[SHIFTED_OFFSET0_DST]], [[SHIFTED_OFFSET0_DST]]
+; CHECK:   shr.s   5, r1, [[SHIFTED_OFFSET0_DST:r[0-9]+]]
 ; CHECK:   add     [[LOADED_VALUE0]], r0, stack[[[SHIFTED_OFFSET0_DST]]]
 ; CHECK:   add     1, [[INDEX0]], [[INDEX0]]
 ; CHECK:   sub.s!  @CPI0_0[0], [[INDEX0]], r4
@@ -29,12 +26,11 @@ define fastcc void @huge-copysize0(i256 addrspace(0)* %dest, i256 addrspace(0)* 
 ; CHECK-LABEL: huge-copysize1
 define fastcc void @huge-copysize1(i256 addrspace(1)* %dest, i256 addrspace(1)* %src) {
 ; CHECK:  add     r0, r0, [[INDEX1:r[0-9]+]]
+; CHECK:  add     r2, r0, [[LDBASE:r[0-9]+]]
+; CHECK:  add     r1, r0, [[STBASE:r[0-9]+]]
 ; CHECK:.BB1_1:
-; CHECK:  shl.s   5, [[INDEX1]], [[SHIFTED_OFFSET1_SRC:r[0-9]+]]
-; CHECK:  add     r1, [[SHIFTED_OFFSET1_SRC]], [[SHIFTED_OFFSET1_DST:r[0-9]+]]
-; CHECK:  add     r2, [[SHIFTED_OFFSET1_SRC]], [[SHIFTED_OFFSET1_SRC]]
-; CHECK:  ld.1    [[SHIFTED_OFFSET1_SRC]], [[LOADED_VALUE1:r[0-9]+]]
-; CHECK:  st.1    [[SHIFTED_OFFSET1_DST]], [[LOADED_VALUE1]]
+; CHECK:  ld.1.inc   [[LDBASE]], [[LDVAL:r[0-9]+]], [[LDBASE]]
+; CHECK:  st.1.inc   [[STBASE]], [[LDVAL]], [[STBASE]]
 ; CHECK:  add     1, [[INDEX1]], [[INDEX1]]
 ; CHECK:  sub.s!  @CPI1_0[0], [[INDEX1]], r{{[0-9]+}}
 ; CHECK:  jump.lt @.BB1_1
@@ -58,12 +54,11 @@ define fastcc void @huge-copysize1(i256 addrspace(1)* %dest, i256 addrspace(1)* 
 ; CHECK-LABEL: huge-copysize2
 define fastcc void @huge-copysize2(i256 addrspace(2)* %dest, i256 addrspace(2)* %src) {
 ; CHECK:  add     r0, r0, [[INDEX2:r[0-9]+]]
+; CHECK:  add     r2, r0, [[LDBASE:r[0-9]+]]
+; CHECK:  add     r1, r0, [[STBASE:r[0-9]+]]
 ; CHECK:.BB2_1:
-; CHECK:  shl.s   5, [[INDEX2]], [[SHIFTED_OFFSET2_SRC:r[0-9]+]]
-; CHECK:  add     r1, [[SHIFTED_OFFSET2_SRC]], [[SHIFTED_OFFSET2_DST:r[0-9]+]]
-; CHECK:  add     r2, [[SHIFTED_OFFSET2_SRC]], [[SHIFTED_OFFSET2_SRC]]
-; CHECK:  ld.2    [[SHIFTED_OFFSET2_SRC]], [[LOADED_VALUE2:r[0-9]+]]
-; CHECK:  st.2    [[SHIFTED_OFFSET2_DST]], [[LOADED_VALUE2]]
+; CHECK:  ld.2.inc   [[LDBASE]], [[LDVAL:r[0-9]+]], [[LDBASE]]
+; CHECK:  st.2.inc   [[STBASE]], [[LDVAL]], [[STBASE]]
 ; CHECK:  add     1, [[INDEX2]], [[INDEX2]]
 ; CHECK:  sub.s!  @CPI2_0[0], [[INDEX2]], r{{[0-9]+}}
 ; CHECK:  jump.lt @.BB2_1
@@ -88,13 +83,12 @@ define fastcc void @huge-copysize2(i256 addrspace(2)* %dest, i256 addrspace(2)* 
 define fastcc void @normal-known-size(i256* %dest, i256* %src) {
 ; CHECK:   add     r0, r0, [[INDEX3:r[3-9]+]]
 ; CHECK: .BB3_1:
-; CHECK:   shl.s   5, [[INDEX3]], [[SHIFTED_OFFSET3_SRC:r[3-9]+]]
-; CHECK:   add     r1, [[SHIFTED_OFFSET3_SRC]], [[SHIFTED_OFFSET3_DST:r[3-9]+]]
-; CHECK:   add     r2, [[SHIFTED_OFFSET3_SRC]], [[SHIFTED_OFFSET3_SRC]]
-; CHECK:   shr.s   5, [[SHIFTED_OFFSET3_SRC]], [[SHIFTED_OFFSET3_SRC]]
+; CHECK:   shr.s   5, [[LOAD_SHIFT_AMMOUNT:r[0-9]+]], [[SHIFTED_OFFSET3_SRC:r[3-9]+]]
 ; CHECK:   add     stack[[[SHIFTED_OFFSET3_SRC]]], r0, [[LOADED_VALUE3:r[3-9]+]]
-; CHECK:   shr.s   5, [[SHIFTED_OFFSET3_DST]], [[SHIFTED_OFFSET3_DST]]
+; CHECK:   shr.s   5, [[STORE_SHIFT_AMMOUNT:r[0-9]+]], [[SHIFTED_OFFSET3_DST:r[0-9]+]]
 ; CHECK:   add     [[LOADED_VALUE3]], r0, stack[[[SHIFTED_OFFSET3_DST]]]
+; CHECK:   add     32, [[STORE_SHIFT_AMMOUNT]], [[STORE_SHIFT_AMMOUNT]]
+; CHECK:   add     32, [[LOAD_SHIFT_AMMOUNT]], [[LOAD_SHIFT_AMMOUNT]]
 ; CHECK:   add     1, [[INDEX3]], [[INDEX3]]
 ; CHECK:   sub.s!  32, [[INDEX3]], r{{[0-9]+}}
 ; CHECK:   jump.lt @.BB3_1
@@ -106,14 +100,15 @@ define fastcc void @normal-known-size(i256* %dest, i256* %src) {
 ; CHECK-LABEL: normal-known-size-2
 define fastcc void @normal-known-size-2(i256* %dest, i256* %src) {
 ; CHECK:   add     r0, r0, [[INDEX4:r[3-9]+]]
+; CHECK:  add     r2, r0, [[LDBASE:r[0-9]+]]
+; CHECK:  add     r1, r0, [[STBASE:r[0-9]+]]
 ; CHECK: .BB4_1:
-; CHECK:   shl.s   5, [[INDEX4]], [[SHIFTED_OFFSET4_SRC:r[3-9]+]]
-; CHECK:   add     r1, [[SHIFTED_OFFSET4_SRC]], [[SHIFTED_OFFSET4_DST:r[3-9]+]]
-; CHECK:   add     r2, [[SHIFTED_OFFSET4_SRC]], [[SHIFTED_OFFSET4_SRC]]
-; CHECK:   shr.s   5, [[SHIFTED_OFFSET4_SRC]], [[SHIFTED_OFFSET4_SRC]]
+; CHECK:   shr.s   5, [[SHIFT_COUNT_SRC:r[0-9]+]], [[SHIFTED_OFFSET4_SRC:r[3-9]+]]
 ; CHECK:   add     stack[[[SHIFTED_OFFSET4_SRC]]], r0, [[LOADED_VALUE4:r[3-9]+]]
-; CHECK:   shr.s   5, [[SHIFTED_OFFSET4_DST]], [[SHIFTED_OFFSET4_DST]]
+; CHECK:   shr.s   5, [[SHIFT_COUNT_DST:r[0-9]+]], [[SHIFTED_OFFSET4_DST:r[0-9]+]]
 ; CHECK:   add     [[LOADED_VALUE4]], r0, stack[[[SHIFTED_OFFSET4_DST]]]
+; CHECK:   add     32, [[SHIFT_COUNT_DST]], [[SHIFT_COUNT_DST]]
+; CHECK:   add     32, [[SHIFT_COUNT_SRC]], [[SHIFT_COUNT_SRC]]
 ; CHECK:   add     1, [[INDEX4]], [[INDEX4]]
 ; CHECK:   sub.s!  33, [[INDEX4]], r{{[0-9]+}}
 ; CHECK:   jump.lt @.BB4_1


### PR DESCRIPTION
Find mem-ops that can be optimized to indexed version, re-write them into patterns that can be recognized by the subsequent combine pass where the original mem-ops will be replaced by their indexed version.