### PR TITLE
[WIP][SyncVM] Use indexed load/store to lower memcpy

### DIFF
--- a/llvm/test/CodeGen/SyncVM/indexedMemOps.ll
+++ b/llvm/test/CodeGen/SyncVM/indexedMemOps.ll
@@ -1,0 +1,24 @@
+; RUN: llc < %s | FileCheck %s
+
+target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
+target triple = "syncvm-unknown-unknown"
+
+@ptr_calldata = private global ptr addrspace(3) null
+
+; Function Attrs: argmemonly nocallback nofree nounwind willreturn
+declare void @llvm.memcpy.p1.p3.i256(ptr addrspace(1) noalias nocapture writeonly, ptr addrspace(3) noalias nocapture readonly, i256, i1 immarg) #5
+
+; CHECK-LABEL: foo
+define void @foo() {
+entry:
+  %calldata_pointer = load ptr addrspace(3), ptr @ptr_calldata, align 32
+  %calldata_source_pointer = getelementptr i8, ptr addrspace(3) %calldata_pointer, i256 122
+; CHECK: ld.inc  r2, r4, r2
+; CHECK: st.1.inc        r1, r4, r1
+  call void @llvm.memcpy.p1.p3.i256(ptr addrspace(1) align 1 inttoptr (i256 128 to ptr addrspace(1)), ptr addrspace(3) align 1 %calldata_source_pointer, i256 64, i1 false)
+  unreachable
+
+return:                                           ; No predecessors!
+  ret void
+}
+

--- a/llvm/test/CodeGen/SyncVM/memcpy-expansion.ll
+++ b/llvm/test/CodeGen/SyncVM/memcpy-expansion.ll
@@ -10,8 +10,8 @@ declare void @llvm.memcpy.p1i256.p1i256.i256(i256 addrspace(1)* noalias nocaptur
 define fastcc void @expand-known(i256 addrspace(1)* %dest, i256 addrspace(3)* %src) {
 ; Loop
 ; CHECK:   %loop-index = phi i256 [ 0, %{{.*}} ], [ [[NEWCTR:%[0-9]+]], %load-store-loop ]
-; CHECK:   [[REG:%[0-9]+]] = load i256, i256 addrspace(3)* %{{[0-9]+}}, align 1
-; CHECK:   store i256 [[REG]], i256 addrspace(1)* %{{[0-9]+}}, align 1
+; CHECK:   [[REG:%[0-9]+]] = load i256, i256 addrspace(3)* %{{.*}}, align 1
+; CHECK:   store i256 [[REG]], i256 addrspace(1)* %{{.*}}, align 1
 ; CHECK:   [[NEWCTR]] = add i256 %loop-index, 1
 
 ; Residual
@@ -34,7 +34,7 @@ define fastcc void @expand-unknown(i256 addrspace(1)* %dest, i256 addrspace(3)* 
 
 ; Loop
 ; CHECK:   [[REG:%[0-9]+]] = load i256, i256 addrspace(3)* %{{[0-9]+}}, align 1
-; CHECK:   store i256 [[REG]], i256 addrspace(1)* %{{[0-9]+}}, align 1
+; CHECK:   store i256 [[REG]], i256 addrspace(1)* %{{.*}}, align 1
 ; CHECK:   br i1 %{{[0-9]+}}, label %{{.*}}, label %{{.*}}
 
 ; Residual

--- a/llvm/test/CodeGen/SyncVM/memintrinsics.ll
+++ b/llvm/test/CodeGen/SyncVM/memintrinsics.ll
@@ -11,12 +11,9 @@ declare void @llvm.memcpy.p2i256.p2i256.i256(i256 addrspace(2)* noalias nocaptur
 define fastcc void @huge-copysize0(i256 addrspace(0)* %dest, i256 addrspace(0)* %src) {
 ; CHECK:   add     r0, r0, [[INDEX0:r[0-9]+]]
 ; CHECK: .BB0_1:
-; CHECK:   shl.s   5, [[INDEX0]], [[SHIFTED_OFFSET0_SRC:r[0-9]+]]
-; CHECK:   add     r1, [[SHIFTED_OFFSET0_SRC]], [[SHIFTED_OFFSET0_DST:r[0-9]+]]
-; CHECK:   add     r2, [[SHIFTED_OFFSET0_SRC]], [[SHIFTED_OFFSET0_SRC]]
-; CHECK:   shr.s   5, [[SHIFTED_OFFSET0_SRC]], [[SHIFTED_OFFSET0_SRC]]
+; CHECK:   shr.s   5, r2, [[SHIFTED_OFFSET0_SRC:r[0-9]+]]
 ; CHECK:   add     stack[[[SHIFTED_OFFSET0_SRC]]], r0, [[LOADED_VALUE0:r[0-9]+]]
-; CHECK:   shr.s   5, [[SHIFTED_OFFSET0_DST]], [[SHIFTED_OFFSET0_DST]]
+; CHECK:   shr.s   5, r1, [[SHIFTED_OFFSET0_DST:r[0-9]+]]
 ; CHECK:   add     [[LOADED_VALUE0]], r0, stack[[[SHIFTED_OFFSET0_DST]]]
 ; CHECK:   add     1, [[INDEX0]], [[INDEX0]]
 ; CHECK:   sub.s!  @CPI0_0[0], [[INDEX0]], r4
@@ -29,12 +26,11 @@ define fastcc void @huge-copysize0(i256 addrspace(0)* %dest, i256 addrspace(0)* 
 ; CHECK-LABEL: huge-copysize1
 define fastcc void @huge-copysize1(i256 addrspace(1)* %dest, i256 addrspace(1)* %src) {
 ; CHECK:  add     r0, r0, [[INDEX1:r[0-9]+]]
+; CHECK:  add     r2, r0, [[LDBASE:r[0-9]+]]
+; CHECK:  add     r1, r0, [[STBASE:r[0-9]+]]
 ; CHECK:.BB1_1:
-; CHECK:  shl.s   5, [[INDEX1]], [[SHIFTED_OFFSET1_SRC:r[0-9]+]]
-; CHECK:  add     r1, [[SHIFTED_OFFSET1_SRC]], [[SHIFTED_OFFSET1_DST:r[0-9]+]]
-; CHECK:  add     r2, [[SHIFTED_OFFSET1_SRC]], [[SHIFTED_OFFSET1_SRC]]
-; CHECK:  ld.1    [[SHIFTED_OFFSET1_SRC]], [[LOADED_VALUE1:r[0-9]+]]
-; CHECK:  st.1    [[SHIFTED_OFFSET1_DST]], [[LOADED_VALUE1]]
+; CHECK:  ld.1.inc   [[LDBASE]], [[LDVAL:r[0-9]+]], [[LDBASE]]
+; CHECK:  st.1.inc   [[STBASE]], [[LDVAL]], [[STBASE]]
 ; CHECK:  add     1, [[INDEX1]], [[INDEX1]]
 ; CHECK:  sub.s!  @CPI1_0[0], [[INDEX1]], r{{[0-9]+}}
 ; CHECK:  jump.lt @.BB1_1
@@ -58,12 +54,11 @@ define fastcc void @huge-copysize1(i256 addrspace(1)* %dest, i256 addrspace(1)* 
 ; CHECK-LABEL: huge-copysize2
 define fastcc void @huge-copysize2(i256 addrspace(2)* %dest, i256 addrspace(2)* %src) {
 ; CHECK:  add     r0, r0, [[INDEX2:r[0-9]+]]
+; CHECK:  add     r2, r0, [[LDBASE:r[0-9]+]]
+; CHECK:  add     r1, r0, [[STBASE:r[0-9]+]]
 ; CHECK:.BB2_1:
-; CHECK:  shl.s   5, [[INDEX2]], [[SHIFTED_OFFSET2_SRC:r[0-9]+]]
-; CHECK:  add     r1, [[SHIFTED_OFFSET2_SRC]], [[SHIFTED_OFFSET2_DST:r[0-9]+]]
-; CHECK:  add     r2, [[SHIFTED_OFFSET2_SRC]], [[SHIFTED_OFFSET2_SRC]]
-; CHECK:  ld.2    [[SHIFTED_OFFSET2_SRC]], [[LOADED_VALUE2:r[0-9]+]]
-; CHECK:  st.2    [[SHIFTED_OFFSET2_DST]], [[LOADED_VALUE2]]
+; CHECK:  ld.2.inc   [[LDBASE]], [[LDVAL:r[0-9]+]], [[LDBASE]]
+; CHECK:  st.2.inc   [[STBASE]], [[LDVAL]], [[STBASE]]
 ; CHECK:  add     1, [[INDEX2]], [[INDEX2]]
 ; CHECK:  sub.s!  @CPI2_0[0], [[INDEX2]], r{{[0-9]+}}
 ; CHECK:  jump.lt @.BB2_1
@@ -88,13 +83,12 @@ define fastcc void @huge-copysize2(i256 addrspace(2)* %dest, i256 addrspace(2)* 
 define fastcc void @normal-known-size(i256* %dest, i256* %src) {
 ; CHECK:   add     r0, r0, [[INDEX3:r[3-9]+]]
 ; CHECK: .BB3_1:
-; CHECK:   shl.s   5, [[INDEX3]], [[SHIFTED_OFFSET3_SRC:r[3-9]+]]
-; CHECK:   add     r1, [[SHIFTED_OFFSET3_SRC]], [[SHIFTED_OFFSET3_DST:r[3-9]+]]
-; CHECK:   add     r2, [[SHIFTED_OFFSET3_SRC]], [[SHIFTED_OFFSET3_SRC]]
-; CHECK:   shr.s   5, [[SHIFTED_OFFSET3_SRC]], [[SHIFTED_OFFSET3_SRC]]
+; CHECK:   shr.s   5, [[LOAD_SHIFT_AMMOUNT:r[0-9]+]], [[SHIFTED_OFFSET3_SRC:r[3-9]+]]
 ; CHECK:   add     stack[[[SHIFTED_OFFSET3_SRC]]], r0, [[LOADED_VALUE3:r[3-9]+]]
-; CHECK:   shr.s   5, [[SHIFTED_OFFSET3_DST]], [[SHIFTED_OFFSET3_DST]]
+; CHECK:   shr.s   5, [[STORE_SHIFT_AMMOUNT:r[0-9]+]], [[SHIFTED_OFFSET3_DST:r[0-9]+]]
 ; CHECK:   add     [[LOADED_VALUE3]], r0, stack[[[SHIFTED_OFFSET3_DST]]]
+; CHECK:   add     32, [[STORE_SHIFT_AMMOUNT]], [[STORE_SHIFT_AMMOUNT]]
+; CHECK:   add     32, [[LOAD_SHIFT_AMMOUNT]], [[LOAD_SHIFT_AMMOUNT]]
 ; CHECK:   add     1, [[INDEX3]], [[INDEX3]]
 ; CHECK:   sub.s!  32, [[INDEX3]], r{{[0-9]+}}
 ; CHECK:   jump.lt @.BB3_1
@@ -106,14 +100,15 @@ define fastcc void @normal-known-size(i256* %dest, i256* %src) {
 ; CHECK-LABEL: normal-known-size-2
 define fastcc void @normal-known-size-2(i256* %dest, i256* %src) {
 ; CHECK:   add     r0, r0, [[INDEX4:r[3-9]+]]
+; CHECK:  add     r2, r0, [[LDBASE:r[0-9]+]]
+; CHECK:  add     r1, r0, [[STBASE:r[0-9]+]]
 ; CHECK: .BB4_1:
-; CHECK:   shl.s   5, [[INDEX4]], [[SHIFTED_OFFSET4_SRC:r[3-9]+]]
-; CHECK:   add     r1, [[SHIFTED_OFFSET4_SRC]], [[SHIFTED_OFFSET4_DST:r[3-9]+]]
-; CHECK:   add     r2, [[SHIFTED_OFFSET4_SRC]], [[SHIFTED_OFFSET4_SRC]]
-; CHECK:   shr.s   5, [[SHIFTED_OFFSET4_SRC]], [[SHIFTED_OFFSET4_SRC]]
+; CHECK:   shr.s   5, [[SHIFT_COUNT_SRC:r[0-9]+]], [[SHIFTED_OFFSET4_SRC:r[3-9]+]]
 ; CHECK:   add     stack[[[SHIFTED_OFFSET4_SRC]]], r0, [[LOADED_VALUE4:r[3-9]+]]
-; CHECK:   shr.s   5, [[SHIFTED_OFFSET4_DST]], [[SHIFTED_OFFSET4_DST]]
+; CHECK:   shr.s   5, [[SHIFT_COUNT_DST:r[0-9]+]], [[SHIFTED_OFFSET4_DST:r[0-9]+]]
 ; CHECK:   add     [[LOADED_VALUE4]], r0, stack[[[SHIFTED_OFFSET4_DST]]]
+; CHECK:   add     32, [[SHIFT_COUNT_DST]], [[SHIFT_COUNT_DST]]
+; CHECK:   add     32, [[SHIFT_COUNT_SRC]], [[SHIFT_COUNT_SRC]]
 ; CHECK:   add     1, [[INDEX4]], [[INDEX4]]
 ; CHECK:   sub.s!  33, [[INDEX4]], r{{[0-9]+}}
 ; CHECK:   jump.lt @.BB4_1


### PR DESCRIPTION
When lower memcpy with known size, do not use loop index to increase the base ptr. Instead, use an explicit ADD to increase the base ptr, the subsequent combine pass can recoginze such pattern and turn them into indexed load/store.