### PR TITLE
[EraVM] Register existing backend passes with LLVM pass manager

### DIFF
--- a/llvm/lib/Target/EraVM/EraVMAddConditions.cpp
+++ b/llvm/lib/Target/EraVM/EraVMAddConditions.cpp
@@ -26,7 +26,9 @@ namespace {
 class EraVMAddConditions : public MachineFunctionPass {
 public:
   static char ID;
-  EraVMAddConditions() : MachineFunctionPass(ID) {}
+  EraVMAddConditions() : MachineFunctionPass(ID) {
+    initializeEraVMAddConditionsPass(*PassRegistry::getPassRegistry());
+  }
 
   const TargetRegisterInfo *TRI;
 

--- a/llvm/lib/Target/EraVM/EraVMBytesToCells.cpp
+++ b/llvm/lib/Target/EraVM/EraVMBytesToCells.cpp
@@ -37,7 +37,9 @@ namespace {
 class EraVMBytesToCells : public MachineFunctionPass {
 public:
   static char ID;
-  EraVMBytesToCells() : MachineFunctionPass(ID) {}
+  EraVMBytesToCells() : MachineFunctionPass(ID) {
+    initializeEraVMBytesToCellsPass(*PassRegistry::getPassRegistry());
+  }
 
   const TargetRegisterInfo *TRI;
 

--- a/llvm/lib/Target/EraVM/EraVMCombineAddressingMode.cpp
+++ b/llvm/lib/Target/EraVM/EraVMCombineAddressingMode.cpp
@@ -39,7 +39,9 @@ namespace {
 class EraVMCombineAddressingMode : public MachineFunctionPass {
 public:
   static char ID;
-  EraVMCombineAddressingMode() : MachineFunctionPass(ID) {}
+  EraVMCombineAddressingMode() : MachineFunctionPass(ID) {
+    initializeEraVMCombineAddressingModePass(*PassRegistry::getPassRegistry());
+  }
 
   bool runOnMachineFunction(MachineFunction &Fn) override;
 

--- a/llvm/lib/Target/EraVM/EraVMCombineFlagSetting.cpp
+++ b/llvm/lib/Target/EraVM/EraVMCombineFlagSetting.cpp
@@ -60,7 +60,9 @@ namespace {
 class EraVMCombineFlagSetting : public MachineFunctionPass {
 public:
   static char ID;
-  EraVMCombineFlagSetting() : MachineFunctionPass(ID) {}
+  EraVMCombineFlagSetting() : MachineFunctionPass(ID) {
+    initializeEraVMCombineFlagSettingPass(*PassRegistry::getPassRegistry());
+  }
 
   bool runOnMachineFunction(MachineFunction &Fn) override;
 

--- a/llvm/lib/Target/EraVM/EraVMCombineToIndexedMemops.cpp
+++ b/llvm/lib/Target/EraVM/EraVMCombineToIndexedMemops.cpp
@@ -48,7 +48,9 @@ namespace {
 class EraVMCombineToIndexedMemops : public MachineFunctionPass {
 public:
   static char ID;
-  EraVMCombineToIndexedMemops() : MachineFunctionPass(ID) {}
+  EraVMCombineToIndexedMemops() : MachineFunctionPass(ID) {
+    initializeEraVMCombineToIndexedMemopsPass(*PassRegistry::getPassRegistry());
+  }
 
   bool runOnMachineFunction(MachineFunction &Fn) override;
 

--- a/llvm/lib/Target/EraVM/EraVMExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/EraVM/EraVMExpandPseudoInsts.cpp
@@ -26,7 +26,9 @@ namespace {
 class EraVMExpandPseudo : public MachineFunctionPass {
 public:
   static char ID;
-  EraVMExpandPseudo() : MachineFunctionPass(ID) {}
+  EraVMExpandPseudo() : MachineFunctionPass(ID) {
+    initializeEraVMExpandPseudoPass(*PassRegistry::getPassRegistry());
+  }
 
   const TargetRegisterInfo *TRI;
 

--- a/llvm/lib/Target/EraVM/EraVMExpandSelect.cpp
+++ b/llvm/lib/Target/EraVM/EraVMExpandSelect.cpp
@@ -27,7 +27,9 @@ namespace {
 class EraVMExpandSelect : public MachineFunctionPass {
 public:
   static char ID;
-  EraVMExpandSelect() : MachineFunctionPass(ID) {}
+  EraVMExpandSelect() : MachineFunctionPass(ID) {
+    initializeEraVMExpandSelectPass(*PassRegistry::getPassRegistry());
+  }
   bool runOnMachineFunction(MachineFunction &Fn) override;
   StringRef getPassName() const override { return ERAVM_EXPAND_SELECT_NAME; }
 

--- a/llvm/lib/Target/EraVM/EraVMStackAddressConstantPropagation.cpp
+++ b/llvm/lib/Target/EraVM/EraVMStackAddressConstantPropagation.cpp
@@ -37,7 +37,10 @@ struct PropagationResult {
 class EraVMStackAddressConstantPropagation : public MachineFunctionPass {
 public:
   static char ID;
-  EraVMStackAddressConstantPropagation() : MachineFunctionPass(ID) {}
+  EraVMStackAddressConstantPropagation() : MachineFunctionPass(ID) {
+    initializeEraVMStackAddressConstantPropagationPass(
+        *PassRegistry::getPassRegistry());
+  }
   bool runOnMachineFunction(MachineFunction &Fn) override;
 
   StringRef getPassName() const override {


### PR DESCRIPTION
This allows -print-after-all/-print-before-all to dump MIR around these passes.