### PR TITLE
[evm-stdlib, evm-runtime] NFC Switch to opaque pointers

### DIFF
--- a/llvm/lib/Target/EraVM/eravm-runtime.ll
+++ b/llvm/lib/Target/EraVM/eravm-runtime.ll
@@ -6,8 +6,8 @@ entry:
   %offset_lead_bytes = shl i256 %addr, 3
   %offset_lead_bits = and i256 %offset_lead_bytes, 248
   %base_int = and i256 %addr, -32
-  %base_ptr = inttoptr i256 %base_int to i256*
-  %hival = load i256, i256* %base_ptr, align 32
+  %base_ptr = inttoptr i256 %base_int to ptr
+  %hival = load i256, ptr %base_ptr, align 32
   %offset_size = add nuw nsw i256 %offset_lead_bits, %size_in_bits
   %fits_cell = icmp ult i256 %offset_size, 257
   br i1 %fits_cell, label %one_cell, label %two_cells
@@ -30,8 +30,8 @@ two_cells:
   %lo_bits_inv = sub nuw nsw i256 256, %lo_bits
   %hival_shifted = shl i256 %hival, %lo_bits
   %lo_base_int = add nuw nsw i256 %base_int, 32
-  %lo_base_ptr = inttoptr i256 %lo_base_int to i256*
-  %loval = load i256, i256* %lo_base_ptr, align 32
+  %lo_base_ptr = inttoptr i256 %lo_base_int to ptr
+  %loval = load i256, ptr %lo_base_ptr, align 32
   %loval_shifted = lshr i256 %loval, %lo_bits_inv
   %valcomb = or i256 %loval_shifted, %hival_shifted
   br label %common.ret
@@ -43,8 +43,8 @@ entry:
   %offset_lead_bits = shl nuw nsw i256 %offset_lead_bytes, 3
   %offset_lead_bits_inv = sub nuw nsw i256 256, %offset_lead_bits
   %base_int = and i256 %addr, -32
-  %base_ptr = inttoptr i256 %base_int to i256*
-  %hival_orig = load i256, i256* %base_ptr, align 32
+  %base_ptr = inttoptr i256 %base_int to ptr
+  %hival_orig = load i256, ptr %base_ptr, align 32
   %offset_size = add nuw nsw i256 %offset_lead_bits, %size_in_bits
   %fits_cell = icmp ult i256 %offset_size, 257
   %mask_hi_common.1 = shl nsw i256 -1, %offset_lead_bits_inv
@@ -63,7 +63,7 @@ one_cell:
   %mask_oc = or i256 %mask_oc_trail, %mask_hi_common
   %orig_oc_masked = and i256 %hival_orig, %mask_oc
   %store_oc.f = or i256 %orig_oc_masked, %store_oc
-  store i256 %store_oc.f, i256* %base_ptr, align 32
+  store i256 %store_oc.f, ptr %base_ptr, align 32
   br label %common.ret
 
 common.ret:
@@ -75,48 +75,48 @@ two_cells:
   %bits_outstanding_inv = sub nuw nsw i256 256, %offset_size
   %hi_val_outstanding = lshr i256 %value, %bits_outstanding
   %hi_store = or i256 %hi_orig, %hi_val_outstanding
-  store i256 %hi_store, i256* %base_ptr, align 32
+  store i256 %hi_store, ptr %base_ptr, align 32
   %lo_base_int = add nuw nsw i256 %base_int, 32
-  %lo_base_ptr = inttoptr i256 %lo_base_int to i256*
-  %loval_orig = load i256, i256* %lo_base_ptr, align 32
+  %lo_base_ptr = inttoptr i256 %lo_base_int to ptr
+  %loval_orig = load i256, ptr %lo_base_ptr, align 32
   %lo_store = shl nuw nsw i256 %value, %bits_outstanding_inv
   %loval_mask = lshr i256 -1, %bits_outstanding
   %loval_masked = and i256 %loval_orig, %loval_mask
   %loval_store = or i256 %loval_masked, %lo_store
-  store i256 %loval_store, i256* %lo_base_ptr, align 32
+  store i256 %loval_store, ptr %lo_base_ptr, align 32
   br label %common.ret
 }
 
 define void @__small_store_as1(i256 %addr.i, i256 %value, i256 %size_in_bits) local_unnamed_addr #1 {
-  %addr = inttoptr i256 %addr.i to i256 addrspace(1)*
+  %addr = inttoptr i256 %addr.i to ptr addrspace(1)
   %sizeinv = sub nuw nsw i256 256, %size_in_bits
   %maskload = lshr i256 -1, %size_in_bits
   %maskval = shl nsw i256 -1, %sizeinv
   %val.m = and i256 %maskval, %value
-  %oldval = load i256, i256 addrspace(1)* %addr, align 1
+  %oldval = load i256, ptr addrspace(1) %addr, align 1
   %oldval.m = and i256 %oldval, %maskload
   %val.f = or i256 %oldval.m, %val.m
-  store i256 %val.f, i256 addrspace(1)* %addr, align 1
+  store i256 %val.f, ptr addrspace(1) %addr, align 1
   ret void
 }
 
 define void @__small_store_as2(i256 %addr.i, i256 %value, i256 %size_in_bits) local_unnamed_addr #1 {
-  %addr = inttoptr i256 %addr.i to i256 addrspace(2)*
+  %addr = inttoptr i256 %addr.i to ptr addrspace(2)
   %sizeinv = sub nuw nsw i256 256, %size_in_bits
   %maskload = lshr i256 -1, %size_in_bits
   %maskval = shl nsw i256 -1, %sizeinv
   %val.m = and i256 %maskval, %value
-  %oldval = load i256, i256 addrspace(2)* %addr, align 1
+  %oldval = load i256, ptr addrspace(2) %addr, align 1
   %oldval.m = and i256 %oldval, %maskload
   %val.f = or i256 %oldval.m, %val.m
-  store i256 %val.f, i256 addrspace(2)* %addr, align 1
+  store i256 %val.f, ptr addrspace(2) %addr, align 1
   ret void
 }
 
-define void @__memset_uma_as1(i256 addrspace(1)* %dest, i256 %val, i256 %size) local_unnamed_addr #2 {
+define void @__memset_uma_as1(ptr addrspace(1) %dest, i256 %val, i256 %size) local_unnamed_addr #2 {
 entry:
   %hascells.not = icmp ult i256 %size, 32
-  %dest.int = ptrtoint i256 addrspace(1)* %dest to i256
+  %dest.int = ptrtoint ptr addrspace(1) %dest to i256
   br i1 %hascells.not, label %copybytes, label %copycells.preheader
 
 copycells.preheader:
@@ -126,8 +126,8 @@ copycells.preheader:
 copycells:
   %cellsrem = phi i256 [ %cellsrem.next, %copycells ], [ %numcells1, %copycells.preheader ]
   %currentdest.int = phi i256 [ %currentdest.inext, %copycells ], [ %dest.int, %copycells.preheader ]
-  %currentdest = inttoptr i256 %currentdest.int to i256 addrspace(1)*
-  store i256 %val, i256 addrspace(1)* %currentdest, align 1
+  %currentdest = inttoptr i256 %currentdest.int to ptr addrspace(1)
+  store i256 %val, ptr addrspace(1) %currentdest, align 1
   %currentdest.inext = add nuw nsw i256 %currentdest.int, 32
   %cellsrem.next = add nsw i256 %cellsrem, -1
   %continue.not = icmp eq i256 %cellsrem.next, 0
@@ -144,22 +144,22 @@ common.ret:
 
 residual:
   %rembits = shl nuw nsw i256 %rembytes, 3
-  %addr.i = inttoptr i256 %addr.int to i256 addrspace(1)*
+  %addr.i = inttoptr i256 %addr.int to ptr addrspace(1)
   %sizeinv.i = sub nuw nsw i256 256, %rembits
   %maskload.i = lshr i256 -1, %rembits
   %maskval.i = shl nsw i256 -1, %sizeinv.i
   %val.m.i = and i256 %maskval.i, %val
-  %oldval.i = load i256, i256 addrspace(1)* %addr.i, align 1
+  %oldval.i = load i256, ptr addrspace(1) %addr.i, align 1
   %oldval.m.i = and i256 %oldval.i, %maskload.i
   %val.f.i = or i256 %oldval.m.i, %val.m.i
-  store i256 %val.f.i, i256 addrspace(1)* %addr.i, align 1
+  store i256 %val.f.i, ptr addrspace(1) %addr.i, align 1
   br label %common.ret
 }
 
-define void @__memset_uma_as2(i256 addrspace(2)* %dest, i256 %val, i256 %size) local_unnamed_addr #2 {
+define void @__memset_uma_as2(ptr addrspace(2) %dest, i256 %val, i256 %size) local_unnamed_addr #2 {
 entry:
   %hascells.not = icmp ult i256 %size, 32
-  %dest.int = ptrtoint i256 addrspace(2)* %dest to i256
+  %dest.int = ptrtoint ptr addrspace(2) %dest to i256
   br i1 %hascells.not, label %copybytes, label %copycells.preheader
 
 copycells.preheader:
@@ -169,8 +169,8 @@ copycells.preheader:
 copycells:
   %cellsrem = phi i256 [ %cellsrem.next, %copycells ], [ %numcells1, %copycells.preheader ]
   %currentdest.int = phi i256 [ %currentdest.inext, %copycells ], [ %dest.int, %copycells.preheader ]
-  %currentdest = inttoptr i256 %currentdest.int to i256 addrspace(2)*
-  store i256 %val, i256 addrspace(2)* %currentdest, align 1
+  %currentdest = inttoptr i256 %currentdest.int to ptr addrspace(2)
+  store i256 %val, ptr addrspace(2) %currentdest, align 1
   %currentdest.inext = add nuw nsw i256 %currentdest.int, 32
   %cellsrem.next = add nsw i256 %cellsrem, -1
   %continue.not = icmp eq i256 %cellsrem.next, 0
@@ -187,146 +187,146 @@ common.ret:
 
 residual:
   %rembits = shl nuw nsw i256 %rembytes, 3
-  %addr.i = inttoptr i256 %addr.int to i256 addrspace(2)*
+  %addr.i = inttoptr i256 %addr.int to ptr addrspace(2)
   %sizeinv.i = sub nuw nsw i256 256, %rembits
   %maskload.i = lshr i256 -1, %rembits
   %maskval.i = shl nsw i256 -1, %sizeinv.i
   %val.m.i = and i256 %maskval.i, %val
-  %oldval.i = load i256, i256 addrspace(2)* %addr.i, align 1
+  %oldval.i = load i256, ptr addrspace(2) %addr.i, align 1
   %oldval.m.i = and i256 %oldval.i, %maskload.i
   %val.f.i = or i256 %oldval.m.i, %val.m.i
-  store i256 %val.f.i, i256 addrspace(2)* %addr.i, align 1
+  store i256 %val.f.i, ptr addrspace(2) %addr.i, align 1
   br label %common.ret
 }
 
-define {i8 addrspace(3)*, i1} @__farcall(i256 %abi_params, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12) #3 personality i32 ()* @__personality {
+define {ptr addrspace(3), i1} @__farcall(i256 %abi_params, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12) #3 personality ptr @__personality {
 entry:
-  %invoke_res = invoke i8 addrspace(3)* @__farcall_int(i256 %abi_params, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12)
+  %invoke_res = invoke ptr addrspace(3) @__farcall_int(i256 %abi_params, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12)
     to label %ok unwind label %err
 ok:
-  %res.1u = insertvalue {i8 addrspace(3)*, i1} undef, i8 addrspace(3)* %invoke_res, 0
-  %res.1f = insertvalue {i8 addrspace(3)*, i1} %res.1u, i1 1, 1
-  ret {i8 addrspace(3)*, i1} %res.1f
+  %res.1u = insertvalue {ptr addrspace(3), i1} undef, ptr addrspace(3) %invoke_res, 0
+  %res.1f = insertvalue {ptr addrspace(3), i1} %res.1u, i1 1, 1
+  ret {ptr addrspace(3), i1} %res.1f
 
 err:
-  %res.2u = landingpad {i8 addrspace(3)*, i1} cleanup
-  %res.2f = insertvalue {i8 addrspace(3)*, i1} %res.2u, i1 0, 1
-  ret {i8 addrspace(3)*, i1} %res.2f
+  %res.2u = landingpad {ptr addrspace(3), i1} cleanup
+  %res.2f = insertvalue {ptr addrspace(3), i1} %res.2u, i1 0, 1
+  ret {ptr addrspace(3), i1} %res.2f
 }
 
-define {i8 addrspace(3)*, i1} @__staticcall(i256 %abi_params, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12) #3 personality i32 ()* @__personality {
+define {ptr addrspace(3), i1} @__staticcall(i256 %abi_params, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12) #3 personality ptr @__personality {
 entry:
-  %invoke_res = invoke i8 addrspace(3)* @__staticcall_int(i256 %abi_params, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12)
+  %invoke_res = invoke ptr addrspace(3) @__staticcall_int(i256 %abi_params, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12)
     to label %ok unwind label %err
 ok:
-  %res.1u = insertvalue {i8 addrspace(3)*, i1} undef, i8 addrspace(3)* %invoke_res, 0
-  %res.1f = insertvalue {i8 addrspace(3)*, i1} %res.1u, i1 1, 1
-  ret {i8 addrspace(3)*, i1} %res.1f
+  %res.1u = insertvalue {ptr addrspace(3), i1} undef, ptr addrspace(3) %invoke_res, 0
+  %res.1f = insertvalue {ptr addrspace(3), i1} %res.1u, i1 1, 1
+  ret {ptr addrspace(3), i1} %res.1f
 
 err:
-  %res.2u = landingpad {i8 addrspace(3)*, i1} cleanup
-  %res.2f = insertvalue {i8 addrspace(3)*, i1} %res.2u, i1 0, 1
-  ret {i8 addrspace(3)*, i1} %res.2f
+  %res.2u = landingpad {ptr addrspace(3), i1} cleanup
+  %res.2f = insertvalue {ptr addrspace(3), i1} %res.2u, i1 0, 1
+  ret {ptr addrspace(3), i1} %res.2f
 }
 
-define {i8 addrspace(3)*, i1} @__delegatecall(i256 %abi_params, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12) #3 personality i32 ()* @__personality {
+define {ptr addrspace(3), i1} @__delegatecall(i256 %abi_params, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12) #3 personality ptr @__personality {
 entry:
-  %invoke_res = invoke i8 addrspace(3)* @__delegatecall_int(i256 %abi_params, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12)
+  %invoke_res = invoke ptr addrspace(3) @__delegatecall_int(i256 %abi_params, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12)
     to label %ok unwind label %err
 ok:
-  %res.1u = insertvalue {i8 addrspace(3)*, i1} undef, i8 addrspace(3)* %invoke_res, 0
-  %res.1f = insertvalue {i8 addrspace(3)*, i1} %res.1u, i1 1, 1
-  ret {i8 addrspace(3)*, i1} %res.1f
+  %res.1u = insertvalue {ptr addrspace(3), i1} undef, ptr addrspace(3) %invoke_res, 0
+  %res.1f = insertvalue {ptr addrspace(3), i1} %res.1u, i1 1, 1
+  ret {ptr addrspace(3), i1} %res.1f
 
 err:
-  %res.2u = landingpad {i8 addrspace(3)*, i1} cleanup
-  %res.2f = insertvalue {i8 addrspace(3)*, i1} %res.2u, i1 0, 1
-  ret {i8 addrspace(3)*, i1} %res.2f
+  %res.2u = landingpad {ptr addrspace(3), i1} cleanup
+  %res.2f = insertvalue {ptr addrspace(3), i1} %res.2u, i1 0, 1
+  ret {ptr addrspace(3), i1} %res.2f
 }
 
-define {i8 addrspace(3)*, i1} @__mimiccall(i256 %abi_params, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12, i256 %mimic) #3 personality i32 ()* @__personality {
+define {ptr addrspace(3), i1} @__mimiccall(i256 %abi_params, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12, i256 %mimic) #3 personality ptr @__personality {
 entry:
-  %invoke_res = invoke i8 addrspace(3)* @__mimiccall_int(i256 %abi_params, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12, i256 %mimic)
+  %invoke_res = invoke ptr addrspace(3) @__mimiccall_int(i256 %abi_params, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12, i256 %mimic)
     to label %ok unwind label %err
 ok:
-  %res.1u = insertvalue {i8 addrspace(3)*, i1} undef, i8 addrspace(3)* %invoke_res, 0
-  %res.1f = insertvalue {i8 addrspace(3)*, i1} %res.1u, i1 1, 1
-  ret {i8 addrspace(3)*, i1} %res.1f
+  %res.1u = insertvalue {ptr addrspace(3), i1} undef, ptr addrspace(3) %invoke_res, 0
+  %res.1f = insertvalue {ptr addrspace(3), i1} %res.1u, i1 1, 1
+  ret {ptr addrspace(3), i1} %res.1f
 
 err:
-  %res.2u = landingpad {i8 addrspace(3)*, i1} cleanup
-  %res.2f = insertvalue {i8 addrspace(3)*, i1} %res.2u, i1 0, 1
-  ret {i8 addrspace(3)*, i1} %res.2f
+  %res.2u = landingpad {ptr addrspace(3), i1} cleanup
+  %res.2f = insertvalue {ptr addrspace(3), i1} %res.2u, i1 0, 1
+  ret {ptr addrspace(3), i1} %res.2f
 }
 
-define {i8 addrspace(3)*, i1} @__farcall_byref(i8 addrspace(3)* %abi_params.r, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12) #3 personality i32 ()* @__personality {
+define {ptr addrspace(3), i1} @__farcall_byref(ptr addrspace(3) %abi_params.r, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12) #3 personality ptr @__personality {
 entry:
-  %abi_params = ptrtoint i8 addrspace(3)* %abi_params.r to i256
-  %invoke_res = invoke i8 addrspace(3)* @__farcall_int(i256 %abi_params, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12)
+  %abi_params = ptrtoint ptr addrspace(3) %abi_params.r to i256
+  %invoke_res = invoke ptr addrspace(3) @__farcall_int(i256 %abi_params, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12)
     to label %ok unwind label %err
 ok:
-  %res.1u = insertvalue {i8 addrspace(3)*, i1} undef, i8 addrspace(3)* %invoke_res, 0
-  %res.1f = insertvalue {i8 addrspace(3)*, i1} %res.1u, i1 1, 1
-  ret {i8 addrspace(3)*, i1} %res.1f
+  %res.1u = insertvalue {ptr addrspace(3), i1} undef, ptr addrspace(3) %invoke_res, 0
+  %res.1f = insertvalue {ptr addrspace(3), i1} %res.1u, i1 1, 1
+  ret {ptr addrspace(3), i1} %res.1f
 
 err:
-  %res.2u = landingpad {i8 addrspace(3)*, i1} cleanup
-  %res.2f = insertvalue {i8 addrspace(3)*, i1} %res.2u, i1 0, 1
-  ret {i8 addrspace(3)*, i1} %res.2f
+  %res.2u = landingpad {ptr addrspace(3), i1} cleanup
+  %res.2f = insertvalue {ptr addrspace(3), i1} %res.2u, i1 0, 1
+  ret {ptr addrspace(3), i1} %res.2f
 }
 
-define {i8 addrspace(3)*, i1} @__staticcall_byref(i8 addrspace(3)* %abi_params.r, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12) #3 personality i32 ()* @__personality {
+define {ptr addrspace(3), i1} @__staticcall_byref(ptr addrspace(3) %abi_params.r, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12) #3 personality ptr @__personality {
 entry:
-  %abi_params = ptrtoint i8 addrspace(3)* %abi_params.r to i256
-  %invoke_res = invoke i8 addrspace(3)* @__staticcall_int(i256 %abi_params, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12)
+  %abi_params = ptrtoint ptr addrspace(3) %abi_params.r to i256
+  %invoke_res = invoke ptr addrspace(3) @__staticcall_int(i256 %abi_params, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12)
     to label %ok unwind label %err
 ok:
-  %res.1u = insertvalue {i8 addrspace(3)*, i1} undef, i8 addrspace(3)* %invoke_res, 0
-  %res.1f = insertvalue {i8 addrspace(3)*, i1} %res.1u, i1 1, 1
-  ret {i8 addrspace(3)*, i1} %res.1f
+  %res.1u = insertvalue {ptr addrspace(3), i1} undef, ptr addrspace(3) %invoke_res, 0
+  %res.1f = insertvalue {ptr addrspace(3), i1} %res.1u, i1 1, 1
+  ret {ptr addrspace(3), i1} %res.1f
 
 err:
-  %res.2u = landingpad {i8 addrspace(3)*, i1} cleanup
-  %res.2f = insertvalue {i8 addrspace(3)*, i1} %res.2u, i1 0, 1
-  ret {i8 addrspace(3)*, i1} %res.2f
+  %res.2u = landingpad {ptr addrspace(3), i1} cleanup
+  %res.2f = insertvalue {ptr addrspace(3), i1} %res.2u, i1 0, 1
+  ret {ptr addrspace(3), i1} %res.2f
 }
 
-define {i8 addrspace(3)*, i1} @__delegatecall_byref(i8 addrspace(3)* %abi_params.r, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12) #3 personality i32 ()* @__personality {
+define {ptr addrspace(3), i1} @__delegatecall_byref(ptr addrspace(3) %abi_params.r, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12) #3 personality ptr @__personality {
 entry:
-  %abi_params = ptrtoint i8 addrspace(3)* %abi_params.r to i256
-  %invoke_res = invoke i8 addrspace(3)* @__delegatecall_int(i256 %abi_params, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12)
+  %abi_params = ptrtoint ptr addrspace(3) %abi_params.r to i256
+  %invoke_res = invoke ptr addrspace(3) @__delegatecall_int(i256 %abi_params, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12)
     to label %ok unwind label %err
 ok:
-  %res.1u = insertvalue {i8 addrspace(3)*, i1} undef, i8 addrspace(3)* %invoke_res, 0
-  %res.1f = insertvalue {i8 addrspace(3)*, i1} %res.1u, i1 1, 1
-  ret {i8 addrspace(3)*, i1} %res.1f
+  %res.1u = insertvalue {ptr addrspace(3), i1} undef, ptr addrspace(3) %invoke_res, 0
+  %res.1f = insertvalue {ptr addrspace(3), i1} %res.1u, i1 1, 1
+  ret {ptr addrspace(3), i1} %res.1f
 
 err:
-  %res.2u = landingpad {i8 addrspace(3)*, i1} cleanup
-  %res.2f = insertvalue {i8 addrspace(3)*, i1} %res.2u, i1 0, 1
-  ret {i8 addrspace(3)*, i1} %res.2f
+  %res.2u = landingpad {ptr addrspace(3), i1} cleanup
+  %res.2f = insertvalue {ptr addrspace(3), i1} %res.2u, i1 0, 1
+  ret {ptr addrspace(3), i1} %res.2f
 }
 
-define {i8 addrspace(3)*, i1} @__mimiccall_byref(i8 addrspace(3)* %abi_params.r, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12, i256 %mimic) #3 personality i32 ()* @__personality {
+define {ptr addrspace(3), i1} @__mimiccall_byref(ptr addrspace(3) %abi_params.r, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12, i256 %mimic) #3 personality ptr @__personality {
 entry:
-  %abi_params = ptrtoint i8 addrspace(3)* %abi_params.r to i256
-  %invoke_res = invoke i8 addrspace(3)* @__mimiccall_int(i256 %abi_params, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12, i256 %mimic)
+  %abi_params = ptrtoint ptr addrspace(3) %abi_params.r to i256
+  %invoke_res = invoke ptr addrspace(3) @__mimiccall_int(i256 %abi_params, i256 %address, i256 %p3, i256 %p4, i256 %p5, i256 %p6, i256 %p7, i256 %p8, i256 %p9, i256 %p10, i256 %p11, i256 %p12, i256 %mimic)
     to label %ok unwind label %err
 ok:
-  %res.1u = insertvalue {i8 addrspace(3)*, i1} undef, i8 addrspace(3)* %invoke_res, 0
-  %res.1f = insertvalue {i8 addrspace(3)*, i1} %res.1u, i1 1, 1
-  ret {i8 addrspace(3)*, i1} %res.1f
+  %res.1u = insertvalue {ptr addrspace(3), i1} undef, ptr addrspace(3) %invoke_res, 0
+  %res.1f = insertvalue {ptr addrspace(3), i1} %res.1u, i1 1, 1
+  ret {ptr addrspace(3), i1} %res.1f
 
 err:
-  %res.2u = landingpad {i8 addrspace(3)*, i1} cleanup
-  %res.2f = insertvalue {i8 addrspace(3)*, i1} %res.2u, i1 0, 1
-  ret {i8 addrspace(3)*, i1} %res.2f
+  %res.2u = landingpad {ptr addrspace(3), i1} cleanup
+  %res.2f = insertvalue {ptr addrspace(3), i1} %res.2u, i1 0, 1
+  ret {ptr addrspace(3), i1} %res.2f
 }
 
-declare i8 addrspace(3)* @__farcall_int(i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256)
-declare i8 addrspace(3)* @__staticcall_int(i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256)
-declare i8 addrspace(3)* @__delegatecall_int(i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256)
-declare i8 addrspace(3)* @__mimiccall_int(i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256)
+declare ptr addrspace(3) @__farcall_int(i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256)
+declare ptr addrspace(3) @__staticcall_int(i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256)
+declare ptr addrspace(3) @__delegatecall_int(i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256)
+declare ptr addrspace(3) @__mimiccall_int(i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256)
 declare i32 @__personality()
 
 attributes #0 = { mustprogress nofree norecurse nosync nounwind readonly willreturn }

--- a/llvm/lib/Target/EraVM/eravm-stdlib.ll
+++ b/llvm/lib/Target/EraVM/eravm-stdlib.ll
@@ -246,8 +246,8 @@ entry:
   ret i256 %res
 }
 
-define void @__cxa_throw(i8* %addr, i8*, i8*) #3 {
-  %addrval = ptrtoint i8* %addr to i256
+define void @__cxa_throw(ptr %addr, ptr, ptr) #3 {
+  %addrval = ptrtoint ptr %addr to i256
   call void @llvm.eravm.throw(i256 %addrval)
   unreachable
 }
@@ -332,23 +332,23 @@ entry:
   ret i256 %abi
 }
 
-define void @__revert(i256 %0, i256 %1, i256 %2) "noinline-oz" #5 personality i32()* @__personality {
+define void @__revert(i256 %0, i256 %1, i256 %2) "noinline-oz" #5 personality ptr @__personality {
 entry:
-  %abi = call i256@__aux_pack_abi(i256 %0, i256 %1, i256 %2)
+  %abi = call i256 @__aux_pack_abi(i256 %0, i256 %1, i256 %2)
   tail call void @llvm.eravm.revert(i256 %abi)
   unreachable
 }
 
-define void @__return(i256 %0, i256 %1, i256 %2) "noinline-oz" #5 personality i32()* @__personality {
+define void @__return(i256 %0, i256 %1, i256 %2) "noinline-oz" #5 personality ptr @__personality {
 entry:
-  %abi = call i256@__aux_pack_abi(i256 %0, i256 %1, i256 %2)
+  %abi = call i256 @__aux_pack_abi(i256 %0, i256 %1, i256 %2)
   tail call void @llvm.eravm.return(i256 %abi)
   unreachable
 }
 
-define i256 @__sha3(i8 addrspace(1)* nocapture nofree noundef %0, i256 %1, i1 %throw_at_failure) "noinline-oz" #1 personality i32()* @__personality {
+define i256 @__sha3(ptr addrspace(1) nocapture nofree noundef %0, i256 %1, i1 %throw_at_failure) "noinline-oz" #1 personality ptr @__personality {
 entry:
-  %addr_int = ptrtoint i8 addrspace(1)* %0 to i256
+  %addr_int = ptrtoint ptr addrspace(1) %0 to i256
   %2 = tail call i256 @llvm.umin.i256(i256 %addr_int, i256 4294967295)
   %3 = tail call i256 @llvm.umin.i256(i256 %1, i256 4294967295)
   %gas_left = tail call i256 @llvm.eravm.gasleft()
@@ -359,14 +359,13 @@ entry:
   %abi_data_offset_and_length = add i256 %abi_data_input_length_shifted, %abi_data_input_offset_shifted
   %abi_data_add_gas = add i256 %abi_data_gas_shifted, %abi_data_offset_and_length
   %abi_data_add_system_call_marker = add i256 %abi_data_add_gas, 904625697166532776746648320380374280103671755200316906558262375061821325312
-  %call_external = tail call { i8 addrspace(3)*, i1 } @__staticcall(i256 %abi_data_add_system_call_marker, i256 32784, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef)
-  %status_code = extractvalue { i8 addrspace(3)*, i1 } %call_external, 1
+  %call_external = tail call { ptr addrspace(3), i1 } @__staticcall(i256 %abi_data_add_system_call_marker, i256 32784, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef, i256 undef)
+  %status_code = extractvalue { ptr addrspace(3), i1 } %call_external, 1
   br i1 %status_code, label %success_block, label %failure_block
 
 success_block:
-  %abi_data_pointer = extractvalue { i8 addrspace(3)*, i1 } %call_external, 0
-  %data_pointer = bitcast i8 addrspace(3)* %abi_data_pointer to i256 addrspace(3)*
-  %keccak256_child_data = load i256, i256 addrspace(3)* %data_pointer, align 1
+  %abi_data_pointer = extractvalue { ptr addrspace(3), i1 } %call_external, 0
+  %keccak256_child_data = load i256, ptr addrspace(3) %abi_data_pointer, align 1
   ret i256 %keccak256_child_data
 
 failure_block:
@@ -377,18 +376,18 @@ revert_block:
   unreachable
 
 throw_block:
-  call void @__cxa_throw(i8* noalias nocapture nofree align 32 null, i8* noalias nocapture nofree align 32 undef, i8* noalias nocapture nofree align 32 undef)
+  call void @__cxa_throw(ptr noalias nocapture nofree align 32 null, ptr noalias nocapture nofree align 32 undef, ptr noalias nocapture nofree align 32 undef)
   unreachable
 }
 
-define void @__mstore8(i256 addrspace(1)* nocapture nofree noundef dereferenceable(32) %addr, i256 %val) #2 {
+define void @__mstore8(ptr addrspace(1) nocapture nofree noundef dereferenceable(32) %addr, i256 %val) #2 {
 entry:
-  %orig_value = load i256, i256 addrspace(1)* %addr, align 1
+  %orig_value = load i256, ptr addrspace(1) %addr, align 1
   %orig_value_shifted_left = shl i256 %orig_value, 8
   %orig_value_shifted_right = lshr i256 %orig_value_shifted_left, 8
   %byte_value_shifted = shl i256 %val, 248
   %store_result = or i256 %orig_value_shifted_right, %byte_value_shifted
-  store i256 %store_result, i256 addrspace(1)* %addr, align 1
+  store i256 %store_result, ptr addrspace(1) %addr, align 1
   ret void
 }
 
@@ -462,7 +461,7 @@ declare i256 @llvm.eravm.gasleft()
 declare void @llvm.eravm.revert(i256)
 declare void @llvm.eravm.return(i256)
 declare i32 @__personality()
-declare { i8 addrspace(3)*, i1 } @__staticcall(i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256) #1
+declare { ptr addrspace(3), i1 } @__staticcall(i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256, i256) #1
 
 attributes #0 = { mustprogress nofree norecurse nosync nounwind readnone willreturn }
 attributes #1 = { argmemonly readonly nofree null_pointer_is_valid }

--- a/llvm/test/CodeGen/EraVM/2dim-arr-bug.ll
+++ b/llvm/test/CodeGen/EraVM/2dim-arr-bug.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s | FileCheck %s
+; RUN: llc -opaque-pointers < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"

--- a/llvm/test/CodeGen/EraVM/add.ll
+++ b/llvm/test/CodeGen/EraVM/add.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s | FileCheck %s
+; RUN: llc -opaque-pointers < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"

--- a/llvm/test/CodeGen/EraVM/addfi.bug.ll
+++ b/llvm/test/CodeGen/EraVM/addfi.bug.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s | FileCheck %s
+; RUN: llc -opaque-pointers < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"

--- a/llvm/test/CodeGen/EraVM/adjsp.ll
+++ b/llvm/test/CodeGen/EraVM/adjsp.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s | FileCheck %s
+; RUN: llc -opaque-pointers < %s | FileCheck %s
 target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"
 

--- a/llvm/test/CodeGen/EraVM/and.ll
+++ b/llvm/test/CodeGen/EraVM/and.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s | FileCheck %s
+; RUN: llc -opaque-pointers < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"

--- a/llvm/test/CodeGen/EraVM/brcc.ll
+++ b/llvm/test/CodeGen/EraVM/brcc.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s | FileCheck %s
+; RUN: llc -opaque-pointers < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"

--- a/llvm/test/CodeGen/EraVM/combine-flag-setting.ll
+++ b/llvm/test/CodeGen/EraVM/combine-flag-setting.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s | FileCheck %s
+; RUN: llc -opaque-pointers < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"

--- a/llvm/test/CodeGen/EraVM/compound.ll
+++ b/llvm/test/CodeGen/EraVM/compound.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s | FileCheck %s
+; RUN: llc -opaque-pointers < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i256:256:256-S32"
 target triple = "eravm"

--- a/llvm/test/CodeGen/EraVM/cond_mbb.ll
+++ b/llvm/test/CodeGen/EraVM/cond_mbb.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s | FileCheck %s
+; RUN: llc -opaque-pointers < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"

--- a/llvm/test/CodeGen/EraVM/cxa_throw.ll
+++ b/llvm/test/CodeGen/EraVM/cxa_throw.ll
@@ -1,6 +1,5 @@
-; RUN: llc < %s | FileCheck %s
-source_filename = "main"
-target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
+; RUN: llc -opaque-pointers < %s | FileCheck %s
+target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"
 
 declare i32 @__personality()

--- a/llvm/test/CodeGen/EraVM/def-spill.ll
+++ b/llvm/test/CodeGen/EraVM/def-spill.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s | FileCheck %s
+; RUN: llc -opaque-pointers < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"

--- a/llvm/test/CodeGen/EraVM/exception-handling.ll
+++ b/llvm/test/CodeGen/EraVM/exception-handling.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s | FileCheck %s
+; RUN: llc -opaque-pointers < %s | FileCheck %s
 target datalayout = "E-p:256:256-i256:256:256-S32"
 target triple = "eravm"
 

--- a/llvm/test/CodeGen/EraVM/farcall-spill.ll
+++ b/llvm/test/CodeGen/EraVM/farcall-spill.ll
@@ -1,4 +1,4 @@
-; RUN: llc --verify-coalescing --enable-eravm-combine-addressing-mode=false < %s | FileCheck %s
+; RUN: llc -opaque-pointers --verify-coalescing --enable-eravm-combine-addressing-mode=false < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"

--- a/llvm/test/CodeGen/EraVM/flag-setting-set-implicit-flags.ll
+++ b/llvm/test/CodeGen/EraVM/flag-setting-set-implicit-flags.ll
@@ -1,4 +1,4 @@
-; RUN: llc -march=eravm -stop-after=eravm-combine-flag-setting -simplify-mir < %s | FileCheck %s
+; RUN: llc -opaque-pointers -march=eravm -stop-after=eravm-combine-flag-setting -simplify-mir < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"

--- a/llvm/test/CodeGen/EraVM/frame_memory.ll
+++ b/llvm/test/CodeGen/EraVM/frame_memory.ll
@@ -1,4 +1,4 @@
-; RUN: llc --enable-eravm-combine-addressing-mode=false < %s | FileCheck %s
+; RUN: llc -opaque-pointers --enable-eravm-combine-addressing-mode=false < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i256:256:256-S32"
 target triple = "eravm"

--- a/llvm/test/CodeGen/EraVM/frameindex.bug.ll
+++ b/llvm/test/CodeGen/EraVM/frameindex.bug.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s | FileCheck %s
+; RUN: llc -opaque-pointers < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"

--- a/llvm/test/CodeGen/EraVM/globals.ll
+++ b/llvm/test/CodeGen/EraVM/globals.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s | FileCheck %s
+; RUN: llc -opaque-pointers < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"

--- a/llvm/test/CodeGen/EraVM/intrinsic.ll
+++ b/llvm/test/CodeGen/EraVM/intrinsic.ll
@@ -1,4 +1,4 @@
-; RUN: opt -O3 < %s | llc | FileCheck %s
+; RUN: opt -opaque-pointers -O3 < %s | llc | FileCheck %s
 
 target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"

--- a/llvm/test/CodeGen/EraVM/load-narrowing-disable.ll
+++ b/llvm/test/CodeGen/EraVM/load-narrowing-disable.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s | FileCheck %s
+; RUN: llc -opaque-pointers < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"

--- a/llvm/test/CodeGen/EraVM/memcpy-expansion.ll
+++ b/llvm/test/CodeGen/EraVM/memcpy-expansion.ll
@@ -1,51 +1,51 @@
-; RUN: llc -stop-after eravm-alloca-hoisting < %s | FileCheck %s
+; RUN: llc -opaque-pointers -stop-after eravm-alloca-hoisting < %s | FileCheck %s
 target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm-unknown-unknown"
 
 ; Function Attrs: argmemonly mustprogress nofree nounwind willreturn
-declare void @llvm.memcpy.p1i256.p3i256.i256(i256 addrspace(1)* noalias nocapture writeonly, i256 addrspace(3)* noalias nocapture readonly, i256, i1 immarg)
-declare void @llvm.memcpy.p1i256.p1i256.i256(i256 addrspace(1)* noalias nocapture writeonly, i256 addrspace(1)* noalias nocapture readonly, i256, i1 immarg)
+declare void @llvm.memcpy.p1.p3.i256(ptr addrspace(1) noalias nocapture writeonly, ptr addrspace(3) noalias nocapture readonly, i256, i1 immarg)
+declare void @llvm.memcpy.p1.p1.i256(ptr addrspace(1) noalias nocapture writeonly, ptr addrspace(1) noalias nocapture readonly, i256, i1 immarg)
 
 ; CHECK-LABEL: expand-known
-define fastcc void @expand-known(i256 addrspace(1)* %dest, i256 addrspace(3)* %src) {
+define fastcc void @expand-known(ptr addrspace(1) %dest, ptr addrspace(3) %src) {
 ; Loop
 ; CHECK:   %loop-index = phi i256 [ 0, %{{.*}} ], [ [[NEWCTR:%[0-9]+]], %load-store-loop ]
-; CHECK:   [[REG:%[0-9]+]] = load i256, i256 addrspace(3)* %{{[0-9]+}}, align 1
-; CHECK:   store i256 [[REG]], i256 addrspace(1)* %{{[0-9]+}}, align 1
+; CHECK:   [[REG:%[0-9]+]] = load i256, ptr addrspace(3) %{{[0-9]+}}, align 1
+; CHECK:   store i256 [[REG]], ptr addrspace(1) %{{[0-9]+}}, align 1
 ; CHECK:   [[NEWCTR]] = add i256 %loop-index, 1
 
 ; Residual
-; CHECK:   [[PART1:%[0-9]+]] = load i256, i256 addrspace(3)* %{{[0-9]+}}, align 1
+; CHECK:   [[PART1:%[0-9]+]] = load i256, ptr addrspace(3) %{{[0-9]+}}, align 1
 ; CHECK:   [[PART1_M:%[0-9]+]] = and i256 [[PART1]], -{{[0-9]+}}
-; CHECK:   [[PART2:%[0-9]+]] = load i256, i256 addrspace(1)* %{{[0-9]+}}, align 1
+; CHECK:   [[PART2:%[0-9]+]] = load i256, ptr addrspace(1) %{{[0-9]+}}, align 1
 ; CHECK:   [[PART2_M:%[0-9]+]] = and i256 [[PART2]], {{[0-9]+}}
 ; CHECK:   [[RES:%[0-9]+]] = or i256 [[PART1_M]], [[PART2_M]]
-; CHECK:   store i256 [[RES]], i256 addrspace(1)* %{{[0-9]+}}, align 1
-  call void @llvm.memcpy.p1i256.p3i256.i256(i256 addrspace(1)* %dest, i256 addrspace(3)* %src, i256 42, i1 false)
+; CHECK:   store i256 [[RES]], ptr addrspace(1) %{{[0-9]+}}, align 1
+  call void @llvm.memcpy.p1.p3.i256(ptr addrspace(1) %dest, ptr addrspace(3) %src, i256 42, i1 false)
   ret void
 }
 
 ; CHECK-LABEL: expand-unknown
-define fastcc void @expand-unknown(i256 addrspace(1)* %dest, i256 addrspace(3)* %src, i256 %size) {
+define fastcc void @expand-unknown(ptr addrspace(1) %dest, ptr addrspace(3) %src, i256 %size) {
 ; CHECK:   %loop-count = udiv i256 %size, 32
 ; CHECK:   %residual-bytes = urem i256 %size, 32
 ; CHECK:   [[COND1:%[0-9]+]] = icmp ne i256 %loop-count, 0
 ; CHECK:   br i1 [[COND1]], label %{{.*}}, label %{{.*}}
 
 ; Loop
-; CHECK:   [[REG:%[0-9]+]] = load i256, i256 addrspace(3)* %{{[0-9]+}}, align 1
-; CHECK:   store i256 [[REG]], i256 addrspace(1)* %{{[0-9]+}}, align 1
+; CHECK:   [[REG:%[0-9]+]] = load i256, ptr addrspace(3) %{{[0-9]+}}, align 1
+; CHECK:   store i256 [[REG]], ptr addrspace(1) %{{[0-9]+}}, align 1
 ; CHECK:   br i1 %{{[0-9]+}}, label %{{.*}}, label %{{.*}}
 
 ; Residual
-; CHECK:   %{{[0-9]+}} = load i256, i256 addrspace(3)* %{{[0-9]+}}, align 1
-; CHECK:   %{{[0-9]+}} = load i256, i256 addrspace(1)* %{{[0-9]+}}, align 1
+; CHECK:   %{{[0-9]+}} = load i256, ptr addrspace(3) %{{[0-9]+}}, align 1
+; CHECK:   %{{[0-9]+}} = load i256, ptr addrspace(1) %{{[0-9]+}}, align 1
 ; CHECK:   [[RES:%[0-9]+]] = or i256 %{{[0-9]+}}, %{{[0-9]+}}
-; CHECK:   store i256 [[RES]], i256 addrspace(1)* %{{[0-9]+}}, align 1
+; CHECK:   store i256 [[RES]], ptr addrspace(1) %{{[0-9]+}}, align 1
 
 ; Residual condition:
 ; CHECK:   [[COND2:%[0-9]+]] = icmp ne i256 %residual-bytes, 0
 ; CHECK:   br i1 [[COND2]], label %{{.*}}, label %{{.*}}
-  call void @llvm.memcpy.p1i256.p3i256.i256(i256 addrspace(1)* %dest, i256 addrspace(3)* %src, i256 %size, i1 false)
+  call void @llvm.memcpy.p1.p3.i256(ptr addrspace(1) %dest, ptr addrspace(3) %src, i256 %size, i1 false)
   ret void
 }

--- a/llvm/test/CodeGen/EraVM/memintrinsics-opt.ll
+++ b/llvm/test/CodeGen/EraVM/memintrinsics-opt.ll
@@ -1,29 +1,29 @@
-; RUN: opt -O3 -S < %s | FileCheck %s
+; RUN: opt -opaque-pointers -O3 -S < %s | FileCheck %s
 target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"
 
-declare void @llvm.memcpy.p0i256.p0i256.i256(i256 addrspace(0)* noalias nocapture writeonly, i256 addrspace(0)* noalias nocapture readonly, i256, i1 immarg)
-declare void @llvm.memcpy.p1i256.p1i256.i256(i256 addrspace(1)* noalias nocapture writeonly, i256 addrspace(1)* noalias nocapture readonly, i256, i1 immarg)
-declare void @llvm.memcpy.p2i256.p2i256.i256(i256 addrspace(2)* noalias nocapture writeonly, i256 addrspace(2)* noalias nocapture readonly, i256, i1 immarg)
+declare void @llvm.memcpy.p0.p0.i256(ptr addrspace(0) noalias nocapture writeonly, ptr addrspace(0) noalias nocapture readonly, i256, i1 immarg)
+declare void @llvm.memcpy.p1.p1.i256(ptr addrspace(1) noalias nocapture writeonly, ptr addrspace(1) noalias nocapture readonly, i256, i1 immarg)
+declare void @llvm.memcpy.p2.p2.i256(ptr addrspace(2) noalias nocapture writeonly, ptr addrspace(2) noalias nocapture readonly, i256, i1 immarg)
 
 ; SimplifyLibCall has this assumption that the size will not exceed i64 datatype.
 ; CHECK-LABEL: huge-copysize0
 define fastcc void @huge-copysize0(i256 addrspace(0)* %dest, i256 addrspace(0)* %src) {
-  ; CHECK: tail call void @llvm.memcpy.p0i256.p0i256.i256(i256* align 1 %dest, i256* align 1 %src, i256 81129638414606681695789005144064, i1 false)
-  call void @llvm.memcpy.p0i256.p0i256.i256(i256 addrspace(0)* %dest, i256 addrspace(0)* %src, i256 81129638414606681695789005144064, i1 false)
+  ; CHECK: tail call void @llvm.memcpy.p0.p0.i256(ptr align 1 %dest, ptr align 1 %src, i256 81129638414606681695789005144064, i1 false)
+  call void @llvm.memcpy.p0.p0.i256(ptr addrspace(0) %dest, ptr addrspace(0) %src, i256 81129638414606681695789005144064, i1 false)
   ret void
 }
 
 ; CHECK-LABEL: huge-copysize1
 define fastcc void @huge-copysize1(i256 addrspace(1)* %dest, i256 addrspace(1)* %src) {
-  ; CHECK: tail call void @llvm.memcpy.p1i256.p1i256.i256(i256 addrspace(1)* align 1 %dest, i256 addrspace(1)* align 1 %src, i256 81129638414606681695789005144064, i1 false)
-  call void @llvm.memcpy.p1i256.p1i256.i256(i256 addrspace(1)* %dest, i256 addrspace(1)* %src, i256 81129638414606681695789005144064, i1 false)
+  ; CHECK: tail call void @llvm.memcpy.p1.p1.i256(ptr addrspace(1) align 1 %dest, ptr  addrspace(1) align 1 %src, i256 81129638414606681695789005144064, i1 false)
+  call void @llvm.memcpy.p1.p1.i256(ptr addrspace(1) %dest, ptr addrspace(1) %src, i256 81129638414606681695789005144064, i1 false)
   ret void
 }
 
 ; CHECK-LABEL: huge-copysize2
 define fastcc void @huge-copysize2(i256 addrspace(2)* %dest, i256 addrspace(2)* %src) {
-  ; CHECK: tail call void @llvm.memcpy.p2i256.p2i256.i256(i256 addrspace(2)* align 1 %dest, i256 addrspace(2)* align 1 %src, i256 81129638414606681695789005144064, i1 false)
-  call void @llvm.memcpy.p2i256.p2i256.i256(i256 addrspace(2)* %dest, i256 addrspace(2)* %src, i256 81129638414606681695789005144064, i1 false)
+  ; CHECK: tail call void @llvm.memcpy.p2.p2.i256(ptr addrspace(2) align 1 %dest, ptr  addrspace(2) align 1 %src, i256 81129638414606681695789005144064, i1 false)
+  call void @llvm.memcpy.p2.p2.i256(ptr addrspace(2) %dest, ptr addrspace(2) %src, i256 81129638414606681695789005144064, i1 false)
   ret void
 }

--- a/llvm/test/CodeGen/EraVM/memintrinsics.ll
+++ b/llvm/test/CodeGen/EraVM/memintrinsics.ll
@@ -1,4 +1,4 @@
-; RUN: llc -O3 < %s | FileCheck %s
+; RUN: llc -opaque-pointers -O3 < %s | FileCheck %s
 target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"
 

--- a/llvm/test/CodeGen/EraVM/mov.ll
+++ b/llvm/test/CodeGen/EraVM/mov.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s | FileCheck %s
+; RUN: llc -opaque-pointers < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"

--- a/llvm/test/CodeGen/EraVM/mstore8-stdlib.ll
+++ b/llvm/test/CodeGen/EraVM/mstore8-stdlib.ll
@@ -1,4 +1,4 @@
-; RUN: opt -O2 -S < %s | FileCheck %s
+; RUN: opt -opaque-pointers -O2 -S < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"

--- a/llvm/test/CodeGen/EraVM/mul.ll
+++ b/llvm/test/CodeGen/EraVM/mul.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s | FileCheck %s
+; RUN: llc -opaque-pointers < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"

--- a/llvm/test/CodeGen/EraVM/or.ll
+++ b/llvm/test/CodeGen/EraVM/or.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s | FileCheck %s
+; RUN: llc -opaque-pointers < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"

--- a/llvm/test/CodeGen/EraVM/overflow.ll
+++ b/llvm/test/CodeGen/EraVM/overflow.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s | FileCheck %s
+; RUN: llc -opaque-pointers < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"

--- a/llvm/test/CodeGen/EraVM/pointer.ll
+++ b/llvm/test/CodeGen/EraVM/pointer.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s | FileCheck %s
+; RUN: llc -opaque-pointers < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i256:256:256-S32"
 target triple = "eravm"

--- a/llvm/test/CodeGen/EraVM/ptradd.ll
+++ b/llvm/test/CodeGen/EraVM/ptradd.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s | FileCheck %s
+; RUN: llc -opaque-pointers < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"

--- a/llvm/test/CodeGen/EraVM/ptrpack.ll
+++ b/llvm/test/CodeGen/EraVM/ptrpack.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s | FileCheck %s
+; RUN: llc -opaque-pointers < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"

--- a/llvm/test/CodeGen/EraVM/ptrshrink.ll
+++ b/llvm/test/CodeGen/EraVM/ptrshrink.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s | FileCheck %s
+; RUN: llc -opaque-pointers < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"

--- a/llvm/test/CodeGen/EraVM/reload-use.ll
+++ b/llvm/test/CodeGen/EraVM/reload-use.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s | FileCheck %s
+; RUN: llc -opaque-pointers < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"

--- a/llvm/test/CodeGen/EraVM/runtime-call-elision.ll
+++ b/llvm/test/CodeGen/EraVM/runtime-call-elision.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s | FileCheck %s
+; RUN: llc -opaque-pointers < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"

--- a/llvm/test/CodeGen/EraVM/selectcc.ll
+++ b/llvm/test/CodeGen/EraVM/selectcc.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s | FileCheck %s
+; RUN: llc -opaque-pointers < %s | FileCheck %s
 
 target triple = "eravm"
 target datalayout = "E-p:256:256-i256:256:256-S32"

--- a/llvm/test/CodeGen/EraVM/selectcc_fatptr.ll
+++ b/llvm/test/CodeGen/EraVM/selectcc_fatptr.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s | FileCheck %s
+; RUN: llc -opaque-pointers < %s | FileCheck %s
 
 target triple = "eravm"
 target datalayout = "E-p:256:256-i256:256:256-S32"

--- a/llvm/test/CodeGen/EraVM/selexpansion-bug.ll
+++ b/llvm/test/CodeGen/EraVM/selexpansion-bug.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s | FileCheck %s
+; RUN: llc -opaque-pointers < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"

--- a/llvm/test/CodeGen/EraVM/sha3-arg3-false-elimin.ll
+++ b/llvm/test/CodeGen/EraVM/sha3-arg3-false-elimin.ll
@@ -1,4 +1,4 @@
-; RUN: opt -O2 -S < %s | FileCheck %s
+; RUN: opt -opaque-pointers -O2 -S < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"

--- a/llvm/test/CodeGen/EraVM/sha3-arg3-true-elimin.ll
+++ b/llvm/test/CodeGen/EraVM/sha3-arg3-true-elimin.ll
@@ -1,4 +1,4 @@
-; RUN: opt -O2 -S < %s | FileCheck %s
+; RUN: opt -opaque-pointers -O2 -S < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"

--- a/llvm/test/CodeGen/EraVM/shl.ll
+++ b/llvm/test/CodeGen/EraVM/shl.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s | FileCheck %s
+; RUN: llc -opaque-pointers < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"

--- a/llvm/test/CodeGen/EraVM/shr.ll
+++ b/llvm/test/CodeGen/EraVM/shr.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s | FileCheck %s
+; RUN: llc -opaque-pointers < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"

--- a/llvm/test/CodeGen/EraVM/stack-address.ll
+++ b/llvm/test/CodeGen/EraVM/stack-address.ll
@@ -1,4 +1,3 @@
-; RUN: llc < %s | FileCheck %s
 ; RUN: llc -opaque-pointers < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"

--- a/llvm/test/CodeGen/EraVM/stdlib-funct-attr-Oz.ll
+++ b/llvm/test/CodeGen/EraVM/stdlib-funct-attr-Oz.ll
@@ -1,9 +1,9 @@
-; RUN: opt -Oz -S < %s | FileCheck %s
+; RUN: opt -opaque-pointers -Oz -S < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"
 
-declare i256 @__sha3(i8 addrspace(1)*, i256, i1) #2
+declare i256 @__sha3(ptr addrspace(1), i256, i1) #2
 declare void @__revert(i256, i256, i256) #1
 declare void @__return(i256, i256, i256) #1
 declare i256 @__exp(i256, i256) #0
@@ -32,11 +32,11 @@ define void @test_return_noinline(i256 %a, i256 %b, i256 %c) {
   ret void
 }
 
-define i256 @test_sha3_noinline(i8 addrspace(1)* %a, i256 %b, i1 %c) {
+define i256 @test_sha3_noinline(ptr addrspace(1) %a, i256 %b, i1 %c) {
 ; CHECK: @test_sha3_noinline{{.*}} #[[SHA3:[0-9]+]]
-; CHECK-NEXT: call fastcc i256 @__sha3(i8 addrspace(1)* %a, i256 %b, i1 %c) #[[NOINLINE]]
+; CHECK-NEXT: call fastcc i256 @__sha3(ptr addrspace(1) %a, i256 %b, i1 %c) #[[NOINLINE]]
 
-  %res = call i256 @__sha3(i8 addrspace(1)* %a, i256 %b, i1 %c)
+  %res = call i256 @__sha3(ptr addrspace(1) %a, i256 %b, i1 %c)
   ret i256 %res
 }
 

--- a/llvm/test/CodeGen/EraVM/sub.ll
+++ b/llvm/test/CodeGen/EraVM/sub.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s | FileCheck %s
+; RUN: llc -opaque-pointers < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"

--- a/llvm/test/CodeGen/EraVM/udiv.ll
+++ b/llvm/test/CodeGen/EraVM/udiv.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s | FileCheck %s
+; RUN: llc -opaque-pointers < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"

--- a/llvm/test/CodeGen/EraVM/uma.ll
+++ b/llvm/test/CodeGen/EraVM/uma.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s | FileCheck %s
+; RUN: llc -opaque-pointers < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"

--- a/llvm/test/CodeGen/EraVM/xor.ll
+++ b/llvm/test/CodeGen/EraVM/xor.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s | FileCheck %s
+; RUN: llc -opaque-pointers < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"

--- a/llvm/test/CodeGen/EraVM/zeroinitializer.ll
+++ b/llvm/test/CodeGen/EraVM/zeroinitializer.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s | FileCheck %s
+; RUN: llc -opaque-pointers < %s | FileCheck %s
 
 target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm-unknown-unknown"


### PR DESCRIPTION
Use opaque pointers in stdlib, runtime and tests that check for pointers in LLVM IR.