### PR TITLE
[EraVM] Unify IntrinsicsEraVM.td header and add licence

### DIFF
--- a/llvm/include/llvm/IR/IntrinsicsEraVM.td
+++ b/llvm/include/llvm/IR/IntrinsicsEraVM.td
@@ -1,7 +1,12 @@
-//===- IntrinsicsTVM.td - Defines EraVM intrinsics ---------*- tablegen -*-===//
+//===-- IntrinsicsTVM.td - Defines EraVM intrinsics --------*- tablegen -*-===//
 //
-/// \file
-/// Defines all EraVM intrinsics.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines all of the EraVM specific intrinsics.
 //
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
This file was missed in the previous PR.