### PR TITLE
[EraVM] Fix potential issues in EraVMOptimizeSelect pass

### DIFF
--- a/llvm/test/CodeGen/EraVM/select_fold.mir
+++ b/llvm/test/CodeGen/EraVM/select_fold.mir
@@ -52,8 +52,8 @@ tracksRegLiveness: true
 body:             |
   bb.0:
     liveins: $r1, $r2
-    $r2 = ADDrrr_s $r1, $r1, 0
-    $r1 = ADDrrr_s killed $r2, $r0, 9, implicit $flags
+    $r2 = ADDrrr_s $r1, $r1, i256 0
+    $r1 = ADDrrr_s killed $r2, $r0, i256 9, implicit $flags
     RET
 ...
 ---


### PR DESCRIPTION
Sometimes it is not safe to change instructions while doing RDA, since RDA internals are using cached information. Update instructions after we finish with BBs traversal. Also, use getImmOrCImm to get conditional code.