### PR TITLE
[EraVM] Fix EraVMIndexedMemOpsPrepare pass

### DIFF
--- a/.github/workflows/compiler-integration-tests.yml
+++ b/.github/workflows/compiler-integration-tests.yml
@@ -127,6 +127,7 @@ jobs:
           XFAILS:
             "CodeGen/EraVM/memcpy-expansion.ll;\
              CodeGen/EraVM/flag-setting-set-implicit-flags.ll;\
+             CodeGen/EraVM/indexed-ld-in-a-loop-bug.ll;\
              CodeGen/EraVM/machine-outliner.mir;\
              CodeGen/EraVM/machine-outliner-tail.mir;\
              CodeGen/EraVM/select_fold.mir;\

--- a/llvm/test/CodeGen/EraVM/indexed-ld-in-a-loop-bug.ll
+++ b/llvm/test/CodeGen/EraVM/indexed-ld-in-a-loop-bug.ll
@@ -1,0 +1,25 @@
+; RUN: llc --stop-after=eravm-indexed-memops-prepare < %s | FileCheck %s
+
+target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
+target triple = "eravm-unknown-unknown"
+
+; CHECK-LABEL: multibb.loop
+define void @multibb.loop(ptr addrspace(2) %start, i1 %cond) nounwind {
+entry:
+  br label %for_body
+
+for_body:                                         ; preds = %if_join31, %entry
+  %storemerge49 = phi i256 [ 4, %entry ], [ %addition_result39, %if_join31 ]
+  ; CHECK: phi ptr addrspace(2) [ %calldata_pointer_with_offset, %entry ], [ %1, %if_join31 ]
+  %calldata_pointer_with_offset = getelementptr i8, ptr addrspace(2) %start, i256 %storemerge49
+  %calldata_value = load i256, ptr addrspace(2) %calldata_pointer_with_offset, align 32
+  br i1 %cond, label %if_main30, label %if_join31
+
+if_main30:                                        ; preds = %for_body
+  unreachable
+
+if_join31:                                        ; preds = %for_body
+  store i256 %calldata_value, ptr addrspace(1) undef, align 1
+  %addition_result39 = add nuw nsw i256 %storemerge49, 32
+  br label %for_body
+}


### PR DESCRIPTION
The pass only worked correctly if a loop body was a latch, otherwise the phi with a wrong incoming BB was created. The patch changes the incoming BB to the actual latch. It also ensure that a loop has only one latch.