### PR TITLE
[DO NOT MERGE] Check if reordering passes does not lead to degradations

### DIFF
--- a/llvm/lib/Target/EraVM/EraVMInstrFormats.td
+++ b/llvm/lib/Target/EraVM/EraVMInstrFormats.td
@@ -208,6 +208,7 @@ class IForm <
   let Inst{40-43} = 0; /* dst1 */
   let Inst{48-51} = 0; /* src1 */
   let Inst{56-63} = opcode;
+  let hasSideEffects = 0;
 }
 
 // TODO: CPR-1360 SP change is currently only allowed in NOPs.

--- a/llvm/lib/Target/EraVM/EraVMTargetMachine.cpp
+++ b/llvm/lib/Target/EraVM/EraVMTargetMachine.cpp
@@ -260,11 +260,11 @@ bool EraVMPassConfig::addInstSelector() {
   (void)TargetPassConfig::addInstSelector();
   // Install an instruction selector.
   addPass(createEraVMISelDag(getEraVMTargetMachine(), getOptLevel()));
+  addPass(createEraVMAddConditionsPass());
   return false;
 }
 
 void EraVMPassConfig::addPreRegAlloc() {
-  addPass(createEraVMAddConditionsPass());
   addPass(createEraVMStackAddressConstantPropagationPass());
   addPass(createEraVMBytesToCellsPass());
   if (TM->getOptLevel() != CodeGenOpt::None) {


### PR DESCRIPTION
Addcc pass is moved to isel, earlier in the pipeline.
At the same time we have discovered that all insns have `hasSideEffects = ?` by default. It should be corrected for the future, but it is also mandatory for this PR, otherwise reordering passes leads to considerable degradations. 