### PR TITLE
Fix no asserts build

### DIFF
--- a/.github/workflows/compiler-integration-tests.yml
+++ b/.github/workflows/compiler-integration-tests.yml
@@ -142,8 +142,7 @@ jobs:
              CodeGen/EraVM/select-zero-bitrot.mir;\
              CodeGen/EraVM/select-zero-flags.mir;\
              CodeGen/EraVM/hoist-flag-setting.mir;\
-             CodeGen/EraVM/fold-similar-instructions.mir;\
-             CodeGen/EraVM/memmove-expansion.ll" # https://github.com/llvm/llvm-project/issues/64197
+             CodeGen/EraVM/fold-similar-instructions.mir"
 
         run: |
           BINDIR=$(target-llvm/build-final/bin/llvm-config --bindir)

--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -8476,8 +8476,7 @@ TargetLowering::expandUnalignedLoad(LoadSDNode *LD, SelectionDAG &DAG) const {
   if (auto ConstPtr = dyn_cast<ConstantSDNode>(Ptr))
     Aligned = ConstPtr->getAPIntValue().urem(32) == 0;
   if (!Aligned && DAG.getTarget().getTargetTriple().isEraVM()) {
-    unsigned NumBits = LoadedVT.getSizeInBits();
-    assert(NumBits == 256);
+    assert(LoadedVT.getSizeInBits() == 256);
     auto Const32 = DAG.getConstant(APInt(256, 32, false), dl, MVT::i256);
     auto Const8 = DAG.getConstant(APInt(256, 8, false), dl, MVT::i256);
     auto Zero = DAG.getConstant(APInt(256, 0, false), dl, MVT::i256);
@@ -8665,8 +8664,7 @@ SDValue TargetLowering::expandUnalignedStore(StoreSDNode *ST,
   if (auto ConstPtr = dyn_cast<ConstantSDNode>(Ptr))
     Aligned = ConstPtr->getAPIntValue().urem(32) == 0;
   if (!Aligned && DAG.getTarget().getTargetTriple().isEraVM()) {
-    unsigned NumBits = StoreMemVT.getSizeInBits();
-    assert(NumBits == 256);
+    assert(StoreMemVT.getSizeInBits() == 256);
     auto Const32 = DAG.getConstant(APInt(256, 32, false), dl, MVT::i256);
     auto Const8 = DAG.getConstant(APInt(256, 8, false), dl, MVT::i256);
     auto Zero = DAG.getConstant(APInt(256, 0, false), dl, MVT::i256);

--- a/llvm/lib/Target/EVM/EVMSingleUseExpression.cpp
+++ b/llvm/lib/Target/EVM/EVMSingleUseExpression.cpp
@@ -92,9 +92,7 @@ static void convertImplicitDefToConstZero(MachineInstr *MI,
                                           MachineFunction &MF,
                                           LiveIntervals &LIS) {
   assert(MI->getOpcode() == TargetOpcode::IMPLICIT_DEF);
-
-  const auto *RegClass = MRI.getRegClass(MI->getOperand(0).getReg());
-  assert(RegClass == &EVM::GPRRegClass);
+  assert(MRI.getRegClass(MI->getOperand(0).getReg()) == &EVM::GPRRegClass);
   MI->setDesc(TII->get(EVM::CONST_I256));
   MI->addOperand(MachineOperand::CreateImm(0));
 }

--- a/llvm/lib/Target/EVM/EVMStackify.cpp
+++ b/llvm/lib/Target/EVM/EVMStackify.cpp
@@ -203,7 +203,7 @@ using MIIter = MachineBasicBlock::iterator;
 using RegisterLocation = std::pair<Register, StackLocation>;
 
 class StackModel {
-  static constexpr unsigned StackAccessDepthLimit = 16;
+  [[maybe_unused]] static constexpr unsigned StackAccessDepthLimit = 16;
   const LiveIntervals &LIS;
   const EVMInstrInfo *TII;
   MachineFunction *MF;
@@ -1016,6 +1016,7 @@ void StackModel::postProcess() {
 }
 
 void StackModel::dumpState() const {
+#ifndef NDEBUG
   LLVM_DEBUG(dbgs() << "X: " << XStack.size() << ", L: " << LStack.size()
                     << ", E: " << EStack.size() << '\n');
   for (const auto &Reg : LStack) {
@@ -1031,6 +1032,7 @@ void StackModel::dumpState() const {
                       << ", Depth: " << getPhysRegDepth(Reg) << '\n');
   }
   LLVM_DEBUG(dbgs() << '\n');
+#endif
 }
 
 unsigned StackModel::getDUPOpcode(unsigned Depth) {

--- a/llvm/lib/Target/EraVM/EraVMBytesToCells.cpp
+++ b/llvm/lib/Target/EraVM/EraVMBytesToCells.cpp
@@ -150,9 +150,7 @@ EraVMBytesToCells::convertRegisterPointerToCells(MachineOperand &MOReg) {
   MachineInstr &MI = *MOReg.getParent();
   const Register Reg = MOReg.getReg();
   assert(Reg.isVirtual() && "Expecting virtual register");
-
-  MachineInstr *DefMI = MRI->getVRegDef(Reg);
-  assert(DefMI);
+  assert(MRI->getVRegDef(Reg));
 
   if (auto FoldedReg = foldWithLeftShift(Reg))
     return *FoldedReg;

--- a/llvm/lib/Target/EraVM/EraVMExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/EraVM/EraVMExpandPseudoInsts.cpp
@@ -110,11 +110,12 @@ bool EraVMExpandPseudo::runOnMachineFunction(MachineFunction &MF) {
         Register FromReg = MI.getOperand(1).getReg();
         if (ToReg != FromReg) {
           LLVM_DEBUG(dbgs() << "Found PTR_TO_INT: "; MI.dump());
-          auto NewMI = BuildMI(*MI.getParent(), &MI, MI.getDebugLoc(),
-                               TII->get(EraVM::ADDrrr_s), ToReg)
-                           .addReg(FromReg)
-                           .addReg(EraVM::R0)
-                           .addImm(0);
+          [[maybe_unused]] auto NewMI =
+              BuildMI(*MI.getParent(), &MI, MI.getDebugLoc(),
+                      TII->get(EraVM::ADDrrr_s), ToReg)
+                  .addReg(FromReg)
+                  .addReg(EraVM::R0)
+                  .addImm(0);
           LLVM_DEBUG(dbgs() << "Converting PTR_TO_INT to: "; NewMI->dump());
         }
         PseudoInst.push_back(&MI);

--- a/llvm/lib/Target/EraVM/EraVMOptimizeSelectPreRA.cpp
+++ b/llvm/lib/Target/EraVM/EraVMOptimizeSelectPreRA.cpp
@@ -274,7 +274,7 @@ bool EraVMOptimizeSelectPreRA::tryFoldSelectZero(MachineBasicBlock &MBB) {
             : EraVM::in0Iterator(UseMI);
 
     // Now we fold the SELECT with its sole user.
-    auto *NewMI =
+    [[maybe_unused]] auto *NewMI =
         getFoldedInst(UseMI, UseMI, NonZeroOpnd, NonSelectOutOpnd->getReg(),
                       NewOp, CCNewMI, NonSelectOutOpnd->getReg());
     LLVM_DEBUG(dbgs() << "== Folding select:"; MI.dump();
@@ -330,9 +330,9 @@ bool EraVMOptimizeSelectPreRA::tryFoldAddToSelect(MachineBasicBlock &MBB) {
     Register TieReg = OutAddIsIn1Use ? EraVM::in0Iterator(UseMI)->getReg()
                                      : EraVM::in1Iterator(UseMI)->getReg();
 
-    auto *NewMI = getFoldedInst(UseMI, MI, EraVM::in0Range(MI),
-                                EraVM::in1Iterator(MI)->getReg(),
-                                MI.getOpcode(), CCNewMI, TieReg);
+    [[maybe_unused]] auto *NewMI = getFoldedInst(
+        UseMI, MI, EraVM::in0Range(MI), EraVM::in1Iterator(MI)->getReg(),
+        MI.getOpcode(), CCNewMI, TieReg);
     LLVM_DEBUG(dbgs() << "== Folding add:"; MI.dump();
                dbgs() << "       and use:"; UseMI.dump();
                dbgs() << "          into:"; NewMI->dump(););

--- a/llvm/lib/Target/EraVM/EraVMStackAddressConstantPropagation.cpp
+++ b/llvm/lib/Target/EraVM/EraVMStackAddressConstantPropagation.cpp
@@ -98,13 +98,14 @@ EraVMStackAddressConstantPropagation::tryPropagateConstant(MachineInstr &MI) {
     int64_t In0Const = LHSRes ? LHSRes->Displacement : 0;
     int64_t In1Const = In1Res ? In1Res->Displacement : 0;
     Register NewVR = RegInfo->createVirtualRegister(&EraVM::GR256RegClass);
-    MachineInstr *NewMI = BuildMI(*MI.getParent(), &MI, MI.getDebugLoc(),
-                                  TII->get(EraVM::ADDrrr_s))
-                              .addDef(NewVR)
-                              .addReg(In0Reg)
-                              .addReg(In1Reg)
-                              .addImm(EraVMCC::COND_NONE)
-                              .getInstr();
+    [[maybe_unused]] MachineInstr *NewMI =
+        BuildMI(*MI.getParent(), &MI, MI.getDebugLoc(),
+                TII->get(EraVM::ADDrrr_s))
+            .addDef(NewVR)
+            .addReg(In0Reg)
+            .addReg(In1Reg)
+            .addImm(EraVMCC::COND_NONE)
+            .getInstr();
     LLVM_DEBUG(dbgs() << "Replace " << MI << "\n  with " << NewMI);
     ++NumInstructionsErased;
     MI.eraseFromParent();

--- a/llvm/test/CodeGen/EraVM/memmove-expansion.ll
+++ b/llvm/test/CodeGen/EraVM/memmove-expansion.ll
@@ -1,5 +1,6 @@
 ; RUN: opt -passes=eravm-lower-intrinsics -S < %s | FileCheck %s
-; RUN: llc -O3 < %s | FileCheck --check-prefix=CHECK-INSTRS %s
+; RUN: llc -O3 --cgp-verify-bfi-updates=false < %s | FileCheck --check-prefix=CHECK-INSTRS %s
+; Verification of BFI updates is disabled because of https://github.com/llvm/llvm-project/issues/64197
 
 target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"

--- a/llvm/test/CodeGen/EraVM/sdiv-isel.ll
+++ b/llvm/test/CodeGen/EraVM/sdiv-isel.ll
@@ -1,5 +1,7 @@
 ; RUN: llc -debug-only=isel %s -o /dev/null 2>&1 | FileCheck %s
 
+; REQUIRES: asserts
+
 target datalayout = "E-p:256:256-i256:256:256-S256-a:256:256"
 target triple = "eravm"
 


### PR DESCRIPTION
After https://github.com/matter-labs/era-compiler-llvm-builder/pull/15, build started to fail with unused variable errors. This PR fixes that.