### PR TITLE
ci: Remove unsupported verify options

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -148,7 +148,6 @@ jobs:
             "--cgp-verify-bfi-updates \
             --compile-twice \
             --earlycse-debug-hash \
-            --loop-distribute-verify \
             --machine-combiner-verify-pattern-order \
             --phicse-debug-hash \
             --reassociate-geps-verify-no-dead-code \
@@ -156,9 +155,7 @@ jobs:
             --scev-verify-ir \
             --tail-dup-verify \
             --unroll-verify-domtree \
-            --verify-regalloc \
-            --vplan-verify-hcfg \
-            --march=eravm"
+            --verify-regalloc"
           XFAILS:
             "CodeGen/EraVM/memcpy-expansion.ll;\
             CodeGen/EraVM/flag-setting-set-implicit-flags.ll;\
@@ -188,7 +185,7 @@ jobs:
             --tail-dup-verify \
             --unroll-verify-domtree \
             --verify-assumption-cache \
-            --verify-cfg-preserved \
+            --verify-analysis-invalidation \
             --verify-cfiinstrs \
             --verify-coalescing \
             --verify-dom-info \
@@ -200,8 +197,7 @@ jobs:
             --verify-misched \
             --verify-regalloc \
             --verify-scev-strict \
-            --vplan-verify-hcfg \
-            --march=eravm"
+            --vplan-verify-hcfg"
         run: |
           BINDIR=$(target-llvm/build-final/bin/llvm-config --bindir)
           ${BINDIR}/llvm-lit -vv -s "-Dopt=${BINDIR}/opt ${OPT_OPTS}" \


### PR DESCRIPTION
Remove `--vplan-verify-hcfg` llc option as no longer supported.
`--vplan-verify-hcfg` was removed in upstream [9923d29](https://github.com/llvm/llvm-project/commit/9923d29cfa917a0c25f3237e0cae9567c8806071): “This drops the separate flag to enable HCFG verification. Instead, all VPlans are verified once they have been created, if assertions are enabled.”

Remove `--loop-distribute-verify` which is no longer included in our build (nor documented there, even in `--help-hidden`.)

Also:
* (Moved to https://github.com/matter-labs/era-compiler-llvm/pull/487: [[EVM] Fix analyses invalidation in EVMLinkRuntime](https://github.com/matter-labs/era-compiler-llvm/pull/486/commits/b1ae6859d182d1868efa2e0d561b55adf1c1c3f7).)
* [ci: Remove -march=eravm from opt and llc options](https://github.com/matter-labs/era-compiler-llvm/pull/486/commits/b381cf7b30373339c9378c878425b5a986110824), which seems to have been a mistake, per discussion.
* Rename per “[StandardInstrumentations] Rename -verify-cfg-preserved -> -verify-analysis-invalidation” https://reviews.llvm.org/D146069.
* (Moved to https://github.com/matter-labs/era-compiler-llvm/pull/489: [Disable AssertAlign for intrinsics in DAG builder](https://github.com/matter-labs/era-compiler-llvm/pull/486/commits/bddd3229139fcef999ac75ffb7b838e9a6839d21) [test].)