### PR TITLE
[EraVM][EVM] Fix analyses invalidation in runtime linking passes

### DIFF
--- a/llvm/lib/Target/EVM/EVMLinkRuntime.cpp
+++ b/llvm/lib/Target/EVM/EVMLinkRuntime.cpp
@@ -110,6 +110,7 @@ ModulePass *llvm::createEVMLinkRuntimePass() { return new EVMLinkRuntime(); }
 
 PreservedAnalyses EVMLinkRuntimePass::run(Module &M,
                                           ModuleAnalysisManager &AM) {
-  EVMLinkRuntimeImpl(M, STDLIB_DATA);
+  if (EVMLinkRuntimeImpl(M, STDLIB_DATA))
+    return PreservedAnalyses::none();
   return PreservedAnalyses::all();
 }

--- a/llvm/lib/Target/EraVM/EraVMLinkRuntime.cpp
+++ b/llvm/lib/Target/EraVM/EraVMLinkRuntime.cpp
@@ -170,6 +170,7 @@ PreservedAnalyses EraVMLinkRuntimePass::run(Module &M,
                                             ModuleAnalysisManager &AM) {
   FunctionAnalysisManager *FAM =
       &AM.getResult<FunctionAnalysisManagerModuleProxy>(M).getManager();
-  EraVMLinkRuntimeImpl(M, STDLIB_DATA, FAM, Level == OptimizationLevel::Oz);
+  if (EraVMLinkRuntimeImpl(M, STDLIB_DATA, FAM, Level == OptimizationLevel::Oz))
+    return PreservedAnalyses::none();
   return PreservedAnalyses::all();
 }


### PR DESCRIPTION
`EraVMLinkRuntime` and `EVMLinkRuntime` don't invalidate analyses when update a module. The patch invalidates all analyses if there were changes.