### PR TITLE
[EraVM] Fix branch probability calculation in probabilityIsProfitable

### DIFF
--- a/llvm/lib/Target/EraVM/EraVMInstrInfo.cpp
+++ b/llvm/lib/Target/EraVM/EraVMInstrInfo.cpp
@@ -1170,8 +1170,12 @@ static bool probabilityIsProfitable(unsigned TrueCycles, unsigned FalseCycles,
   // calculated.
   if (TrueCycles < 2 || FalseCycles > 2)
     return false;
-  return Probability >=
-         BranchProbability((TrueCycles - 1), (TrueCycles - FalseCycles + 1));
+
+  unsigned Numerator = TrueCycles - 1;
+  unsigned Denominator = TrueCycles - FalseCycles + 1;
+  if (!Denominator || Numerator > Denominator)
+    return false;
+  return Probability >= BranchProbability(Numerator, Denominator);
 }
 
 static bool isOptimizeForSize(MachineFunction &MF) {


### PR DESCRIPTION
In some cases, IfConverter can pass max 32-bit unsigned value for TrueCycles and 0 for FalseCycles. Problem in this case is that Denominator will be 0, and BranchProbability will assert. Add check to avoid assertion in BranchProbability constructor.