### PR TITLE
[EraVM] Renumber COND_* constants and move their definitions to *.td

### DIFF
--- a/llvm/lib/Target/EraVM/EraVM.h
+++ b/llvm/lib/Target/EraVM/EraVM.h
@@ -24,18 +24,13 @@
 #include "llvm/Target/TargetMachine.h"
 
 namespace EraVMCC {
-// EraVM specific condition code.
-enum CondCodes {
-  COND_NONE = 0, /// unconditional
-  COND_E = 2,    /// EQ flag is set
-  COND_LT = 4,   /// LT flag is set
-  COND_GT = 8,   /// GT flag is set
-  COND_NE,
-  COND_LE,
-  COND_GE,
 
-  COND_INVALID = -1
-};
+// EraVM-specific condition codes - shared between hand-written C++ and
+// tablegen-erated code. The values of COND_* constants are their binary
+// encodings, except for COND_INVALID which is not encodable.
+#define GET_CondCodes_DECL
+#include "EraVMGenSearchableTables.inc"
+
 } // namespace EraVMCC
 
 namespace EraVMAS {

--- a/llvm/lib/Target/EraVM/EraVMInstrFormats.td
+++ b/llvm/lib/Target/EraVM/EraVMInstrFormats.td
@@ -220,6 +220,23 @@ def pred : PredicateOperand<i256, (ops i256imm), (ops (i256 0))> {
   let EncoderMethod = "getCCOpValue";
 }
 
+class EraVMCondCode<int val> {
+  int Encoding = val;
+}
+def COND_NONE : EraVMCondCode<0>;
+def COND_GT   : EraVMCondCode<1>;
+def COND_LT   : EraVMCondCode<2>;
+def COND_E    : EraVMCondCode<3>;
+def COND_GE   : EraVMCondCode<4>;
+def COND_LE   : EraVMCondCode<5>;
+def COND_NE   : EraVMCondCode<6>;
+def COND_INVALID : EraVMCondCode<-1>;
+
+def CondCodes : GenericEnum {
+  let FilterClass = "EraVMCondCode";
+  let ValueField = "Encoding";
+}
+
 // Pseudo instructions (do not have encoding information, only for asmparser)
 class AsmParserPseudo<dag outs, dag inops, string opc, string asmstr>
   : EraVMInstruction {

--- a/llvm/lib/Target/EraVM/EraVMInstrInfo.td
+++ b/llvm/lib/Target/EraVM/EraVMInstrInfo.td
@@ -347,13 +347,13 @@ def : Pat<(load_code(EraVMselectcc memaddr:$addr1, memaddr:$addr2, imm:$cc)),
           (SELccr memaddr:$addr1, memaddr:$addr2, imm:$cc)>;
 
 // TODO: CPR-1356 stack and code forms
-def : Pat<(int_eravm_ifeq GR256:$src0, GR256:$src1), (SELrrr GR256:$src0, GR256:$src1, 2 /*COND_EQ*/)>;
-def : Pat<(int_eravm_iflt GR256:$src0, GR256:$src1), (SELrrr GR256:$src0, GR256:$src1, 4 /*COND_LT*/)>;
-def : Pat<(int_eravm_ifgt GR256:$src0, GR256:$src1), (SELrrr GR256:$src0, GR256:$src1, 8 /*COND_GT*/)>;
+def : Pat<(int_eravm_ifeq GR256:$src0, GR256:$src1), (SELrrr GR256:$src0, GR256:$src1, COND_E.Encoding)>;
+def : Pat<(int_eravm_iflt GR256:$src0, GR256:$src1), (SELrrr GR256:$src0, GR256:$src1, COND_LT.Encoding)>;
+def : Pat<(int_eravm_ifgt GR256:$src0, GR256:$src1), (SELrrr GR256:$src0, GR256:$src1, COND_GT.Encoding)>;
 
-def : Pat<(int_eravm_ifeq imm16:$src0, imm16:$src1), (SELiir imm16:$src0, imm16:$src1, 2 /*COND_EQ*/)>;
-def : Pat<(int_eravm_iflt imm16:$src0, imm16:$src1), (SELiir imm16:$src0, imm16:$src1, 4 /*COND_LT*/)>;
-def : Pat<(int_eravm_ifgt imm16:$src0, imm16:$src1), (SELiir imm16:$src0, imm16:$src1, 8 /*COND_GT*/)>;
+def : Pat<(int_eravm_ifeq imm16:$src0, imm16:$src1), (SELiir imm16:$src0, imm16:$src1, COND_E.Encoding)>;
+def : Pat<(int_eravm_iflt imm16:$src0, imm16:$src1), (SELiir imm16:$src0, imm16:$src1, COND_LT.Encoding)>;
+def : Pat<(int_eravm_ifgt imm16:$src0, imm16:$src1), (SELiir imm16:$src0, imm16:$src1, COND_GT.Encoding)>;
 
 let hasSideEffects = 1, Defs = [SP], Uses = [SP] in {
 def NOPrrr : Irr_r<OpNoOp, NoSwap, PreserveFlags,


### PR DESCRIPTION
Renumber `EraVMCC:COND_*` constants, so that their values in the `CondCodes` enum match their binary encoding. Additionally, migrate their definition to tablegen, so they can be used both by hand-written C++ code and from patterns described in *.td files.