### PR TITLE
[EraVM] Rework EraVMTargetStreamer class

### DIFF
--- a/llvm/lib/MC/MCAsmStreamer.cpp
+++ b/llvm/lib/MC/MCAsmStreamer.cpp
@@ -226,8 +226,6 @@ public:
 
   void emitBytes(StringRef Data) override;
 
-  void emitIntValue(APInt Value) override;
-
   void emitValueImpl(const MCExpr *Value, unsigned Size,
                      SMLoc Loc = SMLoc()) override;
   void emitIntValue(uint64_t Value, unsigned Size) override;
@@ -1294,17 +1292,6 @@ void MCAsmStreamer::emitBytes(StringRef Data) {
     OS << Directive << (unsigned)C;
     EmitEOL();
   }
-}
-
-void MCAsmStreamer::emitIntValue(APInt Value) {
-  // EraVM local begin
-  if (Value.getBitWidth() == 256) {
-    OS << "\t.cell\t" << Value;
-    EmitEOL();
-    return;
-  }
-  // EraVM local end
-  MCStreamer::emitIntValue(Value);
 }
 
 void MCAsmStreamer::emitBinaryData(StringRef Data) {

--- a/llvm/lib/Target/EraVM/EraVMAsmPrinter.cpp
+++ b/llvm/lib/Target/EraVM/EraVMAsmPrinter.cpp
@@ -248,7 +248,7 @@ void EraVMAsmPrinter::emitGlobalConstant(const DataLayout &DL,
       Constant *C = CVA->getAggregateElement(i);
       auto *CI = cast<ConstantInt>(C);
       assert(CI && CI->getBitWidth() == 256);
-      Streamer->emitGlobalConst(CI->getValue());
+      Streamer->emitCell(CI->getValue());
     }
     return;
   }
@@ -259,7 +259,7 @@ void EraVMAsmPrinter::emitGlobalConstant(const DataLayout &DL,
 
     for (size_t i = 0; i < elem_size; ++i) {
       APInt val = CDS->getElementAsAPInt(i);
-      Streamer->emitGlobalConst(val);
+      Streamer->emitCell(val);
     }
     return;
   }
@@ -275,7 +275,7 @@ void EraVMAsmPrinter::emitGlobalConstant(const DataLayout &DL,
       Constant *C = CVS->getAggregateElement(i);
       // TODO: CPR-920 support operators.
       const ConstantInt *CI = cast<ConstantInt>(C);
-      Streamer->emitGlobalConst(CI->getValue());
+      Streamer->emitCell(CI->getValue());
     }
 
     return;
@@ -290,7 +290,7 @@ void EraVMAsmPrinter::emitGlobalConstant(const DataLayout &DL,
     return;
 
   if (const auto *CI = dyn_cast<ConstantInt>(CV)) {
-    Streamer->emitGlobalConst(CI->getValue());
+    Streamer->emitCell(CI->getValue());
     return;
   }
 

--- a/llvm/lib/Target/EraVM/MCTargetDesc/EraVMMCTargetDesc.h
+++ b/llvm/lib/Target/EraVM/MCTargetDesc/EraVMMCTargetDesc.h
@@ -51,6 +51,10 @@ MCAsmBackend *createEraVMMCAsmBackend(const Target &T,
 std::unique_ptr<MCObjectTargetWriter> createEraVMELFObjectWriter(uint8_t OSABI);
 
 namespace EraVM {
+
+/// Width of the value emitted by .cell N in bits.
+constexpr unsigned CellBitWidth = 256;
+
 /// At now, stack operands are handled specially:
 /// * At the machine instruction level, many instructions may have 6 source
 ///   operand kinds and 4 destination operand kinds, with each combination

--- a/llvm/lib/Target/EraVM/MCTargetDesc/EraVMTargetStreamer.cpp
+++ b/llvm/lib/Target/EraVM/MCTargetDesc/EraVMTargetStreamer.cpp
@@ -12,7 +12,6 @@
 
 #include "MCTargetDesc/EraVMTargetStreamer.h"
 #include "MCTargetDesc/EraVMMCTargetDesc.h"
-#include "llvm/MC/ConstantPools.h"
 #include "llvm/MC/MCAsmInfo.h"
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCExpr.h"
@@ -26,18 +25,6 @@ using namespace llvm;
 // EraVMTargetStreamer Implemenation
 //
 
-EraVMTargetStreamer::EraVMTargetStreamer(MCStreamer &S)
-    : MCTargetStreamer(S), ConstantPools(new AssemblerConstantPools()) {}
+EraVMTargetStreamer::EraVMTargetStreamer(MCStreamer &S) : MCTargetStreamer(S) {}
 
 EraVMTargetStreamer::~EraVMTargetStreamer() = default;
-
-void EraVMTargetStreamer::emitGlobalConst(APInt Value) {
-  if (Value.getBitWidth() < 256) {
-    // align by 256 bit
-    Value = Value.sext(256);
-  }
-  SmallString<86> Str;
-  raw_svector_ostream OS(Str);
-  OS << "\t.cell\t" << Value;
-  Streamer.emitRawText(OS.str());
-}

--- a/llvm/lib/Target/EraVM/MCTargetDesc/EraVMTargetStreamer.h
+++ b/llvm/lib/Target/EraVM/MCTargetDesc/EraVMTargetStreamer.h
@@ -24,10 +24,9 @@ public:
   EraVMTargetStreamer &operator=(EraVMTargetStreamer &) = delete;
   EraVMTargetStreamer(EraVMTargetStreamer &&) = delete;
   EraVMTargetStreamer &&operator=(EraVMTargetStreamer &&) = delete;
-  virtual void emitGlobalConst(APInt Value);
 
-private:
-  std::unique_ptr<AssemblerConstantPools> ConstantPools;
+  /// Emit .cell N (naturally-aligned 256-bit value).
+  virtual void emitCell(const APInt &Value) {}
 };
 } // namespace llvm
 

--- a/llvm/test/MC/EraVM/encoding/data.s
+++ b/llvm/test/MC/EraVM/encoding/data.s
@@ -1,0 +1,67 @@
+; RUN: llvm-mc -arch=eravm -filetype=obj -o %t.o < %s
+; RUN: llvm-readelf --symbols %t.o | FileCheck %s
+; RUN: llvm-readelf --hex-dump=.rodata %t.o | FileCheck --check-prefix=RODATA %s
+; RUN: llvm-readelf --hex-dump=.data   %t.o | FileCheck --check-prefix=DATA   %s
+
+  .rodata
+a:
+  .byte 42
+  .cell -1  ; implicitly aligned at 32-byte boundary
+
+  .globl global_const
+  .type  global_const,@object
+global_const:
+  .cell  0xaabbccddeeff00112233445566778899abcdef0123456789abcdef0123456789
+
+  .local local_const
+  .type  local_const,@object
+local_const:
+  .cell 123
+
+  .data
+b:
+  .cell  0xabcdef0123456789abcdef0123456789aabbccddeeff00112233445566778899
+
+  .globl global_var
+  .type  global_var,@object
+global_var:
+  .cell 42
+  .cell -1
+  .cell 0
+
+  .local local_var
+  .type  local_var,@object
+local_var:
+  .cell 321
+
+; CHECK:      Symbol table '.symtab' contains 7 entries:
+; CHECK-NEXT:    Num:    Value  Size Type    Bind   Vis       Ndx         Name
+; CHECK-NEXT:      0: 00000000     0 NOTYPE  LOCAL  DEFAULT   UND
+; CHECK-NEXT:      1: 00000000     0 NOTYPE  LOCAL  DEFAULT [[RO:[0-9]+]] a
+; CHECK-NEXT:      2: 00000060     0 OBJECT  LOCAL  DEFAULT [[RO]]        local_const
+; CHECK-NEXT:      3: 00000000     0 NOTYPE  LOCAL  DEFAULT [[RW:[0-9]+]] b
+; CHECK-NEXT:      4: 00000080     0 OBJECT  LOCAL  DEFAULT [[RW]]        local_var
+; CHECK-NEXT:      5: 00000040     0 OBJECT  GLOBAL DEFAULT [[RO]]        global_const
+; CHECK-NEXT:      6: 00000020     0 OBJECT  GLOBAL DEFAULT [[RW]]        global_var
+
+; RODATA:      Hex dump of section '.rodata':
+; RODATA-NEXT: 0x00000000 2a000000 00000000 00000000 00000000 *...............
+; RODATA-NEXT: 0x00000010 00000000 00000000 00000000 00000000 ................
+; RODATA-NEXT: 0x00000020 ffffffff ffffffff ffffffff ffffffff ................
+; RODATA-NEXT: 0x00000030 ffffffff ffffffff ffffffff ffffffff ................
+; RODATA-NEXT: 0x00000040 aabbccdd eeff0011 22334455 66778899 ........"3DUfw..
+; RODATA-NEXT: 0x00000050 abcdef01 23456789 abcdef01 23456789 ....#Eg.....#Eg.
+; RODATA-NEXT: 0x00000060 00000000 00000000 00000000 00000000 ................
+; RODATA-NEXT: 0x00000070 00000000 00000000 00000000 0000007b ...............{
+
+; DATA:      Hex dump of section '.data':
+; DATA-NEXT: 0x00000000 abcdef01 23456789 abcdef01 23456789 ....#Eg.....#Eg.
+; DATA-NEXT: 0x00000010 aabbccdd eeff0011 22334455 66778899 ........"3DUfw..
+; DATA-NEXT: 0x00000020 00000000 00000000 00000000 00000000 ................
+; DATA-NEXT: 0x00000030 00000000 00000000 00000000 0000002a ...............*
+; DATA-NEXT: 0x00000040 ffffffff ffffffff ffffffff ffffffff ................
+; DATA-NEXT: 0x00000050 ffffffff ffffffff ffffffff ffffffff ................
+; DATA-NEXT: 0x00000060 00000000 00000000 00000000 00000000 ................
+; DATA-NEXT: 0x00000070 00000000 00000000 00000000 00000000 ................
+; DATA-NEXT: 0x00000080 00000000 00000000 00000000 00000000 ................
+; DATA-NEXT: 0x00000090 00000000 00000000 00000000 00000141 ...............A


### PR DESCRIPTION
Separate ELF- and asm-specific logic, remove unused field.

In AsmParser code, replace MCAsmStreamer::emitIntValue() override with a better target-specific solution.