### PR TITLE
[EraVM] Remove i8 alignment from data layout in tests

### DIFF
--- a/llvm/test/CodeGen/EraVM/add.ll
+++ b/llvm/test/CodeGen/EraVM/add.ll
@@ -1,6 +1,6 @@
 ; RUN: llc --disable-eravm-scalar-opt-passes < %s | FileCheck %s
 
-target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
+target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"
 
 @val = addrspace(4) global i256 42

--- a/llvm/test/CodeGen/EraVM/and.ll
+++ b/llvm/test/CodeGen/EraVM/and.ll
@@ -1,6 +1,6 @@
 ; RUN: llc --disable-eravm-scalar-opt-passes < %s | FileCheck %s
 
-target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
+target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"
 
 @val = addrspace(4) global i256 42

--- a/llvm/test/CodeGen/EraVM/array.ll
+++ b/llvm/test/CodeGen/EraVM/array.ll
@@ -1,6 +1,6 @@
 ; RUN: llc --disable-eravm-scalar-opt-passes < %s | FileCheck %s
 
-target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
+target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"
 
 @val = global [10 x i256] zeroinitializer

--- a/llvm/test/CodeGen/EraVM/cond_mbb.ll
+++ b/llvm/test/CodeGen/EraVM/cond_mbb.ll
@@ -1,6 +1,6 @@
 ; RUN: llc < %s | FileCheck %s
 
-target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
+target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"
 
 ; CHECK-LABEL: test1

--- a/llvm/test/CodeGen/EraVM/immediate.ll
+++ b/llvm/test/CodeGen/EraVM/immediate.ll
@@ -1,6 +1,6 @@
 ; RUN: llc < %s | FileCheck %s
 
-target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
+target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"
 
 ; CHECK-LABEL: .text

--- a/llvm/test/CodeGen/EraVM/mov.ll
+++ b/llvm/test/CodeGen/EraVM/mov.ll
@@ -1,6 +1,6 @@
 ; RUN: llc --disable-eravm-scalar-opt-passes < %s | FileCheck %s
 
-target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
+target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"
 
 @val = addrspace(4) global i256 42

--- a/llvm/test/CodeGen/EraVM/mul.ll
+++ b/llvm/test/CodeGen/EraVM/mul.ll
@@ -1,6 +1,6 @@
 ; RUN: llc --disable-eravm-scalar-opt-passes < %s | FileCheck %s
 
-target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
+target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"
 
 @val = addrspace(4) global i256 42

--- a/llvm/test/CodeGen/EraVM/or.ll
+++ b/llvm/test/CodeGen/EraVM/or.ll
@@ -1,6 +1,6 @@
 ; RUN: llc --disable-eravm-scalar-opt-passes < %s | FileCheck %s
 
-target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
+target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"
 
 @val = addrspace(4) global i256 42

--- a/llvm/test/CodeGen/EraVM/ptradd.ll
+++ b/llvm/test/CodeGen/EraVM/ptradd.ll
@@ -1,6 +1,6 @@
 ; RUN: llc --disable-eravm-scalar-opt-passes < %s | FileCheck %s
 
-target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
+target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"
 
 @val = addrspace(4) global i256 42

--- a/llvm/test/CodeGen/EraVM/ptrpack.ll
+++ b/llvm/test/CodeGen/EraVM/ptrpack.ll
@@ -1,6 +1,6 @@
 ; RUN: llc --disable-eravm-scalar-opt-passes < %s | FileCheck %s
 
-target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
+target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"
 
 @val = addrspace(4) global i256 42

--- a/llvm/test/CodeGen/EraVM/ptrshrink.ll
+++ b/llvm/test/CodeGen/EraVM/ptrshrink.ll
@@ -1,6 +1,6 @@
 ; RUN: llc --disable-eravm-scalar-opt-passes < %s | FileCheck %s
 
-target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
+target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"
 
 @val = addrspace(4) global i256 42

--- a/llvm/test/CodeGen/EraVM/ra_regress.ll
+++ b/llvm/test/CodeGen/EraVM/ra_regress.ll
@@ -1,8 +1,6 @@
 ; RUN: llc -O0 < %s | FileCheck %s
 
-; ModuleID = 'Test_65'
-source_filename = "Test_65"
-target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
+target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"
 
 ; CHECK-LABEL: test_length

--- a/llvm/test/CodeGen/EraVM/runtime-call-elision.ll
+++ b/llvm/test/CodeGen/EraVM/runtime-call-elision.ll
@@ -1,6 +1,6 @@
 ; RUN: llc < %s | FileCheck %s
 
-target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
+target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"
 
 declare void @__small_store_as0(i256 %addr, i256 %size_in_bits, i256 %value)

--- a/llvm/test/CodeGen/EraVM/selexpansion-bug.ll
+++ b/llvm/test/CodeGen/EraVM/selexpansion-bug.ll
@@ -1,6 +1,6 @@
 ; RUN: llc < %s | FileCheck %s
 
-target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
+target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"
 
 declare i32 @__personality()

--- a/llvm/test/CodeGen/EraVM/shl.ll
+++ b/llvm/test/CodeGen/EraVM/shl.ll
@@ -1,6 +1,6 @@
 ; RUN: llc --disable-eravm-scalar-opt-passes < %s | FileCheck %s
 
-target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
+target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"
 
 @val = addrspace(4) global i256 42

--- a/llvm/test/CodeGen/EraVM/shr.ll
+++ b/llvm/test/CodeGen/EraVM/shr.ll
@@ -1,6 +1,6 @@
 ; RUN: llc --disable-eravm-scalar-opt-passes < %s | FileCheck %s
 
-target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
+target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"
 
 @val = addrspace(4) global i256 42

--- a/llvm/test/CodeGen/EraVM/sub.ll
+++ b/llvm/test/CodeGen/EraVM/sub.ll
@@ -1,6 +1,6 @@
 ; RUN: llc --disable-eravm-scalar-opt-passes < %s | FileCheck %s
 
-target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
+target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"
 
 @val = addrspace(4) global i256 42

--- a/llvm/test/CodeGen/EraVM/switch-lowering.ll
+++ b/llvm/test/CodeGen/EraVM/switch-lowering.ll
@@ -1,6 +1,6 @@
 ; RUN: llc < %s | FileCheck %s
 
-target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
+target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm-unknown-unknown"
 
 ; CHECK-LABEL: __runtime

--- a/llvm/test/CodeGen/EraVM/xor.ll
+++ b/llvm/test/CodeGen/EraVM/xor.ll
@@ -1,6 +1,6 @@
 ; RUN: llc --disable-eravm-scalar-opt-passes < %s | FileCheck %s
 
-target datalayout = "E-p:256:256-i8:256:256:256-i256:256:256-S32-a:256:256"
+target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"
 
 @val = addrspace(4) global i256 42


### PR DESCRIPTION
`i8` must be naturally aligned.