### PR TITLE
[EraVM][TableGen] Split regular and .inc variants of heap load/store

### DIFF
--- a/llvm/lib/Target/EraVM/EraVMInstrFormats.td
+++ b/llvm/lib/Target/EraVM/EraVMInstrFormats.td
@@ -735,24 +735,22 @@ class IFarCall<EraVMOpcode opcode,
 }
 
 class IUMA<EraVMOpcode opcode,
-           SrcSpecialMode src, bit is_inc,
+           SrcSpecialMode src,
            dag outs, dag ins,
            string asmstr,
            list<dag> pattern>
   : IForm <opcode, outs, ins, asmstr, pattern> {
 
   let AsmString = !strconcat(opcode.Name,
-                             !if(is_inc, ".inc", ""),
                              "${cc}", "\t", asmstr);
-  let Opcode = UMAOpcEncoder<opcode.Encoding, opcode.BaseOpcode,
-                             src, is_inc>.Opcode;
+  let Opcode = UMAOpcEncoder<opcode.Encoding, opcode.BaseOpcode, src>.Opcode;
 }
 
 class IUMAr_r<EraVMOpcode opcode,
               dag outs, dag ins,
               string asmstr,
               list<dag> pattern>
- : IUMA<opcode, SrcSpecialReg, 0, outs, ins, asmstr, pattern> {
+ : IUMA<opcode, SrcSpecialReg, outs, ins, asmstr, pattern> {
   bits<4> rs0;
   bits<4> rd0;
 
@@ -764,7 +762,7 @@ class IUMAr_rr<EraVMOpcode opcode,
                dag outs, dag ins,
                string asmstr,
                list<dag> pattern>
- : IUMA<opcode, SrcSpecialReg, 1, outs, ins, asmstr, pattern> {
+ : IUMA<opcode, SrcSpecialReg, outs, ins, asmstr, pattern> {
   bits<4> rs0;
   bits<4> rd0;
   bits<4> rd1;
@@ -778,7 +776,7 @@ class IUMAi_r<EraVMOpcode opcode,
               dag outs, dag ins,
               string asmstr,
               list<dag> pattern>
- : IUMA<opcode, SrcSpecialImm, 0, outs, ins, asmstr, pattern> {
+ : IUMA<opcode, SrcSpecialImm, outs, ins, asmstr, pattern> {
   bits<16> addr;
   bits<4> rd0;
 
@@ -790,7 +788,7 @@ class IUMAi_rr<EraVMOpcode opcode,
                dag outs, dag ins,
                string asmstr,
                list<dag> pattern>
- : IUMA<opcode, SrcSpecialImm, 1, outs, ins, asmstr, pattern> {
+ : IUMA<opcode, SrcSpecialImm, outs, ins, asmstr, pattern> {
   bits<16> addr;
   bits<4> rd0;
   bits<4> rd1;
@@ -804,7 +802,7 @@ class IUMArr_<EraVMOpcode opcode,
               dag outs, dag ins,
               string asmstr,
               list<dag> pattern>
- : IUMA<opcode, SrcSpecialReg, 0, outs, ins, asmstr, pattern> {
+ : IUMA<opcode, SrcSpecialReg, outs, ins, asmstr, pattern> {
   bits<4> rs0;
   bits<4> rs1;
 
@@ -816,7 +814,7 @@ class IUMArr_r<EraVMOpcode opcode,
                dag outs, dag ins,
                string asmstr,
                list<dag> pattern>
- : IUMA<opcode, SrcSpecialReg, 1, outs, ins, asmstr, pattern> {
+ : IUMA<opcode, SrcSpecialReg, outs, ins, asmstr, pattern> {
   bits<4> rs0;
   bits<4> rs1;
   bits<4> rd0;
@@ -830,7 +828,7 @@ class IUMAir_<EraVMOpcode opcode,
               dag outs, dag ins,
               string asmstr,
               list<dag> pattern>
- : IUMA<opcode, SrcSpecialImm, 0, outs, ins, asmstr, pattern> {
+ : IUMA<opcode, SrcSpecialImm, outs, ins, asmstr, pattern> {
   bits<16> addr;
   bits<4> rs1;
 
@@ -842,7 +840,7 @@ class IUMAir_r<EraVMOpcode opcode,
                dag outs, dag ins,
                string asmstr,
                list<dag> pattern>
- : IUMA<opcode, SrcSpecialImm, 1, outs, ins, asmstr, pattern> {
+ : IUMA<opcode, SrcSpecialImm, outs, ins, asmstr, pattern> {
   bits<16> addr;
   bits<4> rs1;
   bits<4> rd0;

--- a/llvm/lib/Target/EraVM/EraVMInstrInfo.td
+++ b/llvm/lib/Target/EraVM/EraVMInstrInfo.td
@@ -959,13 +959,13 @@ multiclass HeapLoadInc<EraVMOpcode opcode> {
 
 defm LD1 : HeapLoad<OpLoadHeap, load_heap>;
 defm LD2 : HeapLoad<OpLoadAuxHeap, load_heapaux>;
-defm LD1Inc : HeapLoadInc<OpLoadHeap>;
-defm LD2Inc : HeapLoadInc<OpLoadAuxHeap>;
+defm LD1Inc : HeapLoadInc<OpLoadHeapInc>;
+defm LD2Inc : HeapLoadInc<OpLoadAuxHeapInc>;
 
 let mayLoad = 1 in {
 def LD      : IUMAr_r<OpLoadPtr, (outs GR256:$rd0), (ins GRPTR:$rs0),
                      "$rs0, $rd0", []>;
-def LDInc   : IUMAr_rr<OpLoadPtr, (outs GR256:$rd0, GRPTR:$rd1), (ins GRPTR:$rs0),
+def LDInc   : IUMAr_rr<OpLoadPtrInc, (outs GR256:$rd0, GRPTR:$rd1), (ins GRPTR:$rs0),
                       "$rs0, $rd0, $rd1", []>;
 }
 
@@ -989,8 +989,8 @@ multiclass HeapStoreInc<EraVMOpcode opcode> {
 
 defm ST1 : HeapStore<OpStoreHeap, store_heap>;
 defm ST2 : HeapStore<OpStoreAuxHeap, store_heapaux>;
-defm ST1Inc : HeapStoreInc<OpStoreHeap>;
-defm ST2Inc : HeapStoreInc<OpStoreAuxHeap>;
+defm ST1Inc : HeapStoreInc<OpStoreHeapInc>;
+defm ST2Inc : HeapStoreInc<OpStoreAuxHeapInc>;
 
 def : MnemonicAlias<"uma.fat_ptr_read", "ld">;
 def : MnemonicAlias<"uma.fat_ptr_read.inc", "ld.inc">;

--- a/llvm/lib/Target/EraVM/EraVMOpcodes.td
+++ b/llvm/lib/Target/EraVM/EraVMOpcodes.td
@@ -115,10 +115,10 @@ class JumpOpcEncoder<bits<11> BaseOpcode,
 }
 
 class UMAOpcEncoder<OpcodeEncoding encoding, bits<11> BaseOpcode,
-                    SrcSpecialMode src, bit is_inc> {
+                    SrcSpecialMode src> {
   bits<11> Opcode =
-    !cond(!eq(encoding, LoadPtrEncoding) : !add(BaseOpcode, is_inc),
-          !eq(encoding, HeapOpEncoding)  : !add(BaseOpcode, !mul(10, src.Value), is_inc),
+    !cond(!eq(encoding, LoadPtrEncoding) : BaseOpcode,
+          !eq(encoding, HeapOpEncoding)  : !add(BaseOpcode, !mul(10, src.Value)),
           true : -1);
 }
 
@@ -204,16 +204,21 @@ def OpRevert   : EraVMOpcode<"ret.revert", 1071, RetEncoding>; // to_label ⇒ 1
 def OpPanic    : EraVMOpcode<"ret.panic",  1073, RetEncoding>; // to_label ⇒ 1073 + to_label
 
 // aliased as uma.heap_read
-def OpLoadHeap     : EraVMOpcode<"ld.1", 1075, HeapOpEncoding>; // src inc ⇒ 1075 + 10 × src + inc
+def OpLoadHeap        : EraVMOpcode<"ld.1",     1075, HeapOpEncoding>; // src inc ⇒ 1075 + 10 × src + inc
+def OpLoadHeapInc     : EraVMOpcode<"ld.1.inc", 1076, HeapOpEncoding>;
 // aliased as uma.heap_write
-def OpStoreHeap    : EraVMOpcode<"st.1", 1077, HeapOpEncoding>; // src inc ⇒ 1077 + 10 × src + inc
+def OpStoreHeap       : EraVMOpcode<"st.1",     1077, HeapOpEncoding>; // src inc ⇒ 1077 + 10 × src + inc
+def OpStoreHeapInc    : EraVMOpcode<"st.1.inc", 1078, HeapOpEncoding>;
 // aliased as uma.aux_heap_read
-def OpLoadAuxHeap  : EraVMOpcode<"ld.2", 1079, HeapOpEncoding>; // src inc ⇒ 1079 + 10 × src + inc
+def OpLoadAuxHeap     : EraVMOpcode<"ld.2",     1079, HeapOpEncoding>; // src inc ⇒ 1079 + 10 × src + inc
+def OpLoadAuxHeapInc  : EraVMOpcode<"ld.2.inc", 1080, HeapOpEncoding>;
 // aliased as uma.aux_heap_write
-def OpStoreAuxHeap : EraVMOpcode<"st.2", 1081, HeapOpEncoding>; // src inc ⇒ 1081 + 10 × src + inc
+def OpStoreAuxHeap    : EraVMOpcode<"st.2",     1081, HeapOpEncoding>; // src inc ⇒ 1081 + 10 × src + inc
+def OpStoreAuxHeapInc : EraVMOpcode<"st.2.inc", 1082, HeapOpEncoding>;
 
 // aliased as uma.fat_ptr_read
-def OpLoadPtr      : EraVMOpcode<"ld",  1083, LoadPtrEncoding>; // inc ⇒ 1083 + inc
+def OpLoadPtr      : EraVMOpcode<"ld",     1083, LoadPtrEncoding>; // inc ⇒ 1083 + inc
+def OpLoadPtrInc   : EraVMOpcode<"ld.inc", 1084, LoadPtrEncoding>;
 
 def OpDecommit       : EraVMOpcode<"log.decommit", 1093, DirectEncoding>;
 def OpTransientLoad  : EraVMOpcode<"tload",    1094, DirectEncoding>;


### PR DESCRIPTION
In preparation for renaming of assembler mnemonics, split `EraVMOpcode`s corresponding to heap load/store instructions into regular and incrementing variants, so their mnemonics can be set independently.