### PR TITLE
[CI] CPR-1698 spelling and grammar checker in Code Review Checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -119,6 +119,7 @@ understandable?
 ## Documentation
 - [ ] Is there sufficient documentation?
 - [ ] Is the ReadMe.md file up to date?
+- [ ] Have you run a spelling and grammar checker?
 
 ## Best Practices
 - [ ] Follow Single Responsibility principle?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,33 +1,6 @@
 # Code Review Checklist
 
-<!-- 
-MIT License
 
-Copyright (c) 2020 Michaela Greiler
-from https://github.com/mgreiler/code-review-checklist/
-Modified 2023– by Matter Labs,
-some extracts from https://www.codereviewchecklist.com added,
-Copyright (c) 2020 Lee Englestone
-also MIT License.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
- -->
 
 ## Purpose
 
@@ -134,3 +107,32 @@ understandable?
 expert or a usability expert, should look over
 the code before it can be accepted?
 - [ ] Will this code change impact different teams, and should they review the change as well?
+
+<!-- 
+MIT License
+
+Copyright (c) 2020 Michaela Greiler
+from https://github.com/mgreiler/code-review-checklist/
+Modified 2023– by Matter Labs,
+some extracts from https://www.codereviewchecklist.com added,
+Copyright (c) 2020 Lee Englestone
+also MIT License.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -115,11 +115,11 @@ better?
 understandable?
 - [ ] Could some comments be removed by making the code itself more readable?
 - [ ] Is there any commented-out code?
+- [ ] Have you run a spelling and grammar checker?
 
 ## Documentation
 - [ ] Is there sufficient documentation?
 - [ ] Is the ReadMe.md file up to date?
-- [ ] Have you run a spelling and grammar checker?
 
 ## Best Practices
 - [ ] Follow Single Responsibility principle?


### PR DESCRIPTION
# Code Review Checklist

## Purpose
Motivate reduction in spelling and grammar errors in comments and documentation.  
Also moved license to a less annoying location.

## Ticket Number
Originally suggested for CI in CPR-1698, which could have caused problems; this is less risky.

## Readability
[x] Have you run a spelling and grammar checker?  Proselint, MacOS checker in TextEdit with Grammar checkbox checked.
