### PR TITLE
ci: fix for forks repositories and build binaries workflow

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -1,0 +1,100 @@
+name: Build LLVM binaries
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # every month to regenerate ccache
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git REF to use for the build"
+        required: false
+        type: string
+      build_macos_amd64:
+        description: "Build for MacOS amd64?"
+        required: false
+        type: boolean
+        default: true
+      build_macos_arm64:
+        description: "Build for MacOS arm64?"
+        required: false
+        type: boolean
+        default: true
+      build_linux_amd64:
+        description: "Build for Linux amd64?"
+        required: false
+        type: boolean
+        default: true
+      build_linux_arm64:
+        description: "Build for Linux arm64?"
+        required: false
+        type: boolean
+        default: true
+      build_windows_amd64:
+        description: "Build for Windows amd64?"
+        required: false
+        type: boolean
+        default: true
+
+
+jobs:
+
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: "MacOS x86"
+            runner: macos-12-large
+            required: ${{ github.event.inputs.build_macos_amd64 }}
+          - name: "MacOS arm64"
+            runner: [self-hosted, macOS, ARM64]
+            required: ${{ github.event.inputs.build_macos_arm64 }}
+          - name: "Linux x86"
+            runner: matterlabs-ci-runner
+            image: matterlabs/llvm_runner:ubuntu22-llvm17-latest
+            required: ${{ github.event.inputs.build_linux_amd64 }}
+          - name: "Linux ARM64"
+            runner: matterlabs-ci-runner-arm
+            image: matterlabs/llvm_runner:ubuntu22-llvm17-latest
+            required: ${{ github.event.inputs.build_linux_arm64 }}
+          - name: "Windows"
+            runner: windows-2022-github-hosted-64core
+            required: ${{ github.event.inputs.build_windows_amd64 }}
+    runs-on: ${{ matrix.runner }}
+    container:
+      image: ${{ matrix.image || '' }} # Special workaround to allow matrix builds with optional container
+    name: ${{ matrix.name }}
+    steps:
+      - name: Checkout source
+        if: matrix.required == 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          path: "llvm"
+
+      - name: Prepare Windows env
+        if: matrix.required == 'true' && runner.os == 'Windows'
+        uses: matter-labs/era-compiler-ci/.github/actions/prepare-msys@v1
+
+      - name: Build LLVM
+        if: matrix.required == 'true'
+        uses: matter-labs/era-compiler-ci/.github/actions/build-llvm@v1
+        with:
+          extra-args: "\\-DLLVM_ENABLE_WERROR=On \\-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
+          enable-tests: true
+          enable-assertions: true
+          clone-llvm: false
+          ccache-key-type: 'static'
+          save-ccache: ${{ matrix.name == 'Linux x86' }}
+
+      # Required to keep executable permissions for binaries
+      - name: Prepare tarball
+        if: matrix.required == 'true'
+        run: tar -czf ${{ runner.os }}-${{ runner.arch }}-target-final.tar.gz ./target-llvm/target-final
+
+      - name: Upload LLVM binaries
+        if: matrix.required == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: llvm-bins-${{ runner.os }}-${{ runner.arch }}
+          path: ./${{ runner.os }}-${{ runner.arch }}-target-final.tar.gz

--- a/.github/workflows/compiler-benchmarks.yml
+++ b/.github/workflows/compiler-benchmarks.yml
@@ -33,6 +33,10 @@ on:
         required: false
         default: ""
 
+concurrency:
+  group: ${{ github.repository_id }}-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   # Benchmarks workflow call from the era-compiler-ci repository
@@ -49,3 +53,5 @@ jobs:
       compiler_llvm_candidate_branch: ${{ github.event.inputs.compiler_llvm_candidate_branch || github.head_ref }}
       compiler_llvm_benchmark_mode: ${{ github.event.inputs.compiler_llvm_benchmark_mode || '^M^B3' }}
       compiler_llvm_benchmark_path: ${{ github.event.inputs.compiler_llvm_benchmark_path || '' }}
+      ccache-key-type: 'static' # rotate ccache key every month
+      compiler-llvm-repo: ${{ github.event.pull_request.head.repo.full_name }} # required to properly test forks

--- a/.github/workflows/compiler-integration-tests.yml
+++ b/.github/workflows/compiler-integration-tests.yml
@@ -1,9 +1,6 @@
 name: Integration tests
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
   workflow_dispatch:
     inputs:
@@ -15,6 +12,10 @@ on:
         description: "compiler-llvm branch"
         required: true
         default: "main"
+
+concurrency:
+  group: ${{ github.repository_id }}-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
 
@@ -31,4 +32,6 @@ jobs:
     secrets: inherit
     with:
       compiler-tester-ref: ${{ github.event.inputs.compiler_tester_branch || 'main' }}
-      llvm-ref: ${{ github.event.inputs.compiler_llvm_branch || github.head_ref }}
+      llvm-ref: ${{ github.event.inputs.compiler_llvm_branch || github.head_ref || github.event.repository.default_branch }}
+      ccache-key-type: 'static' # rotate ccache key every month
+      compiler-llvm-repo: ${{ github.event.pull_request.head.repo.full_name }} # required to properly test forks

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -2,8 +2,8 @@ name: Regression tests
 
 on:
   pull_request:
-    branches:
-      - main
+    # branches:
+    #   - main
   workflow_dispatch:
     inputs:
       commits-to-test:
@@ -39,6 +39,7 @@ jobs:
         with:
           ref: ${{ steps.extract_branch.outputs.head_ref }}
           fetch-depth: ${{ github.event.pull_request.commits || github.event.inputs.commits-to-test }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Prepare commits
         id: prepare
@@ -65,6 +66,7 @@ jobs:
         with:
           ref: ${{ matrix.commit }}
           fetch-depth: ${{ needs.prepare-test-matrix.outputs.fetch_depth }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Get changed files
         id: changed-files
@@ -80,8 +82,12 @@ jobs:
       - name: Run code formatter
         run: |
           set -x
-          python3 ./llvm/utils/git/code-format-helper-era-llvm.py \
-            --token ${{ secrets.GITHUB_TOKEN }} \
+          if [ '${{ github.event.pull_request.head.repo.fork }}' = 'true' ]; then
+            TOKEN_PARAM=""
+          else
+            TOKEN_PARAM="--token ${{ secrets.GITHUB_TOKEN }}"
+          fi
+          python3 ./llvm/utils/git/code-format-helper-era-llvm.py ${TOKEN_PARAM} \
             --issue-number ${{ github.event.pull_request.number }} \
             --start-rev ${{ github.event.pull_request.base.sha }} \
             --end-rev ${{ matrix.commit }} \
@@ -103,12 +109,7 @@ jobs:
         with:
           ref: ${{ matrix.commit }}
           path: "llvm"
-
-      # Ccache will be updated each month
-      # Older caches will be deprecated automatically after 7 days of inactivity
-      - name: Define ccache key
-        id: ccache-key
-        run: echo "key=llvm-${{ github.event.repository.default_branch }}-$(date +'%Y-%m')" | tee -a "${GITHUB_OUTPUT}"
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Build LLVM
         uses: matter-labs/era-compiler-ci/.github/actions/build-llvm@v1
@@ -117,8 +118,7 @@ jobs:
           enable-tests: true
           enable-assertions: true
           clone-llvm: false
-          ccache-key: ${{ steps.ccache-key.outputs.key }}
-
+          ccache-key-type: 'static' # rotate ccache key every month
 
       # `verify-llvm` is a special target that runs all the regression tests
       # it includes `check-llvm` and special codegen tests

--- a/llvm/utils/git/code-format-helper-era-llvm.py
+++ b/llvm/utils/git/code-format-helper-era-llvm.py
@@ -327,7 +327,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--token", type=str, required=True, help="GitHub authentiation token"
+        "--token", type=str, required=False, help="GitHub authentiation token"
     )
     parser.add_argument(
         "--repo",


### PR DESCRIPTION
# Code Review Checklist

## Purpose

* [x] Fixes issues with testing fork repositories
* [x] Introduces LLVM build binaries workflow for two purposes: regen ccache monthly and allow manual building of LLVM for all platforms 

## Testing

Special regression tests job from the fork is tested [here](https://github.com/matter-labs/era-compiler-llvm/actions/runs/9365344548). All commits were created and tested as expected.

## Ticket Number

* Fixes [CPR-1728](https://linear.app/matterlabs/issue/CPR-1728/add-a-workflow-building-llvm-binaries-for-all-platforms)
* Related to [CPR-1706](https://linear.app/matterlabs/issue/CPR-1706/issue-with-checkout-fork-repositories)
* Related to [CPR-1717](https://linear.app/matterlabs/issue/CPR-1717/turn-off-the-on-merge-trigger-in-ci)
