### PR TITLE
[EraVM][TableGen] Split `EraVMOpcode`s for to_l1 and event (NFC)

### DIFF
--- a/llvm/lib/Target/EraVM/EraVMInstrFormats.td
+++ b/llvm/lib/Target/EraVM/EraVMInstrFormats.td
@@ -331,23 +331,6 @@ class ILogRrr_r<EraVMOpcode opcode, dag outs, dag ins,
   let Dst0 = rd0;
 }
 
-class ILogRFirstrr_<EraVMOpcode opcode, bit is_first,
-                    dag outs, dag ins,
-                    string asmstr, list<dag> pattern>
-  : IForm <opcode, outs, ins, asmstr, pattern> {
-  bits<4> rs0;
-  bits<4> rs1;
-
-  let Src0 = rs0;
-  let Src1 = rs1;
-
-  let AsmString = !strconcat(opcode.Name,
-                             !if(is_first, ".first", ""),
-                             "${cc}", "\t", asmstr);
-  let Opcode = LogROpcEncoder<opcode.Encoding, opcode.BaseOpcode,
-                              is_first>.Opcode;
-}
-
 class IBinary<EraVMOpcode opcode,
               SrcMode src, DstMode dst,
               mod_swap swap, mod_set_flags set_flags,

--- a/llvm/lib/Target/EraVM/EraVMInstrInfo.td
+++ b/llvm/lib/Target/EraVM/EraVMInstrInfo.td
@@ -1171,18 +1171,18 @@ let hasSideEffects = 1 in {
 }
 
 let hasSideEffects = 1 in {
-def L1r : ILogRFirstrr_<OpLogToL1, 0, (outs), (ins GR256:$rs0, GR256:$rs1),
+def L1r : ILogRrr_<OpLogToL1, (outs), (ins GR256:$rs0, GR256:$rs1),
                         "$rs0, $rs1",
                         [(int_eravm_tol1 GR256:$rs0, GR256:$rs1, 0)]>;
-def L1Firstr : ILogRFirstrr_<OpLogToL1, 1, (outs), (ins GR256:$rs0, GR256:$rs1),
+def L1Firstr : ILogRrr_<OpLogToL1First, (outs), (ins GR256:$rs0, GR256:$rs1),
                              "$rs0, $rs1",
                              [(int_eravm_tol1 GR256:$rs0, GR256:$rs1, 1)]>;
 
-def EVTr : ILogRFirstrr_<OpLogEvent, 0, (outs), (ins GR256:$rs0, GR256:$rs1),
+def EVTr : ILogRrr_<OpLogEvent, (outs), (ins GR256:$rs0, GR256:$rs1),
                          "$rs0, $rs1",
                          [(int_eravm_event GR256:$rs0, GR256:$rs1, 0)]>;
 
-def EVTFirstr : ILogRFirstrr_<OpLogEvent, 1, (outs), (ins GR256:$rs0, GR256:$rs1),
+def EVTFirstr : ILogRrr_<OpLogEventFirst, (outs), (ins GR256:$rs0, GR256:$rs1),
                               "$rs0, $rs1",
                               [(int_eravm_event GR256:$rs0, GR256:$rs1, 1)]>;
 

--- a/llvm/lib/Target/EraVM/EraVMOpcodes.td
+++ b/llvm/lib/Target/EraVM/EraVMOpcodes.td
@@ -122,14 +122,6 @@ class UMAOpcEncoder<OpcodeEncoding encoding, bits<11> BaseOpcode,
           true : -1);
 }
 
-class LogROpcEncoder<OpcodeEncoding encoding, bits<11> BaseOpcode,
-                     bit is_first> {
-  bits<11> Opcode =
-    !cond(!eq(encoding, LogEncoding) : !add(BaseOpcode, is_first),
-          !eq(encoding, DirectEncoding) : BaseOpcode,
-          true : -1);
-}
-
 class EraVMOpcode<string name, bits<11> opc, OpcodeEncoding encoding> {
   string Name = name;
   bits<11> BaseOpcode = opc;
@@ -186,8 +178,10 @@ def OpContextIncrementTxNumber : EraVMOpcode<"context.inc_tx_num",       1049, D
 def OpSload     : EraVMOpcode<"sload",      1050, DirectEncoding>;
 def OpSstore    : EraVMOpcode<"sstore",     1051, DirectEncoding>;
 
-def OpLogToL1   : EraVMOpcode<"to_l1",      1052, LogEncoding>; // is_first ⇒ 1052 + is_first
-def OpLogEvent  : EraVMOpcode<"event",      1054, LogEncoding>; // is_first ⇒ 1054 + is_first
+def OpLogToL1       : EraVMOpcode<"to_l1",       1052, DirectEncoding>; // is_first ⇒ 1052 + is_first
+def OpLogToL1First  : EraVMOpcode<"to_l1.first", 1053, DirectEncoding>;
+def OpLogEvent      : EraVMOpcode<"event",       1054, DirectEncoding>; // is_first ⇒ 1054 + is_first
+def OpLogEventFirst : EraVMOpcode<"event.first", 1055, DirectEncoding>;
 def OpLogPrecompile : EraVMOpcode<"precompile", 1056, DirectEncoding>;
 
 def OpFarcall  : EraVMOpcode<"far_call",     1057, FarCallEncoding>; // is_shard is_static ⇒ 1057 + 2 × is_static + is_shard


### PR DESCRIPTION
In preparation for renaming of assembler mnemonics, split EraVMOpcode definitions for `to_l1` and `event` instructions into base and `.first` variants, so their mnemonics can be specified independently.