### PR TITLE
[EraVM][TableGen] Split `EraVMOpcode`s for ret-like instructions (NFC)

### DIFF
--- a/llvm/lib/Target/EraVM/EraVMInstrFormats.td
+++ b/llvm/lib/Target/EraVM/EraVMInstrFormats.td
@@ -637,7 +637,6 @@ class Isr_sr<EraVMOpcode opcode,
 }
 
 class IRetBase<EraVMOpcode opcode,
-               bit to_label,
                dag ins,
                string asmstr,
                list<dag> pattern>
@@ -646,18 +645,13 @@ class IRetBase<EraVMOpcode opcode,
   let isReturn = 1;
   let isTerminator = 1;
   let isBarrier = 1;
-
-  let AsmString = !strconcat(opcode.Name,
-                             !if(to_label, ".to_label", ""),
-                             "${cc}", "\t", asmstr);
-  let Opcode = RetOpcEncoder<opcode.BaseOpcode, to_label>.Opcode;
 }
 
 class IRet<EraVMOpcode opcode,
            dag ins,
            string asmstr,
            list<dag> pattern>
-  : IRetBase <opcode, false, ins, asmstr, pattern > {
+  : IRetBase <opcode, ins, asmstr, pattern > {
   bits<4> rs0;
 
   let Src0 = rs0;
@@ -667,7 +661,7 @@ class IRetToLabel<EraVMOpcode opcode,
                   dag ins,
                   string asmstr,
                   list<dag> pattern>
-  : IRetBase <opcode, true, ins, asmstr, pattern > {
+  : IRetBase <opcode, ins, asmstr, pattern > {
   bits<4> rs0;
   bits<16> dest;
 

--- a/llvm/lib/Target/EraVM/EraVMInstrInfo.td
+++ b/llvm/lib/Target/EraVM/EraVMInstrInfo.td
@@ -1075,14 +1075,14 @@ def JCALL: Pseudo<(outs), (ins jmptarget:$dest), []>,
            PseudoInstExpansion<(JCl jmptarget:$dest, 0)>;
 
 def RETr : IRet<OpRet, (ins GR256:$rs0), "$rs0", []>;
-def RETrl : IRetToLabel<OpRet, (ins GR256:$rs0, jmptarget:$dest), "$rs0, $dest", []>;
+def RETrl : IRetToLabel<OpRetToLabel, (ins GR256:$rs0, jmptarget:$dest), "$rs0, $dest", []>;
 
 def REVERTr : IRet<OpRevert, (ins GR256:$rs0), "$rs0", []>;
-def REVERTrl : IRetToLabel<OpRevert, (ins GR256:$rs0, jmptarget:$dest), "$rs0, $dest", []>;
+def REVERTrl : IRetToLabel<OpRevertToLabel, (ins GR256:$rs0, jmptarget:$dest), "$rs0, $dest", []>;
 
 let rs0 = 0 in {
 def PANIC  : IRet<OpPanic, (ins), "", []>;
-def PANICl : IRetToLabel<OpPanic, (ins jmptarget:$dest), "$dest", []>;
+def PANICl : IRetToLabel<OpPanicToLabel, (ins jmptarget:$dest), "$dest", []>;
 }
 
 let isReturn = 1, isTerminator = 1, isBarrier = 1  in {

--- a/llvm/lib/Target/EraVM/EraVMOpcodes.td
+++ b/llvm/lib/Target/EraVM/EraVMOpcodes.td
@@ -104,11 +104,6 @@ class FarCallOpcEncoder<bits<11> BaseOpcode,
   bits<11> Opcode = !add(BaseOpcode, !mul(2, is_static), is_shard);
 }
 
-class RetOpcEncoder<bits<11> BaseOpcode,
-                    bit to_label> {
-  bits<11> Opcode = !add(BaseOpcode, to_label);
-}
-
 class JumpOpcEncoder<bits<11> BaseOpcode,
                      SrcMode src> {
   bits<11> Opcode = !add(BaseOpcode, src.Value);
@@ -189,9 +184,12 @@ def OpFarcall  : EraVMOpcode<"far_call",     1057, FarCallEncoding>; // is_shard
 def OpDelegate : EraVMOpcode<"far_call.delegate", 1061, FarCallEncoding>; // is_shard is_static ⇒ 1061 + 2 × is_static + is_shard
 def OpMimic    : EraVMOpcode<"far_call.mimic",    1065, FarCallEncoding>; // is_shard is_static ⇒ 1065 + 2 × is_static + is_shard
 
-def OpRet      : EraVMOpcode<"ret.ok",     1069, RetEncoding>; // to_label ⇒ 1069 + to_label
-def OpRevert   : EraVMOpcode<"ret.revert", 1071, RetEncoding>; // to_label ⇒ 1071 + to_label
-def OpPanic    : EraVMOpcode<"ret.panic",  1073, RetEncoding>; // to_label ⇒ 1073 + to_label
+def OpRet           : EraVMOpcode<"ret.ok",              1069, DirectEncoding>; // to_label ⇒ 1069 + to_label
+def OpRetToLabel    : EraVMOpcode<"ret.ok.to_label",     1070, DirectEncoding>;
+def OpRevert        : EraVMOpcode<"ret.revert",          1071, DirectEncoding>; // to_label ⇒ 1071 + to_label
+def OpRevertToLabel : EraVMOpcode<"ret.revert.to_label", 1072, DirectEncoding>;
+def OpPanic         : EraVMOpcode<"ret.panic",           1073, DirectEncoding>; // to_label ⇒ 1073 + to_label
+def OpPanicToLabel  : EraVMOpcode<"ret.panic.to_label",  1074, DirectEncoding>;
 
 def OpLoadHeap        : EraVMOpcode<"ld.1",     1075, HeapOpEncoding>; // src inc ⇒ 1075 + 10 × src + inc
 def OpLoadHeapInc     : EraVMOpcode<"ld.1.inc", 1076, HeapOpEncoding>;


### PR DESCRIPTION
In preparation for renaming of assembler mnemonics, split `EraVMOpcode` definitions for ret, revert and panic instructions into "without label" and "with label" variants, so their mnemonics can be specified independently.