### PR TITLE
[EraVM] Make `@fat.ptr.call` test case check for ptr.add instruction

### DIFF
--- a/llvm/test/CodeGen/EraVM/calling-convensions.ll
+++ b/llvm/test/CodeGen/EraVM/calling-convensions.ll
@@ -435,7 +435,7 @@ define void @fat.ptr.arg(i256 addrspace(3)* %ptr) {
 
 ; CHECK-LABEL: fat.ptr.call
 define void @fat.ptr.call(i256 %a1, i256 addrspace(3)* %ptr) {
-  ; CHECK: add r2, r0, r1
+  ; CHECK: ptr.add r2, r0, r1
   call void @fat.ptr.arg(i256 addrspace(3)* %ptr)
   ret void
 }


### PR DESCRIPTION
Clarify the `@fat.ptr.call` test case before renaming the mnemonics.

The instructions actually generated for `@fat.ptr.call` function are

    ptr.add    r2, r0, r1
    near_call  r0, @fat.ptr.arg, @DEFAULT_UNWIND
    ret

Before renaming `ptr.add` to `addp`, the first line was accidentally matched by the `add r2, r0, r1` substring.