### PR TITLE
[EraVM][TableGen] Cleanup the description of ret/revert/panic

### DIFF
--- a/llvm/lib/Target/EraVM/EraVMAsmPrinter.cpp
+++ b/llvm/lib/Target/EraVM/EraVMAsmPrinter.cpp
@@ -121,13 +121,14 @@ void EraVMAsmPrinter::emitInstruction(const MachineInstr *MI) {
     EmitToStreamer(*OutStreamer, TmpInst);
     return;
   }
-  case EraVM::REVERT:
-  case EraVM::RETURN: {
+  case EraVM::DEFAULT_FAR_REVERT:
+  case EraVM::DEFAULT_FAR_RETURN: {
+    bool IsRevert = Opc == EraVM::DEFAULT_FAR_REVERT;
     MCSymbol *DefaultFarReturnSym = OutContext.getOrCreateSymbol(
-        Opc == EraVM::REVERT ? "DEFAULT_FAR_REVERT" : "DEFAULT_FAR_RETURN");
+        IsRevert ? "DEFAULT_FAR_REVERT" : "DEFAULT_FAR_RETURN");
     // Expand to: ret/revert.to_label $rs0, @DEFAULT_FAR_RETURN
     MCOperand MCOp;
-    TmpInst.setOpcode(Opc == EraVM::REVERT ? EraVM::REVERTrl : EraVM::RETrl);
+    TmpInst.setOpcode(IsRevert ? EraVM::REVERTrl : EraVM::RETrl);
     // Operand: rs0
     lowerOperand(MI->getOperand(0), MCOp);
     TmpInst.addOperand(MCOp);

--- a/llvm/lib/Target/EraVM/EraVMInstrInfo.td
+++ b/llvm/lib/Target/EraVM/EraVMInstrInfo.td
@@ -1122,7 +1122,6 @@ def THROW : Pseudo<(outs), (ins GR256:$rs0, pred:$cc), [(EraVMthrow GR256:$rs0)]
 
 def : InstAlias<"ret${cc}", (RETr R1, pred:$cc)>;
 def : InstAlias<"revert${cc}", (REVERTr R1, pred:$cc)>;
-def : InstAlias<"panic${cc}", (PANIC pred:$cc)>;
 
 // TODO Make these aliases preferred for printing after switching to the new syntax.
 let EmitPriority = 0 in {
@@ -1131,8 +1130,8 @@ def : InstAlias<"ret.revert.to_label${cc} $dest", (REVERTrl R1, jmptarget:$dest,
 }
 
 let isTerminator = 1, isBarrier = 1, isReturn = 1 in {
-def RETURN : Pseudo<(outs), (ins GR256:$rs0, pred:$cc), [(EraVMreturn GR256:$rs0)]>;
-def REVERT : Pseudo<(outs), (ins GR256:$rs0, pred:$cc), [(EraVMrevert GR256:$rs0)]>;
+def DEFAULT_FAR_RETURN : Pseudo<(outs), (ins GR256:$rs0, pred:$cc), [(EraVMreturn GR256:$rs0)]>;
+def DEFAULT_FAR_REVERT : Pseudo<(outs), (ins GR256:$rs0, pred:$cc), [(EraVMrevert GR256:$rs0)]>;
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/EraVM/EraVMOpcodes.td
+++ b/llvm/lib/Target/EraVM/EraVMOpcodes.td
@@ -188,7 +188,7 @@ def OpRet           : EraVMOpcode<"ret.ok",              1069, DirectEncoding>; 
 def OpRetToLabel    : EraVMOpcode<"ret.ok.to_label",     1070, DirectEncoding>;
 def OpRevert        : EraVMOpcode<"ret.revert",          1071, DirectEncoding>; // to_label ⇒ 1071 + to_label
 def OpRevertToLabel : EraVMOpcode<"ret.revert.to_label", 1072, DirectEncoding>;
-def OpPanic         : EraVMOpcode<"ret.panic",           1073, DirectEncoding>; // to_label ⇒ 1073 + to_label
+def OpPanic         : EraVMOpcode<"panic",               1073, DirectEncoding>; // to_label ⇒ 1073 + to_label
 def OpPanicToLabel  : EraVMOpcode<"ret.panic.to_label",  1074, DirectEncoding>;
 
 def OpLoadHeap        : EraVMOpcode<"ld.1",     1075, HeapOpEncoding>; // src inc ⇒ 1075 + 10 × src + inc


### PR DESCRIPTION
Rename RETURN and REVERT pseudos to make their purpose easier to understand.

Remove InstAlias for panic instruction. Since register operand of panic instruction was removed, it virtually became a MnemonicAlias, so update the definition of OpPanic instead as no alias needed in the new syntax.