### PR TITLE
[EraVM][TableGen] Rename instruction defs according to new syntax

### DIFF
--- a/llvm/lib/Target/EraVM/EraVMHoistFlagSetting.cpp
+++ b/llvm/lib/Target/EraVM/EraVMHoistFlagSetting.cpp
@@ -145,11 +145,11 @@ static bool isValidCandidate(const MachineInstr &MI, const EraVMInstrInfo *TII,
     switch (MI.getOpcode()) {
     default:
       break;
-    case EraVM::LDInc:
-    case EraVM::LD1Incr:
-    case EraVM::LD2Incr:
-    case EraVM::ST1Incr:
-    case EraVM::ST2Incr:
+    case EraVM::LDPI:
+    case EraVM::LDMIhr:
+    case EraVM::LDMIahr:
+    case EraVM::STMIhr:
+    case EraVM::STMIahr:
       return true;
     }
   }

--- a/llvm/lib/Target/EraVM/EraVMISelDAGToDAG.cpp
+++ b/llvm/lib/Target/EraVM/EraVMISelDAGToDAG.cpp
@@ -403,7 +403,7 @@ void EraVMDAGToDAGISel::Select(SDNode *Node) {
       SDValue Chain = ld->getChain();
       SDValue Ptr = ld->getBasePtr();
       auto Zero = CurDAG->getTargetConstant(0, DL, MVT::i256);
-      auto *LD = CurDAG->getMachineNode(EraVM::LD, DL, ld->getMemoryVT(),
+      auto *LD = CurDAG->getMachineNode(EraVM::LDP, DL, ld->getMemoryVT(),
                                         MVT::Other, Ptr, Zero, Chain);
       ReplaceNode(Node, LD);
       return;

--- a/llvm/lib/Target/EraVM/EraVMInstrInfo.td
+++ b/llvm/lib/Target/EraVM/EraVMInstrInfo.td
@@ -981,18 +981,18 @@ multiclass HeapLoadInc<EraVMOpcode opcode> {
 }
 }
 
-defm LD1 : HeapLoad<OpLoadHeap, load_heap>;
-defm LD2 : HeapLoad<OpLoadAuxHeap, load_heapaux>;
-defm LD1Inc : HeapLoadInc<OpLoadHeapInc>;
-defm LD2Inc : HeapLoadInc<OpLoadAuxHeapInc>;
+defm LDMh   : HeapLoad<OpLoadHeap, load_heap>;
+defm LDMah  : HeapLoad<OpLoadAuxHeap, load_heapaux>;
+defm LDMIh  : HeapLoadInc<OpLoadHeapInc>;
+defm LDMIah : HeapLoadInc<OpLoadAuxHeapInc>;
 
-defm LDst : HeapLoad<OpStaticRead, load_static>;
-defm LDstInc : HeapLoadInc<OpStaticReadInc>;
+defm LDMst  : HeapLoad<OpStaticRead, load_static>;
+defm LDMIst : HeapLoadInc<OpStaticReadInc>;
 
 let mayLoad = 1 in {
-def LD      : IUMAr_r<OpLoadPtr, (outs GR256:$rd0), (ins GRPTR:$rs0),
+def LDP      : IUMAr_r<OpLoadPtr, (outs GR256:$rd0), (ins GRPTR:$rs0),
                      "$rs0, $rd0", []>;
-def LDInc   : IUMAr_rr<OpLoadPtrInc, (outs GR256:$rd0, GRPTR:$rd1), (ins GRPTR:$rs0),
+def LDPI   : IUMAr_rr<OpLoadPtrInc, (outs GR256:$rd0, GRPTR:$rd1), (ins GRPTR:$rs0),
                       "$rs0, $rd0, $rd1", []>;
 }
 
@@ -1014,13 +1014,13 @@ multiclass HeapStoreInc<EraVMOpcode opcode> {
 }
 }
 
-defm ST1 : HeapStore<OpStoreHeap, store_heap>;
-defm ST2 : HeapStore<OpStoreAuxHeap, store_heapaux>;
-defm ST1Inc : HeapStoreInc<OpStoreHeapInc>;
-defm ST2Inc : HeapStoreInc<OpStoreAuxHeapInc>;
+defm STMh   : HeapStore<OpStoreHeap, store_heap>;
+defm STMah  : HeapStore<OpStoreAuxHeap, store_heapaux>;
+defm STMIh  : HeapStoreInc<OpStoreHeapInc>;
+defm STMIah : HeapStoreInc<OpStoreAuxHeapInc>;
 
-defm STst : HeapStore<OpStaticWrite, store_static>;
-defm STstInc : HeapStoreInc<OpStaticWriteInc>;
+defm STMst  : HeapStore<OpStaticWrite, store_static>;
+defm STMIst : HeapStoreInc<OpStaticWriteInc>;
 
 //===----------------------------------------------------------------------===//
 // Control flow instructions
@@ -1193,44 +1193,44 @@ def CTXIncTx   : IContext_<OpContextIncrementTxNumber, (outs), (ins), "", [(int_
 //===----------------------------------------------------------------------===//
 // Fat Pointer
 //===----------------------------------------------------------------------===//
-def SLDrr : ILogRr_r<OpSload, (outs GR256:$rd0), (ins GR256:$rs0),
+def LDS : ILogRr_r<OpSload, (outs GR256:$rd0), (ins GR256:$rs0),
                      "$rs0, $rd0",
                      [(set GR256:$rd0, (load_storage GR256:$rs0))]>;
-def TLDrr : ILogRr_r<OpTransientLoad, (outs GR256:$rd0), (ins GR256:$rs0),
+def LDT : ILogRr_r<OpTransientLoad, (outs GR256:$rd0), (ins GR256:$rs0),
                      "$rs0, $rd0",
                      [(set GR256:$rd0, (load_transient GR256:$rs0))]>;
 
 let hasSideEffects = 1 in {
-  def SSTr : ILogRrr_<OpSstore, (outs), (ins GR256:$rs0, GR256:$rs1),
+  def STS : ILogRrr_<OpSstore, (outs), (ins GR256:$rs0, GR256:$rs1),
                       "$rs0, $rs1",
                       [(store_storage GR256:$rs1, GR256:$rs0)]>;
-  def TSTr : ILogRrr_<OpTransientStore, (outs), (ins GR256:$rs0, GR256:$rs1),
+  def STT : ILogRrr_<OpTransientStore, (outs), (ins GR256:$rs0, GR256:$rs1),
                       "$rs0, $rs1",
                       [(store_transient GR256:$rs1, GR256:$rs0)]>;
 }
 
 let hasSideEffects = 1 in {
-def L1r : ILogRrr_<OpLogToL1, (outs), (ins GR256:$rs0, GR256:$rs1),
+def LOGL1 : ILogRrr_<OpLogToL1, (outs), (ins GR256:$rs0, GR256:$rs1),
                         "$rs0, $rs1",
                         [(int_eravm_tol1 GR256:$rs0, GR256:$rs1, 0)]>;
-def L1Firstr : ILogRrr_<OpLogToL1First, (outs), (ins GR256:$rs0, GR256:$rs1),
+def LOGL1I : ILogRrr_<OpLogToL1Initial, (outs), (ins GR256:$rs0, GR256:$rs1),
                              "$rs0, $rs1",
                              [(int_eravm_tol1 GR256:$rs0, GR256:$rs1, 1)]>;
 
-def EVTr : ILogRrr_<OpLogEvent, (outs), (ins GR256:$rs0, GR256:$rs1),
+def LOG : ILogRrr_<OpLogEvent, (outs), (ins GR256:$rs0, GR256:$rs1),
                          "$rs0, $rs1",
                          [(int_eravm_event GR256:$rs0, GR256:$rs1, 0)]>;
 
-def EVTFirstr : ILogRrr_<OpLogEventFirst, (outs), (ins GR256:$rs0, GR256:$rs1),
+def LOGI : ILogRrr_<OpLogEventInitial, (outs), (ins GR256:$rs0, GR256:$rs1),
                               "$rs0, $rs1",
                               [(int_eravm_event GR256:$rs0, GR256:$rs1, 1)]>;
 
-def PCOMPr : ILogRrr_r<OpLogPrecompile, (outs GR256:$rd0), (ins GR256:$rs0, GR256:$rs1),
+def CALLP : ILogRrr_r<OpLogPrecompile, (outs GR256:$rd0), (ins GR256:$rs0, GR256:$rs1),
                        "$rs0, $rs1, $rd0",
                        [(set GR256:$rd0, (int_eravm_precompile GR256:$rs0, GR256:$rs1))]>;
 }
 
-def DECOMMITr : ILogRrr_r<OpDecommit, (outs GRPTR:$rd0), (ins GR256:$rs0, GR256:$rs1),
+def DCMT : ILogRrr_r<OpDecommit, (outs GRPTR:$rd0), (ins GR256:$rs0, GR256:$rs1),
                           "$rs0, $rs1, $rd0",
                           [(set GRPTR:$rd0, (EraVMlog_decommit GR256:$rs0, GR256:$rs1))]>;
 

--- a/llvm/lib/Target/EraVM/EraVMOpcodes.td
+++ b/llvm/lib/Target/EraVM/EraVMOpcodes.td
@@ -174,11 +174,11 @@ def OpContextIncrementTxNumber : EraVMOpcode<"context.inc_tx_num",       1049, D
 def OpSload     : EraVMOpcode<"sload",      1050, DirectEncoding>;
 def OpSstore    : EraVMOpcode<"sstore",     1051, DirectEncoding>;
 
-def OpLogToL1       : EraVMOpcode<"to_l1",       1052, DirectEncoding>; // is_first ⇒ 1052 + is_first
-def OpLogToL1First  : EraVMOpcode<"to_l1.first", 1053, DirectEncoding>;
-def OpLogEvent      : EraVMOpcode<"event",       1054, DirectEncoding>; // is_first ⇒ 1054 + is_first
-def OpLogEventFirst : EraVMOpcode<"event.first", 1055, DirectEncoding>;
-def OpLogPrecompile : EraVMOpcode<"precompile", 1056, DirectEncoding>;
+def OpLogToL1         : EraVMOpcode<"to_l1",       1052, DirectEncoding>; // is_first ⇒ 1052 + is_first
+def OpLogToL1Initial  : EraVMOpcode<"to_l1.first", 1053, DirectEncoding>;
+def OpLogEvent        : EraVMOpcode<"event",       1054, DirectEncoding>; // is_first ⇒ 1054 + is_first
+def OpLogEventInitial : EraVMOpcode<"event.first", 1055, DirectEncoding>;
+def OpLogPrecompile   : EraVMOpcode<"precompile",  1056, DirectEncoding>;
 
 def OpFarcall  : EraVMOpcode<"far_call",     1057, FarCallEncoding>; // is_shard is_static ⇒ 1057 + 2 × is_static + is_shard
 def OpDelegate : EraVMOpcode<"far_call.delegate", 1061, FarCallEncoding>; // is_shard is_static ⇒ 1061 + 2 × is_static + is_shard

--- a/llvm/test/CodeGen/EraVM/indexed-memops-ldinc.mir
+++ b/llvm/test/CodeGen/EraVM/indexed-memops-ldinc.mir
@@ -24,7 +24,7 @@
 ...
 ---
 # CHECK-LABEL: test
-# CHECK: %1:gr256, %5:grptr = LDInc %0, 0
+# CHECK: %1:gr256, %5:grptr = LDPI %0, 0
 
 name:            test
 alignment:       1
@@ -82,9 +82,9 @@ body:             |
     liveins: $r1
 
     %0:grptr = COPY $r1
-    %1:gr256 = LD %0, i256 0
+    %1:gr256 = LDP %0, i256 0
     %2:grptr = PTR_ADDxrr_s i256 32, %0, 0
-    %3:gr256 = LD killed %2, i256 0
+    %3:gr256 = LDP killed %2, i256 0
     %4:gr256 = ADDrrr_s killed %1, killed %3, 0
     $r1 = COPY %4
     RET i256 0, implicit $r1

--- a/llvm/test/CodeGen/EraVM/phi-node-elimination-fatptr-tag.mir
+++ b/llvm/test/CodeGen/EraVM/phi-node-elimination-fatptr-tag.mir
@@ -117,7 +117,7 @@ body:             |
 
   bb.3.exit:
     %2:grptr = PHI %1, %bb.2, %0, %bb.1
-    %6:gr256 = LD killed %2, i256 0
+    %6:gr256 = LDP killed %2, i256 0
     $r1 = COPY killed %6
     RET i256 0, implicit killed $r1
 

--- a/llvm/test/CodeGen/EraVM/select_fold.mir
+++ b/llvm/test/CodeGen/EraVM/select_fold.mir
@@ -321,7 +321,7 @@ tracksRegLiveness: true
 body:             |
   bb.0:
     liveins: $r1, $r2
-    $r2 = LD1r $r1, 0
+    $r2 = LDMhr $r1, 0
     $r1 = ADDrrr_s killed $r2, $r0, 9, implicit $flags
     RET 0
 ...


### PR DESCRIPTION
Rename load/store as well as several special instructions to reflect their current names according to new syntax.

Remove trailing "r" from several instructions that only have a fixed set of supported operands and would need "rr" or "rrr" suffix anyway.
