### PR TITLE
[EraVM][MC] Clarify usage of MemOperandKind and EncodedOperandMode enums

### DIFF
--- a/llvm/lib/Target/EraVM/AsmParser/EraVMAsmParser.cpp
+++ b/llvm/lib/Target/EraVM/AsmParser/EraVMAsmParser.cpp
@@ -152,13 +152,15 @@ public:
       return false;
 
     switch (Mem.Kind) {
+    case EraVM::OperandInvalid:
     case EraVM::OperandCode:
       return false;
+    case EraVM::OperandStackAbsolute:
+    case EraVM::OperandStackSPRelative:
+      return true;
     case EraVM::OperandStackSPDecrement:
     case EraVM::OperandStackSPIncrement:
       return IsInput == (Mem.Kind == EraVM::OperandStackSPDecrement);
-    default:
-      return true;
     }
   }
 

--- a/llvm/lib/Target/EraVM/Disassembler/EraVMDisassembler.cpp
+++ b/llvm/lib/Target/EraVM/Disassembler/EraVMDisassembler.cpp
@@ -133,7 +133,8 @@ DecodeStatus EraVMDisassembler::getInstruction(MCInst &MI, uint64_t &Size,
   uint64_t NewOpcode = OldOpcode;
   Insn &= ~EraVM::EncodedOpcodeMask;
 
-  int SrcMode = EraVM::OperandCode, DstMode = EraVM::OperandCode;
+  EraVM::EncodedOperandMode SrcMode = EraVM::ModeNotApplicable;
+  EraVM::EncodedOperandMode DstMode = EraVM::ModeNotApplicable;
   const EraVMOpcodeInfo *Info =
       EraVM::analyzeEncodedOpcode(OldOpcode, SrcMode, DstMode);
   if (!Info)

--- a/llvm/lib/Target/EraVM/MCTargetDesc/EraVMInstPrinter.cpp
+++ b/llvm/lib/Target/EraVM/MCTargetDesc/EraVMInstPrinter.cpp
@@ -147,7 +147,7 @@ void EraVMInstPrinter::printStackOperand(const MCInst *MI, unsigned OpNo,
   using namespace EraVM;
 
   unsigned BaseReg = 0;
-  MemOperandKind Kind = MemOperandKind::OperandCode;
+  MemOperandKind Kind = MemOperandKind::OperandInvalid;
   const MCSymbol *Symbol = nullptr;
   int Addend = 0;
   analyzeMCOperandsStack(*MI, OpNo, IsInput, BaseReg, Kind, Symbol, Addend);

--- a/llvm/lib/Target/EraVM/MCTargetDesc/EraVMMCTargetDesc.cpp
+++ b/llvm/lib/Target/EraVM/MCTargetDesc/EraVMMCTargetDesc.cpp
@@ -105,8 +105,9 @@ const EraVMOpcodeInfo *llvm::EraVM::findOpcodeInfo(unsigned Opcode) {
   return It;
 }
 
-const EraVMOpcodeInfo *EraVM::analyzeEncodedOpcode(unsigned EncodedOpcode,
-                                                   int &SrcMode, int &DstMode) {
+const EraVMOpcodeInfo *
+EraVM::analyzeEncodedOpcode(unsigned EncodedOpcode, EncodedOperandMode &SrcMode,
+                            EncodedOperandMode &DstMode) {
   const EraVMOpcodeInfo *Info = findOpcodeInfo(EncodedOpcode);
   int OpcodeDelta = EncodedOpcode - Info->BaseOpcode;
 
@@ -114,9 +115,11 @@ const EraVMOpcodeInfo *EraVM::analyzeEncodedOpcode(unsigned EncodedOpcode,
   DstMode = ModeNotApplicable;
 
   if (Info->SrcMultiplier)
-    SrcMode = (OpcodeDelta / Info->SrcMultiplier) % NumSrcModes;
+    SrcMode =
+        EncodedOperandMode((OpcodeDelta / Info->SrcMultiplier) % NumSrcModes);
   if (Info->DstMultiplier)
-    DstMode = (OpcodeDelta / Info->DstMultiplier) % NumDstModes;
+    DstMode =
+        EncodedOperandMode((OpcodeDelta / Info->DstMultiplier) % NumDstModes);
 
   return Info;
 }

--- a/llvm/lib/Target/EraVM/MCTargetDesc/EraVMMCTargetDesc.h
+++ b/llvm/lib/Target/EraVM/MCTargetDesc/EraVMMCTargetDesc.h
@@ -125,6 +125,7 @@ constexpr unsigned CellBitWidth = 256;
 ///     and dummy integer immediate for absolute addressing
 ///   * a few special cases exist - see appendMCOperands function.
 enum MemOperandKind {
+  OperandInvalid,
   OperandCode,
   OperandStackAbsolute,
   OperandStackSPRelative,
@@ -143,7 +144,7 @@ void appendMCOperands(MCContext &Ctx, MCInst &MI, MemOperandKind Kind,
                       unsigned Reg, const MCSymbol *Symbol, int Addend);
 
 // encode_src_mode / encode_dst_mode
-enum OperandModes {
+enum EncodedOperandMode {
   ModeNotApplicable = -1, // no such operand
   ModeReg = 0,            // SrcReg, DstReg
   ModeSpMod = 1,          // SrcSpRelativePop, DstSpRelativePush
@@ -159,7 +160,8 @@ const uint64_t EncodedOpcodeMask = UINT64_C(0x7ff);
 
 const EraVMOpcodeInfo *findOpcodeInfo(unsigned Opcode);
 const EraVMOpcodeInfo *analyzeEncodedOpcode(unsigned EncodedOpcode,
-                                            int &SrcMode, int &DstMode);
+                                            EncodedOperandMode &SrcMode,
+                                            EncodedOperandMode &DstMode);
 
 } // namespace EraVM
 } // namespace llvm


### PR DESCRIPTION
Explicitly specify EncodedOperandMode type and only convert it to int when necessary.

Introduce MemOperandKind::OperandInvalid to not implicitly use OperandCode as invalid stack operand kind.