### PR TITLE
ci: fix cumulative commits in regression tests

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -2,8 +2,8 @@ name: Regression tests
 
 on:
   pull_request:
-    # branches:
-    #   - main
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       commits-to-test:
@@ -68,13 +68,17 @@ jobs:
           fetch-depth: ${{ needs.prepare-test-matrix.outputs.fetch_depth }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
+      - name: Define previous commit
+        id: previous-commit
+        run: echo "sha=$(git show --quiet --pretty='%H' ${{ matrix.commit }}^1)" | tee -a "${GITHUB_OUTPUT}"
+
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v39
         with:
           separator: ","
           sha: ${{ matrix.commit }}
-          base_sha: ${{ github.event.pull_request.base.sha }}
+          base_sha: ${{ steps.previous-commit.outputs.sha }}
 
       - name: Install formatting requirements
         run: python3 -m pip install -r ./llvm/utils/git/requirements_formatting_era_llvm.txt
@@ -89,7 +93,7 @@ jobs:
           fi
           python3 ./llvm/utils/git/code-format-helper-era-llvm.py ${TOKEN_PARAM} \
             --issue-number ${{ github.event.pull_request.number }} \
-            --start-rev ${{ github.event.pull_request.base.sha }} \
+            --start-rev ${{ steps.previous-commit.outputs.sha }} \
             --end-rev ${{ matrix.commit }} \
             --changed-files ${{ steps.changed-files.outputs.all_changed_files }}
 
@@ -108,8 +112,15 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ matrix.commit }}
+          fetch-depth: ${{ needs.prepare-test-matrix.outputs.fetch_depth }}
           path: "llvm"
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: Define previous commit
+        if: github.event_name == 'pull_request'
+        working-directory: llvm
+        id: previous-commit
+        run: echo "sha=$(git show --quiet --pretty='%H' ${{ matrix.commit }}^1)" | tee -a "${GITHUB_OUTPUT}"
 
       - name: Build LLVM
         uses: matter-labs/era-compiler-ci/.github/actions/build-llvm@v1
@@ -130,9 +141,7 @@ jobs:
         if: github.event_name == 'pull_request'
         working-directory: llvm
         run: |
-          git fetch --progress --depth=1 origin \
-            "+refs/heads/${{ github.event.pull_request.base.ref }}:refs/heads/${{ github.event.pull_request.base.ref }}"
-          CHANGES=$(git diff -U0 ${{ github.event.pull_request.base.sha }})
+          CHANGES=$(git diff -U0 ${{ steps.previous-commit.outputs.sha }})
           echo "Running clang-tidy on the following changes: ${CHANGES}"
           echo "${CHANGES}" | \
              ./clang-tools-extra/clang-tidy/tool/clang-tidy-diff_Zegar.py \


### PR DESCRIPTION
# Code Review Checklist

## Purpose

Use previous commit for comparison, instead of cumulative changes for format and tidy.

## Ticket Number

N/A

## Tests

* [Run with multiple commits](https://github.com/matter-labs/era-compiler-llvm/actions/runs/9415742944)
* [Two commits confirmation run](https://github.com/matter-labs/era-compiler-llvm/actions/runs/9416124043/job/25938607049?pr=605)
* All commits were checked as they supposed to
