### PR TITLE
Cherry pick commits to disable bitcode-uselistorder.ll test

### DIFF
--- a/llvm/test/tools/llvm-reduce/bitcode-uselistorder.ll
+++ b/llvm/test/tools/llvm-reduce/bitcode-uselistorder.ll
@@ -1,3 +1,5 @@
+; UNSUPPORTED: target={{aarch64|arm64}}-{{.*}}
+
 ; RUN: llvm-as -o %t.bc %s
 
 ; RUN: llvm-reduce -j=1 --abort-on-invalid-reduction \

--- a/llvm/test/tools/llvm-reduce/bitcode-uselistorder.ll
+++ b/llvm/test/tools/llvm-reduce/bitcode-uselistorder.ll
@@ -1,4 +1,5 @@
-; UNSUPPORTED: target={{aarch64|arm64}}-{{.*}}
+; Sometimes fails with an assert on many targets.
+; UNSUPPORTED: target={{.*}}
 
 ; RUN: llvm-as -o %t.bc %s
 


### PR DESCRIPTION
This test is [flaky](https://github.com/matter-labs/era-compiler-llvm/actions/runs/9449451545/job/26025796628), and it is disabled in the LLVM trunk. Cherry pick commits to disable it.