### PR TITLE
[EraVM] Drop repeated instruction operands definitions from *.td files

### DIFF
--- a/llvm/lib/Target/EraVM/EraVMInstrFormats.td
+++ b/llvm/lib/Target/EraVM/EraVMInstrFormats.td
@@ -191,6 +191,44 @@ def stackout : Operand<i256> {
 }
 
 //===----------------------------------------------------------------------===//
+// EraVM Instruction Operands - helper definitions.
+//===----------------------------------------------------------------------===//
+
+// Description of EraVM instruction operand, except for ${cc}.
+class EraVMOperand<string str, dag ins, dag outs = (outs)> {
+  string AsmOps = str;
+  dag InOps = ins;
+  dag OutOps = outs;
+}
+
+def rs0 : EraVMOperand<"$rs0", (ins GR256:$rs0)>;
+def rs1 : EraVMOperand<"$rs1", (ins GR256:$rs1)>;
+def rd0 : EraVMOperand<"$rd0", (ins), (outs GR256:$rd0)>;
+def rd1 : EraVMOperand<"$rd1", (ins), (outs GR256:$rd1)>;
+
+def rs0_ptr : EraVMOperand<"$rs0", (ins GRPTR:$rs0)>;
+def rs1_ptr : EraVMOperand<"$rs1", (ins GRPTR:$rs1)>;
+def rd0_ptr : EraVMOperand<"$rd0", (ins), (outs GRPTR:$rd0)>;
+def rd1_ptr : EraVMOperand<"$rd1", (ins), (outs GRPTR:$rd1)>;
+
+def src0_stack : EraVMOperand<"$src0", (ins stackin:$src0)>;
+def src0_code  : EraVMOperand<"$src0", (ins memop:$src0)>;
+def src0_imm   : EraVMOperand<"$imm", (ins imm16:$imm)>;
+
+def dst0_stack : EraVMOperand<"$dst0", (ins stackout:$dst0)>;
+
+def callee : EraVMOperand<"$callee", (ins jmptarget:$callee)>;
+def unwind : EraVMOperand<"$unwind", (ins jmptarget:$unwind)>;
+
+def addr : EraVMOperand<"$addr", (ins imm16:$addr)>;
+
+def ret_addr   : EraVMOperand<"$ret_addr", (ins), (outs GR256:$ret_addr)>;
+def dest_label : EraVMOperand<"$dest", (ins jmptarget:$dest)>;
+def dest_reg   : EraVMOperand<"$dest", (ins GR256:$dest)>;
+def dest_code  : EraVMOperand<"$dest", (ins memop:$dest)>;
+def dest_stack : EraVMOperand<"$dest", (ins stackin:$dest)>;
+
+//===----------------------------------------------------------------------===//
 // EraVM Instructions
 //===----------------------------------------------------------------------===//
 
@@ -293,12 +331,23 @@ class AsmParserPseudo<dag outs, dag inops, string opc, string asmstr>
 
 // Real instructions (have encoding)
 class IForm <EraVMOpcode opcode,
-             dag oops, dag inops,
-             string asmstr,
+             list<EraVMOperand> ops,
              list<dag> pattern> : EraVMInstruction, Encoding {
   bits<3> cc;
 
-  dag InOperandList  = !con(inops, (ins pred:$cc));
+  // Aggregate fields from `ops`, for example:
+  //   asmstr = "$src0, $rs1, $rd0"
+  //   iops = (ins stackin:$src0, GR256:$rs1)
+  //   oops = (outs GR256:$rd0)
+  // Note that asmstr is a field instead of defvar, as it is used by this class
+  // to define AsmString as well as by subclasses to redefine it.
+  string asmstr = !if(!empty(ops), "",
+                      !foldl(ops[0].AsmOps, !tail(ops),
+                             acc, x, !strconcat(acc, ", ", x.AsmOps)));
+  defvar iops = !foldl((ins),  ops, acc, x, !con(acc, x.InOps));
+  defvar oops = !foldl((outs), ops, acc, x, !con(acc, x.OutOps));
+
+  dag InOperandList  = !con(iops, (ins pred:$cc));
   dag OutOperandList = oops;
   let Pattern        = pattern;
   let Size           = 8;
@@ -310,39 +359,36 @@ class IForm <EraVMOpcode opcode,
   let UseLogicalOperandMappings = true;
 }
 
-class IJump<EraVMOpcode opcode,
-            SrcMode src,
-            dag outs, dag ins, string asmstr, list<dag> pattern>
-  : IForm <opcode, outs, ins, asmstr, pattern> {
+class IJump<EraVMOpcode opcode, SrcMode src,
+            list<EraVMOperand> ops, list<dag> pattern>
+  : IForm <opcode, ops, pattern> {
 
   let isIndirectBranch = !ne(src, SrcImm);
   let mayLoad = !or(isStackIn<src>.Value, !eq(src, SrcCodeAddr));
   let Opcode = JumpOpcEncoder<opcode.BaseOpcode, src>.Opcode;
 }
 
-class IContextBase<EraVMOpcode opcode, dag outs, dag ins, string asmstr, list<dag> pattern>
-  : IForm <opcode, outs, ins, asmstr, pattern> { }
+class IContextBase<EraVMOpcode opcode, list<EraVMOperand> ops, list<dag> pattern>
+  : IForm <opcode, ops, pattern>;
 
-class IContext_<EraVMOpcode opcode, dag outs, dag ins, string asmstr, list<dag> pattern>
-  : IContextBase<opcode, outs, ins, asmstr, pattern>;
-class IContextr_<EraVMOpcode opcode, dag outs, dag ins, string asmstr, list<dag> pattern>
-  : IContextBase<opcode, outs, ins, asmstr, pattern> {
+class IContext_<EraVMOpcode opcode, list<dag> pattern>
+  : IContextBase<opcode, [], pattern>;
+class IContextr_<EraVMOpcode opcode, list<dag> pattern>
+  : IContextBase<opcode, [rs0], pattern> {
   bits<4> rs0;
   let Src0 = rs0;
 }
-class IContext_r<EraVMOpcode opcode, dag outs, dag ins, string asmstr, list<dag> pattern>
-  : IContextBase<opcode, outs, ins, asmstr, pattern> {
+class IContext_r<EraVMOpcode opcode, list<dag> pattern>
+  : IContextBase<opcode, [rd0], pattern> {
   bits<4> rd0;
   let Dst0 = rd0;
 }
 
-class ILogRBase<EraVMOpcode opcode, dag outs, dag ins,
-                string asmstr, list<dag> pattern>
-  : IForm <opcode, outs, ins, asmstr, pattern> { }
+class ILogRBase<EraVMOpcode opcode, list<EraVMOperand> ops, list<dag> pattern>
+  : IForm <opcode, ops, pattern>;
 
-class ILogRr_r<EraVMOpcode opcode, dag outs, dag ins,
-               string asmstr, list<dag> pattern>
-  : ILogRBase<opcode, outs, ins, asmstr, pattern> {
+class ILogRr_r<EraVMOpcode opcode, list<dag> pattern>
+  : ILogRBase<opcode, [rs0, rd0], pattern> {
   bits<4> rs0;
   bits<4> rd0;
 
@@ -350,9 +396,8 @@ class ILogRr_r<EraVMOpcode opcode, dag outs, dag ins,
   let Dst0 = rd0;
 }
 
-class ILogRrr_<EraVMOpcode opcode, dag outs, dag ins,
-               string asmstr, list<dag> pattern>
-  : ILogRBase<opcode, outs, ins, asmstr, pattern> {
+class ILogRrr_<EraVMOpcode opcode, list<dag> pattern>
+  : ILogRBase<opcode, [rs0, rs1], pattern> {
   bits<4> rs0;
   bits<4> rs1;
 
@@ -360,9 +405,8 @@ class ILogRrr_<EraVMOpcode opcode, dag outs, dag ins,
   let Src1 = rs1;
 }
 
-class ILogRrr_r<EraVMOpcode opcode, dag outs, dag ins,
-                string asmstr, list<dag> pattern>
-  : ILogRBase<opcode, outs, ins, asmstr, pattern> {
+class ILogRrr_r<EraVMOpcode opcode, list<EraVMOperand> ops, list<dag> pattern>
+  : ILogRBase<opcode, ops, pattern> {
   bits<4> rs0;
   bits<4> rs1;
   bits<4> rd0;
@@ -375,10 +419,9 @@ class ILogRrr_r<EraVMOpcode opcode, dag outs, dag ins,
 class IBinary<EraVMOpcode opcode,
               SrcMode src, DstMode dst,
               mod_swap swap, mod_set_flags set_flags,
-              dag outs, dag ins,
-              string asmstr,
+              list<EraVMOperand> ops,
               list<dag> pattern>
-  : IForm <opcode, outs, ins, asmstr, pattern > {
+  : IForm <opcode, ops, pattern> {
   string BaseOpcode;
   mod_set_flags Silent = set_flags;
   mod_swap ReverseOperands = swap;
@@ -401,10 +444,9 @@ class IBinary<EraVMOpcode opcode,
 class IBinaryR<EraVMOpcode opcode,
                SrcMode src,
                mod_swap swap_operands, mod_set_flags silent,
-               dag outs, dag ins,
-               string asmstr,
+               list<EraVMOperand> ops,
                list<dag> pattern>
-  : IBinary <opcode, src, DstReg, swap_operands, silent, outs, ins, asmstr, pattern > {
+  : IBinary <opcode, src, DstReg, swap_operands, silent, ops, pattern> {
   bits<4> rd0;
 
   let DestAddrMode = ToReg;
@@ -412,13 +454,23 @@ class IBinaryR<EraVMOpcode opcode,
   let Dst0 = rd0;
 }
 
+class IBinaryRR<EraVMOpcode opcode,
+                SrcMode src,
+                mod_swap swap_operands, mod_set_flags silent,
+                list<EraVMOperand> ops,
+                list<dag> pattern>
+  : IBinaryR <opcode, src, swap_operands, silent, ops, pattern> {
+  bits<4> rd1;
+
+  let Dst1 = rd1;
+}
+
 class IBinaryS<EraVMOpcode opcode,
                SrcMode src,
                mod_swap swap, mod_set_flags set_flags,
-               dag outs, dag ins,
-               string asmstr,
+               list<EraVMOperand> ops,
                list<dag> pattern>
-  : IBinary <opcode, src, DstStackAbsolute, swap, set_flags, outs, ins, asmstr, pattern > {
+  : IBinary <opcode, src, DstStackAbsolute, swap, set_flags, ops, pattern> {
   // Encode stack operand into 20 bits as reg + imm offset
   bits<20> dst0;
 
@@ -426,6 +478,17 @@ class IBinaryS<EraVMOpcode opcode,
 
   let Dst0 = dst0{3-0};
   let Imm1 = dst0{19-4};
+}
+
+class IBinarySR<EraVMOpcode opcode,
+               SrcMode src,
+               mod_swap swap, mod_set_flags set_flags,
+               list<EraVMOperand> ops,
+               list<dag> pattern>
+  : IBinaryS <opcode, src, swap, set_flags, ops, pattern> {
+  bits<4> rd1;
+
+  let Dst1 = rd1;
 }
 
 // Mix-in classes to hook standard fields for different combinations
@@ -475,161 +538,159 @@ class SrcOperandsSR {
 
 class Irr_r<EraVMOpcode opcode,
             mod_swap swap_operands, mod_set_flags silent,
-            dag outs, dag ins,
-            string asmstr,
             list<dag> pattern>
-  : IBinaryR<opcode, SrcReg, swap_operands, silent, outs, ins, asmstr, pattern>,
+  : IBinaryR<opcode, SrcReg, swap_operands, silent, [rs0, rs1, rd0], pattern>,
+    SrcOperandsRR;
+
+class Ipr_p<EraVMOpcode opcode,
+            mod_swap swap_operands, mod_set_flags silent,
+            list<dag> pattern>
+  : IBinaryR<opcode, SrcReg, swap_operands, silent, [rs0_ptr, rs1, rd0_ptr], pattern>,
     SrcOperandsRR;
 
 class Irr_rr<EraVMOpcode opcode,
              mod_swap swap_operands, mod_set_flags silent,
-             dag outs, dag ins,
-             string asmstr,
              list<dag> pattern>
-  : Irr_r<opcode, swap_operands, silent, outs, ins, asmstr, pattern> {
-  bits<4> rd1;
-
-  let Dst1 = rd1;
-}
+  : IBinaryRR<opcode, SrcReg, swap_operands, silent, [rs0, rs1, rd0, rd1], pattern>,
+    SrcOperandsRR;
 
 class Iir_r<EraVMOpcode opcode,
             mod_swap swap_operands, mod_set_flags silent,
-            dag outs, dag ins,
-            string asmstr,
             list<dag> pattern>
-  : IBinaryR<opcode, SrcImm, swap_operands, silent, outs, ins, asmstr, pattern>,
+  : IBinaryR<opcode, SrcImm, swap_operands, silent, [src0_imm, rs1, rd0], pattern>,
+    SrcOperandsIR;
+
+class Iip_p<EraVMOpcode opcode,
+            mod_swap swap_operands, mod_set_flags silent,
+            list<dag> pattern>
+  : IBinaryR<opcode, SrcImm, swap_operands, silent, [src0_imm, rs1_ptr, rd0_ptr], pattern>,
     SrcOperandsIR;
 
 class Iir_rr<EraVMOpcode opcode,
              mod_swap swap_operands, mod_set_flags silent,
-             dag outs, dag ins,
-             string asmstr,
              list<dag> pattern>
-  : Iir_r<opcode, swap_operands, silent, outs, ins, asmstr, pattern> {
-  bits<4> rd1;
+  : IBinaryRR<opcode, SrcImm, swap_operands, silent, [src0_imm, rs1, rd0, rd1], pattern>,
+    SrcOperandsIR;
 
-  let Dst1 = rd1;
-}
 
 class Imr_r<EraVMOpcode opcode,
             mod_swap swap_operands, mod_set_flags silent,
-            dag outs, dag ins,
-            string asmstr,
             list<dag> pattern>
-  : IBinaryR<opcode, SrcCodeAddr, swap_operands, silent, outs, ins, asmstr, pattern>,
+  : IBinaryR<opcode, SrcCodeAddr, swap_operands, silent, [src0_code, rs1, rd0], pattern>,
+    SrcOperandsMR;
+
+class Imp_p<EraVMOpcode opcode,
+            mod_swap swap_operands, mod_set_flags silent,
+            list<dag> pattern>
+  : IBinaryR<opcode, SrcCodeAddr, swap_operands, silent, [src0_code, rs1_ptr, rd0_ptr], pattern>,
     SrcOperandsMR;
 
 class Isr_r<EraVMOpcode opcode,
             mod_swap swap_operands, mod_set_flags silent,
-            dag outs, dag ins,
-            string asmstr,
             list<dag> pattern>
-  : IBinaryR<opcode, SrcStackAbsolute, swap_operands, silent, outs, ins, asmstr, pattern>,
+  : IBinaryR<opcode, SrcStackAbsolute, swap_operands, silent, [src0_stack, rs1, rd0], pattern>,
+    SrcOperandsSR;
+
+class Isr_p<EraVMOpcode opcode,
+            mod_swap swap_operands, mod_set_flags silent,
+            list<dag> pattern>
+  : IBinaryR<opcode, SrcStackAbsolute, swap_operands, silent, [src0_stack, rs1, rd0_ptr], pattern>,
+    SrcOperandsSR;
+
+class Isp_p<EraVMOpcode opcode,
+            mod_swap swap_operands, mod_set_flags silent,
+            list<dag> pattern>
+  : IBinaryR<opcode, SrcStackAbsolute, swap_operands, silent, [src0_stack, rs1_ptr, rd0_ptr], pattern>,
     SrcOperandsSR;
 
 class Imr_rr<EraVMOpcode opcode,
              mod_swap swap_operands, mod_set_flags silent,
-             dag outs, dag ins,
-             string asmstr,
              list<dag> pattern>
-  : Imr_r<opcode, swap_operands, silent, outs, ins, asmstr, pattern> {
-  bits<4> rd1;
-
-  let Dst1 = rd1;
-}
+  : IBinaryRR<opcode, SrcCodeAddr, swap_operands, silent, [src0_code, rs1, rd0, rd1], pattern>,
+    SrcOperandsMR;
 
 class Isr_rr<EraVMOpcode opcode,
              mod_swap swap_operands, mod_set_flags silent,
-             dag outs, dag ins,
-             string asmstr,
              list<dag> pattern>
-  : Isr_r<opcode, swap_operands, silent, outs, ins, asmstr, pattern> {
-  bits<4> rd1;
-
-  let Dst1 = rd1;
-}
+  : IBinaryRR<opcode, SrcStackAbsolute, swap_operands, silent, [src0_stack, rs1, rd0, rd1], pattern>,
+    SrcOperandsSR;
 
 class Irr_s<EraVMOpcode opcode,
             mod_swap swap_operands, mod_set_flags silent,
-            dag outs, dag ins,
-            string asmstr,
             list<dag> pattern>
-  : IBinaryS<opcode, SrcReg, swap_operands, silent, outs, ins, asmstr, pattern>,
+  : IBinaryS<opcode, SrcReg, swap_operands, silent, [rs0, rs1, dst0_stack], pattern>,
+    SrcOperandsRR;
+
+class Ipr_s<EraVMOpcode opcode,
+            mod_swap swap_operands, mod_set_flags silent,
+            list<dag> pattern>
+  : IBinaryS<opcode, SrcReg, swap_operands, silent, [rs0_ptr, rs1, dst0_stack], pattern>,
     SrcOperandsRR;
 
 class Irr_sr<EraVMOpcode opcode,
              mod_swap swap_operands, mod_set_flags silent,
-             dag outs, dag ins,
-             string asmstr,
              list<dag> pattern>
-  : Irr_s<opcode, swap_operands, silent, outs, ins, asmstr, pattern> {
-  bits<4> rd1;
-
-  let Dst1 = rd1;
-}
+  : IBinarySR<opcode, SrcReg, swap_operands, silent, [rs0, rs1, dst0_stack, rd1], pattern>,
+    SrcOperandsRR;
 
 class Iir_s<EraVMOpcode opcode,
             mod_swap swap_operands, mod_set_flags silent,
-            dag outs, dag ins,
-            string asmstr,
             list<dag> pattern>
-  : IBinaryS<opcode, SrcImm, swap_operands, silent, outs, ins, asmstr, pattern>,
+  : IBinaryS<opcode, SrcImm, swap_operands, silent, [src0_imm, rs1, dst0_stack], pattern>,
+    SrcOperandsIR;
+
+class Iip_s<EraVMOpcode opcode,
+            mod_swap swap_operands, mod_set_flags silent,
+            list<dag> pattern>
+  : IBinaryS<opcode, SrcImm, swap_operands, silent, [src0_imm, rs1_ptr, dst0_stack], pattern>,
     SrcOperandsIR;
 
 class Iir_sr<EraVMOpcode opcode,
              mod_swap swap_operands, mod_set_flags silent,
-             dag outs, dag ins,
-             string asmstr,
              list<dag> pattern>
-  : Iir_s<opcode, swap_operands, silent, outs, ins, asmstr, pattern> {
-  bits<4> rd1;
-
-  let Dst1 = rd1;
-}
+  : IBinarySR<opcode, SrcImm, swap_operands, silent, [src0_imm, rs1, dst0_stack, rd1], pattern>,
+    SrcOperandsIR;
 
 class Imr_s<EraVMOpcode opcode,
             mod_swap swap_operands, mod_set_flags silent,
-            dag outs, dag ins,
-            string asmstr,
             list<dag> pattern>
-  : IBinaryS<opcode, SrcCodeAddr, swap_operands, silent, outs, ins, asmstr, pattern>,
+  : IBinaryS<opcode, SrcCodeAddr, swap_operands, silent, [src0_code, rs1, dst0_stack], pattern>,
+    SrcOperandsMR;
+
+class Imp_s<EraVMOpcode opcode,
+            mod_swap swap_operands, mod_set_flags silent,
+            list<dag> pattern>
+  : IBinaryS<opcode, SrcCodeAddr, swap_operands, silent, [src0_code, rs1_ptr, dst0_stack], pattern>,
     SrcOperandsMR;
 
 class Isr_s<EraVMOpcode opcode,
             mod_swap swap_operands, mod_set_flags silent,
-            dag outs, dag ins,
-            string asmstr,
             list<dag> pattern>
-  : IBinaryS<opcode, SrcStackAbsolute, swap_operands, silent, outs, ins, asmstr, pattern>,
+  : IBinaryS<opcode, SrcStackAbsolute, swap_operands, silent, [src0_stack, rs1, dst0_stack], pattern>,
+    SrcOperandsSR;
+
+class Isp_s<EraVMOpcode opcode,
+            mod_swap swap_operands, mod_set_flags silent,
+            list<dag> pattern>
+  : IBinaryS<opcode, SrcStackAbsolute, swap_operands, silent, [src0_stack, rs1_ptr, dst0_stack], pattern>,
     SrcOperandsSR;
 
 class Imr_sr<EraVMOpcode opcode,
              mod_swap swap_operands, mod_set_flags silent,
-             dag outs, dag ins,
-             string asmstr,
              list<dag> pattern>
-  : Imr_s<opcode, swap_operands, silent, outs, ins, asmstr, pattern> {
-  bits<4> rd1;
-
-  let Dst1 = rd1;
-}
+  : IBinarySR<opcode, SrcCodeAddr, swap_operands, silent, [src0_code, rs1, dst0_stack, rd1], pattern>,
+    SrcOperandsMR;
 
 class Isr_sr<EraVMOpcode opcode,
              mod_swap swap_operands, mod_set_flags silent,
-             dag outs, dag ins,
-             string asmstr,
              list<dag> pattern>
-  : Isr_s<opcode, swap_operands, silent, outs, ins, asmstr, pattern> {
-  bits<4> rd1;
-
-  let Dst1 = rd1;
-}
+  : IBinarySR<opcode, SrcStackAbsolute, swap_operands, silent, [src0_stack, rs1, dst0_stack, rd1], pattern>,
+    SrcOperandsSR;
 
 class IRetBase<EraVMOpcode opcode,
-               dag ins,
-               string asmstr,
+               list<EraVMOperand> ops,
                list<dag> pattern>
-  : IForm <opcode, (outs), ins, asmstr, pattern > {
+  : IForm <opcode, ops, pattern> {
 
   let isReturn = 1;
   let isTerminator = 1;
@@ -637,20 +698,18 @@ class IRetBase<EraVMOpcode opcode,
 }
 
 class IRet<EraVMOpcode opcode,
-           dag ins,
-           string asmstr,
+           list<EraVMOperand> ops,
            list<dag> pattern>
-  : IRetBase <opcode, ins, asmstr, pattern > {
+  : IRetBase <opcode, ops, pattern> {
   bits<4> rs0;
 
   let Src0 = rs0;
 }
 
 class IRetToLabel<EraVMOpcode opcode,
-                  dag ins,
-                  string asmstr,
+                  list<EraVMOperand> ops,
                   list<dag> pattern>
-  : IRetBase <opcode, ins, asmstr, pattern > {
+  : IRetBase <opcode, ops, pattern> {
   bits<4> rs0;
   bits<16> dest;
 
@@ -658,22 +717,21 @@ class IRetToLabel<EraVMOpcode opcode,
   let Imm0 = dest;
 }
 
-class ICall<EraVMOpcode opcode, dag ins, string asmstr, list<dag> pattern>
-  : IForm <opcode, (outs), ins, asmstr, pattern > {
-  bits<4> in1;
+class ICall<EraVMOpcode opcode, list<dag> pattern>
+  : IForm <opcode, [rs0, callee, unwind], pattern> {
+  bits<4> rs0;
   bits<16> callee;
   bits<16> unwind;
 
-  let Src0 = in1;
+  let Src0 = rs0;
   let Imm0 = callee;
   let Imm1 = unwind;
 }
 
 class IFarCall<EraVMOpcode opcode,
                bit is_shard, bit is_static,
-               dag ins,
-               string asmstr, list<dag> pattern>
-  : IForm <opcode, (outs), ins, asmstr, pattern > {
+               list<dag> pattern>
+  : IForm <opcode, [rs0, rs1, unwind], pattern> {
   bits<4> rs0;
   bits<4> rs1;
   bits<16> unwind;
@@ -694,21 +752,15 @@ class IFarCall<EraVMOpcode opcode,
 
 class IUMA<EraVMOpcode opcode,
            SrcSpecialMode src,
-           dag outs, dag ins,
-           string asmstr,
+           list<EraVMOperand> ops,
            list<dag> pattern>
-  : IForm <opcode, outs, ins, asmstr, pattern> {
+  : IForm <opcode, ops, pattern> {
 
-  let AsmString = !strconcat(opcode.Name,
-                             "${cc}", "\t", asmstr);
   let Opcode = UMAOpcEncoder<opcode.Encoding, opcode.BaseOpcode, src>.Opcode;
 }
 
-class IUMAr_r<EraVMOpcode opcode,
-              dag outs, dag ins,
-              string asmstr,
-              list<dag> pattern>
- : IUMA<opcode, SrcSpecialReg, outs, ins, asmstr, pattern> {
+class IUMAr_r<EraVMOpcode opcode, list<dag> pattern>
+ : IUMA<opcode, SrcSpecialReg, [rs0, rd0], pattern> {
   bits<4> rs0;
   bits<4> rd0;
 
@@ -716,11 +768,17 @@ class IUMAr_r<EraVMOpcode opcode,
   let Dst0 = rd0;
 }
 
-class IUMAr_rr<EraVMOpcode opcode,
-               dag outs, dag ins,
-               string asmstr,
-               list<dag> pattern>
- : IUMA<opcode, SrcSpecialReg, outs, ins, asmstr, pattern> {
+class IUMAp_r<EraVMOpcode opcode, list<dag> pattern>
+ : IUMA<opcode, SrcSpecialReg, [rs0_ptr, rd0], pattern> {
+  bits<4> rs0;
+  bits<4> rd0;
+
+  let Src0 = rs0;
+  let Dst0 = rd0;
+}
+
+class IUMAr_rr<EraVMOpcode opcode, list<dag> pattern>
+ : IUMA<opcode, SrcSpecialReg, [rs0, rd0, rd1], pattern> {
   bits<4> rs0;
   bits<4> rd0;
   bits<4> rd1;
@@ -730,11 +788,19 @@ class IUMAr_rr<EraVMOpcode opcode,
   let Dst1 = rd1;
 }
 
-class IUMAi_r<EraVMOpcode opcode,
-              dag outs, dag ins,
-              string asmstr,
-              list<dag> pattern>
- : IUMA<opcode, SrcSpecialImm, outs, ins, asmstr, pattern> {
+class IUMAp_rp<EraVMOpcode opcode, list<dag> pattern>
+ : IUMA<opcode, SrcSpecialReg, [rs0_ptr, rd0, rd1_ptr], pattern> {
+  bits<4> rs0;
+  bits<4> rd0;
+  bits<4> rd1;
+
+  let Src0 = rs0;
+  let Dst0 = rd0;
+  let Dst1 = rd1;
+}
+
+class IUMAi_r<EraVMOpcode opcode, list<dag> pattern>
+ : IUMA<opcode, SrcSpecialImm, [addr, rd0], pattern> {
   bits<16> addr;
   bits<4> rd0;
 
@@ -742,11 +808,8 @@ class IUMAi_r<EraVMOpcode opcode,
   let Dst0 = rd0;
 }
 
-class IUMAi_rr<EraVMOpcode opcode,
-               dag outs, dag ins,
-               string asmstr,
-               list<dag> pattern>
- : IUMA<opcode, SrcSpecialImm, outs, ins, asmstr, pattern> {
+class IUMAi_rr<EraVMOpcode opcode, list<dag> pattern>
+ : IUMA<opcode, SrcSpecialImm, [addr, rd0, rd1], pattern> {
   bits<16> addr;
   bits<4> rd0;
   bits<4> rd1;
@@ -756,11 +819,8 @@ class IUMAi_rr<EraVMOpcode opcode,
   let Dst1 = rd1;
 }
 
-class IUMArr_<EraVMOpcode opcode,
-              dag outs, dag ins,
-              string asmstr,
-              list<dag> pattern>
- : IUMA<opcode, SrcSpecialReg, outs, ins, asmstr, pattern> {
+class IUMArr_<EraVMOpcode opcode, list<dag> pattern>
+ : IUMA<opcode, SrcSpecialReg, [rs0, rs1], pattern> {
   bits<4> rs0;
   bits<4> rs1;
 
@@ -768,11 +828,8 @@ class IUMArr_<EraVMOpcode opcode,
   let Src1 = rs1;
 }
 
-class IUMArr_r<EraVMOpcode opcode,
-               dag outs, dag ins,
-               string asmstr,
-               list<dag> pattern>
- : IUMA<opcode, SrcSpecialReg, outs, ins, asmstr, pattern> {
+class IUMArr_r<EraVMOpcode opcode, list<dag> pattern>
+ : IUMA<opcode, SrcSpecialReg, [rs0, rs1, rd0], pattern> {
   bits<4> rs0;
   bits<4> rs1;
   bits<4> rd0;
@@ -782,11 +839,8 @@ class IUMArr_r<EraVMOpcode opcode,
   let Dst0 = rd0;
 }
 
-class IUMAir_<EraVMOpcode opcode,
-              dag outs, dag ins,
-              string asmstr,
-              list<dag> pattern>
- : IUMA<opcode, SrcSpecialImm, outs, ins, asmstr, pattern> {
+class IUMAir_<EraVMOpcode opcode, list<dag> pattern>
+ : IUMA<opcode, SrcSpecialImm, [addr, rs1], pattern> {
   bits<16> addr;
   bits<4> rs1;
 
@@ -794,11 +848,8 @@ class IUMAir_<EraVMOpcode opcode,
   let Src1 = rs1;
 }
 
-class IUMAir_r<EraVMOpcode opcode,
-               dag outs, dag ins,
-               string asmstr,
-               list<dag> pattern>
- : IUMA<opcode, SrcSpecialImm, outs, ins, asmstr, pattern> {
+class IUMAir_r<EraVMOpcode opcode, list<dag> pattern>
+ : IUMA<opcode, SrcSpecialImm, [addr, rs1, rd0], pattern> {
   bits<16> addr;
   bits<4> rs1;
   bits<4> rd0;

--- a/llvm/lib/Target/EraVM/EraVMInstrInfo.td
+++ b/llvm/lib/Target/EraVM/EraVMInstrInfo.td
@@ -304,30 +304,14 @@ def : Pat<(int_eravm_iflt imm16:$src0, imm16:$src1), (SELiir imm16:$src0, imm16:
 def : Pat<(int_eravm_ifgt imm16:$src0, imm16:$src1), (SELiir imm16:$src0, imm16:$src1, COND_GT.Encoding)>;
 
 let hasSideEffects = 1, Defs = [SP], Uses = [SP], mayStore = 0 in {
-def NOPrrr : Irr_r<OpNoOp, NoSwap, PreserveFlags,
-                   (outs GR256:$rd0), (ins GR256:$rs0, GR256:$rs1),
-                   "$rs0, $rs1, $rd0", []>;
-def NOPirr : Iir_r<OpNoOp, NoSwap, PreserveFlags,
-                   (outs GR256:$rd0), (ins imm16:$imm, GR256:$rs1),
-                   "$imm, $rs1, $rd0", []>;
-def NOPcrr : Imr_r<OpNoOp, NoSwap, PreserveFlags,
-                   (outs GR256:$rd0), (ins memop:$src0, GR256:$rs1),
-                   "$src0, $rs1, $rd0", []>;
-def NOPsrr : Isr_r<OpNoOp, NoSwap, PreserveFlags,
-                   (outs GR256:$rd0), (ins stackin:$src0, GR256:$rs1),
-                   "$src0, $rs1, $rd0", []>;
-def NOPrrs : Irr_s<OpNoOp, NoSwap, PreserveFlags,
-                   (outs), (ins GR256:$rs0, GR256:$rs1, stackout:$dst0),
-                   "$rs0, $rs1, $dst0", []>;
-def NOPirs : Iir_s<OpNoOp, NoSwap, PreserveFlags,
-                   (outs), (ins imm16:$imm, GR256:$rs1, stackout:$dst0),
-                   "$imm, $rs1, $dst0", []>;
-def NOPcrs : Imr_s<OpNoOp, NoSwap, PreserveFlags,
-                   (outs), (ins memop:$src0, GR256:$rs1, stackout:$dst0),
-                   "$src0, $rs1, $dst0", []>;
-def NOPsrs : Isr_s<OpNoOp, NoSwap, PreserveFlags,
-                   (outs), (ins stackin:$src0, GR256:$rs1, stackout:$dst0),
-                   "$src0, $rs1, $dst0", []>;
+def NOPrrr : Irr_r<OpNoOp, NoSwap, PreserveFlags, []>;
+def NOPirr : Iir_r<OpNoOp, NoSwap, PreserveFlags, []>;
+def NOPcrr : Imr_r<OpNoOp, NoSwap, PreserveFlags, []>;
+def NOPsrr : Isr_r<OpNoOp, NoSwap, PreserveFlags, []>;
+def NOPrrs : Irr_s<OpNoOp, NoSwap, PreserveFlags, []>;
+def NOPirs : Iir_s<OpNoOp, NoSwap, PreserveFlags, []>;
+def NOPcrs : Imr_s<OpNoOp, NoSwap, PreserveFlags, []>;
+def NOPsrs : Isr_s<OpNoOp, NoSwap, PreserveFlags, []>;
 }
 
 def : Pat<(EraVMadd_to_sp GR256:$reg), (NOPrrs R0, R0, R0, $reg, 0, 0)>;
@@ -343,62 +327,38 @@ multiclass Arith<EraVMOpcode opcode, SDPatternOperator node, bit commutes> {
   let BaseOpcode = opcode.Name, isCommutable = commutes in {
 
   def rrr_s : Irr_r<opcode, NoSwap, PreserveFlags,
-                   (outs GR256:$rd0), (ins GR256:$rs0, GR256:$rs1),
-                   "$rs0, $rs1, $rd0",
                    [(set GR256:$rd0, (node GR256:$rs0, GR256:$rs1))]>,
                    FlagSetting, Swappable, AddrModeRel, RetAddrModeRel;
-  def rrr_v : Irr_r<opcode, NoSwap, SetFlags,
-                   (outs GR256:$rd0), (ins GR256:$rs0, GR256:$rs1),
-                   "$rs0, $rs1, $rd0", []>,
+  def rrr_v : Irr_r<opcode, NoSwap, SetFlags, []>,
                    FlagSetting, Swappable, AddrModeRel, RetAddrModeRel;
 
   def crr_s : Imr_r<opcode, NoSwap, PreserveFlags,
-                   (outs GR256:$rd0), (ins memop:$src0, GR256:$rs1),
-                   "$src0, $rs1, $rd0",
                    [(set GR256:$rd0, (node (load_code memaddr:$src0), GR256:$rs1))]>,
                    FlagSetting, Swappable, AddrModeRel, RetAddrModeRel;
-  def crr_v : Imr_r<opcode, NoSwap, SetFlags,
-                   (outs GR256:$rd0), (ins memop:$src0, GR256:$rs1),
-                   "$src0, $rs1, $rd0", []>,
+  def crr_v : Imr_r<opcode, NoSwap, SetFlags, []>,
                    FlagSetting, Swappable, AddrModeRel, RetAddrModeRel;
   def srr_s : Isr_r<opcode, NoSwap, PreserveFlags,
-                   (outs GR256:$rd0), (ins stackin:$src0, GR256:$rs1),
-                   "$src0, $rs1, $rd0",
                    [(set GR256:$rd0, (node (load_stack stackaddr:$src0), GR256:$rs1))]>,
                    FlagSetting, Swappable, AddrModeRel, RetAddrModeRel;
-  def srr_v : Isr_r<opcode, NoSwap, SetFlags,
-                   (outs GR256:$rd0), (ins stackin:$src0, GR256:$rs1),
-                   "$src0, $rs1, $rd0", []>,
+  def srr_v : Isr_r<opcode, NoSwap, SetFlags, []>,
                    FlagSetting, Swappable, AddrModeRel, RetAddrModeRel;
 
   def rrs_s : Irr_s<opcode, NoSwap, PreserveFlags,
-                   (outs), (ins GR256:$rs0, GR256:$rs1, stackout:$dst0),
-                   "$rs0, $rs1, $dst0",
                    [(store_stack (node GR256:$rs0, GR256:$rs1), stackaddr:$dst0)]>,
                    FlagSetting, Swappable, AddrModeRel, RetAddrModeRel;
-  def rrs_v : Irr_s<opcode, NoSwap, SetFlags,
-                   (outs), (ins GR256:$rs0, GR256:$rs1, stackout:$dst0),
-                   "$rs0, $rs1, $dst0", []>,
+  def rrs_v : Irr_s<opcode, NoSwap, SetFlags, []>,
                    FlagSetting, Swappable, AddrModeRel, RetAddrModeRel;
 
   def crs_s : Imr_s<opcode, NoSwap, PreserveFlags,
-                   (outs), (ins memop:$src0, GR256:$rs1, stackout:$dst0),
-                   "$src0, $rs1, $dst0",
                    [(store_stack (node (load_code memaddr:$src0), GR256:$rs1), stackaddr:$dst0)]>,
                    FlagSetting, Swappable, AddrModeRel, RetAddrModeRel;
-  def crs_v : Imr_s<opcode, NoSwap, SetFlags,
-                   (outs), (ins memop:$src0, GR256:$rs1, stackout:$dst0),
-                   "$src0, $rs1, $dst0", []>,
+  def crs_v : Imr_s<opcode, NoSwap, SetFlags, []>,
                    FlagSetting, Swappable, AddrModeRel, RetAddrModeRel;
 
   def srs_s : Isr_s<opcode, NoSwap, PreserveFlags,
-                   (outs), (ins stackin:$src0, GR256:$rs1, stackout:$dst0),
-                   "$src0, $rs1, $dst0",
                    [(store_stack (node (load_stack stackaddr:$src0), GR256:$rs1), stackaddr:$dst0)]>,
                    FlagSetting, Swappable, AddrModeRel, RetAddrModeRel;
-  def srs_v : Isr_s<opcode, NoSwap, SetFlags,
-                   (outs), (ins stackin:$src0, GR256:$rs1, stackout:$dst0),
-                   "$src0, $rs1, $dst0", []>,
+  def srs_v : Isr_s<opcode, NoSwap, SetFlags, []>,
                    FlagSetting, Swappable, AddrModeRel, RetAddrModeRel;
   }
 }
@@ -406,21 +366,14 @@ multiclass Arith<EraVMOpcode opcode, SDPatternOperator node, bit commutes> {
 multiclass ArithICommutable<EraVMOpcode opcode, SDPatternOperator node> : Arith<opcode, node, 1> {
   let BaseOpcode = opcode.Name, isCommutable = 1 in {
   def irr_s : Iir_r<opcode, NoSwap, PreserveFlags,
-                   (outs GR256:$rd0), (ins imm16:$imm, GR256:$rs1),
-                   "$imm, $rs1, $rd0", [(set GR256:$rd0, (node GR256:$rs1, imm16:$imm))]>,
+                   [(set GR256:$rd0, (node GR256:$rs1, imm16:$imm))]>,
                    FlagSetting, AddrModeRel, RetAddrModeRel;
-  def irr_v : Iir_r<opcode, NoSwap, SetFlags,
-                   (outs GR256:$rd0), (ins imm16:$imm, GR256:$rs1),
-                   "$imm, $rs1, $rd0", []>,
+  def irr_v : Iir_r<opcode, NoSwap, SetFlags, []>,
                    FlagSetting, AddrModeRel, RetAddrModeRel;
   def irs_s : Iir_s<opcode, NoSwap, PreserveFlags,
-                   (outs), (ins imm16:$imm, GR256:$rs1, stackout:$dst0),
-                   "$imm, $rs1, $dst0",
                    [(store_stack (node GR256:$rs1, imm16:$imm), stackaddr:$dst0)]>,
                    FlagSetting, AddrModeRel, RetAddrModeRel;
-  def irs_v : Iir_s<opcode, NoSwap, SetFlags,
-                   (outs), (ins imm16:$imm, GR256:$rs1, stackout:$dst0),
-                   "$imm, $rs1, $dst0", []>,
+  def irs_v : Iir_s<opcode, NoSwap, SetFlags, []>,
                    FlagSetting, AddrModeRel, RetAddrModeRel;
   } // end isCommutable = 1
 
@@ -435,13 +388,9 @@ multiclass ArithICommutable<EraVMOpcode opcode, SDPatternOperator node> : Arith<
 multiclass ArithINonCommutable<EraVMOpcode opcode, SDPatternOperator node> : Arith<opcode, node, 0> {
   let BaseOpcode = opcode.Name in {
   def irr_s : Iir_r<opcode, NoSwap, PreserveFlags,
-                   (outs GR256:$rd0), (ins imm16:$imm, GR256:$rs1),
-                   "$imm, $rs1, $rd0",
                    [(set GR256:$rd0, (node imm16:$imm, GR256:$rs1))]>,
                    FlagSetting, Swappable, AddrModeRel, RetAddrModeRel;
   def xrr_s : Iir_r<opcode, Swap, PreserveFlags,
-                   (outs GR256:$rd0), (ins imm16:$imm, GR256:$rs1),
-                   "$imm, $rs1, $rd0",
                    [(set GR256:$rd0, (node GR256:$rs1, imm16:$imm))]>,
                    FlagSetting, Swappable, RetAddrModeRel;
 
@@ -449,87 +398,51 @@ multiclass ArithINonCommutable<EraVMOpcode opcode, SDPatternOperator node> : Ari
   // "mnemonic.s rs0, rs1, rd0" instructions for the sake of uniformity, that
   // are otherwise redundant. *Rel base classes are dropped, as these
   // instructions are not intended to participate in InstrMappings.
-  def rrr_s_alias : Irr_r<opcode, Swap, PreserveFlags,
-                          (outs GR256:$rd0), (ins GR256:$rs0, GR256:$rs1),
-                          "$rs0, $rs1, $rd0", []>;
-  def rrr_v_alias : Irr_r<opcode, Swap, SetFlags,
-                          (outs GR256:$rd0), (ins GR256:$rs0, GR256:$rs1),
-                          "$rs0, $rs1, $rd0", []>;
-  def rrs_s_alias : Irr_s<opcode, Swap, PreserveFlags,
-                          (outs), (ins GR256:$rs0, GR256:$rs1, stackout:$dst0),
-                          "$rs0, $rs1, $dst0", []>;
-  def rrs_v_alias : Irr_s<opcode, Swap, SetFlags,
-                          (outs), (ins GR256:$rs0, GR256:$rs1, stackout:$dst0),
-                          "$rs0, $rs1, $dst0", []>;
+  def rrr_s_alias : Irr_r<opcode, Swap, PreserveFlags, []>;
+  def rrr_v_alias : Irr_r<opcode, Swap, SetFlags, []>;
+  def rrs_s_alias : Irr_s<opcode, Swap, PreserveFlags, []>;
+  def rrs_v_alias : Irr_s<opcode, Swap, SetFlags, []>;
 
-  def irr_v : Iir_r<opcode, NoSwap, SetFlags,
-                   (outs GR256:$rd0), (ins imm16:$imm, GR256:$rs1),
-                   "$imm, $rs1, $rd0", []>,
+  def irr_v : Iir_r<opcode, NoSwap, SetFlags, []>,
                    FlagSetting, Swappable, AddrModeRel, RetAddrModeRel;
-  def xrr_v : Iir_r<opcode, Swap, SetFlags,
-                   (outs GR256:$rd0), (ins imm16:$imm, GR256:$rs1),
-                   "$imm, $rs1, $rd0", []>,
+  def xrr_v : Iir_r<opcode, Swap, SetFlags, []>,
                    FlagSetting, Swappable, RetAddrModeRel;
 
   def yrr_s : Imr_r<opcode, Swap, PreserveFlags,
-                   (outs GR256:$rd0), (ins memop:$src0, GR256:$rs1),
-                   "$src0, $rs1, $rd0",
                    [(set GR256:$rd0, (node GR256:$rs1, (load_code memaddr:$src0)))]>,
                    FlagSetting, Swappable, RetAddrModeRel;
-  def yrr_v : Imr_r<opcode, Swap, SetFlags,
-                   (outs GR256:$rd0), (ins memop:$src0, GR256:$rs1),
-                   "$src0, $rs1, $rd0", []>,
+  def yrr_v : Imr_r<opcode, Swap, SetFlags, []>,
                    FlagSetting, Swappable, RetAddrModeRel;
   def zrr_s : Isr_r<opcode, Swap, PreserveFlags,
-                   (outs GR256:$rd0), (ins stackin:$src0, GR256:$rs1),
-                   "$src0, $rs1, $rd0",
                    [(set GR256:$rd0, (node GR256:$rs1, (load_stack stackaddr:$src0)))]>,
                    FlagSetting, Swappable, RetAddrModeRel;
-  def zrr_v : Isr_r<opcode, Swap, SetFlags,
-                   (outs GR256:$rd0), (ins stackin:$src0, GR256:$rs1),
-                   "$src0, $rs1, $rd0", []>,
+  def zrr_v : Isr_r<opcode, Swap, SetFlags, []>,
                    FlagSetting, Swappable, RetAddrModeRel;
 
   def irs_s : Iir_s<opcode, NoSwap, PreserveFlags,
-                   (outs), (ins imm16:$imm, GR256:$rs1, stackout:$dst0),
-                   "$imm, $rs1, $dst0",
                    [(store_stack (node imm16:$imm, GR256:$rs1), stackaddr:$dst0)]>,
                    FlagSetting, Swappable, AddrModeRel, RetAddrModeRel;
 
   def xrs_s : Iir_s<opcode, Swap, PreserveFlags,
-                   (outs), (ins imm16:$imm, GR256:$rs1, stackout:$dst0),
-                   "$imm, $rs1, $dst0",
                    [(store_stack (node GR256:$rs1, imm16:$imm), stackaddr:$dst0)]>,
                    FlagSetting, Swappable, RetAddrModeRel;
 
-  def irs_v : Iir_s<opcode, NoSwap, SetFlags,
-                   (outs), (ins imm16:$imm, GR256:$rs1, stackout:$dst0),
-                   "$imm, $rs1, $dst0", []>,
+  def irs_v : Iir_s<opcode, NoSwap, SetFlags, []>,
                    FlagSetting, Swappable, AddrModeRel, RetAddrModeRel;
-  def xrs_v : Iir_s<opcode, Swap, SetFlags,
-                   (outs), (ins imm16:$imm, GR256:$rs1, stackout:$dst0),
-                   "$imm, $rs1, $dst0", []>,
+  def xrs_v : Iir_s<opcode, Swap, SetFlags, []>,
                    FlagSetting, Swappable, RetAddrModeRel;
 
   def yrs_s : Imr_s<opcode, Swap, PreserveFlags,
-                   (outs), (ins memop:$src0, GR256:$rs1, stackout:$dst0),
-                   "$src0, $rs1, $dst0",
                    [(store_stack (node GR256:$rs1, (load_code memaddr:$src0)), stackaddr:$dst0)]>,
                    FlagSetting, Swappable, RetAddrModeRel;
 
-  def yrs_v : Imr_s<opcode, Swap, SetFlags,
-                   (outs), (ins memop:$src0, GR256:$rs1, stackout:$dst0),
-                   "$src0, $rs1, $dst0", []>,
+  def yrs_v : Imr_s<opcode, Swap, SetFlags, []>,
                    FlagSetting, Swappable, RetAddrModeRel;
 
   def zrs_s : Isr_s<opcode, Swap, PreserveFlags,
-                   (outs), (ins stackin:$src0, GR256:$rs1, stackout:$dst0),
-                   "$src0, $rs1, $dst0",
                    [(store_stack (node GR256:$rs1, (load_stack stackaddr:$src0)), stackaddr:$dst0)]>,
                    FlagSetting, Swappable, RetAddrModeRel;
-  def zrs_v : Isr_s<opcode, Swap, SetFlags,
-                   (outs), (ins stackin:$src0, GR256:$rs1, stackout:$dst0),
-                   "$src0, $rs1, $dst0", []>,
+  def zrs_v : Isr_s<opcode, Swap, SetFlags, []>,
                    FlagSetting, Swappable, RetAddrModeRel;
   }
 
@@ -553,9 +466,7 @@ multiclass ArithINonCommutable<EraVMOpcode opcode, SDPatternOperator node> : Ari
 multiclass PtrInstr<EraVMOpcode opcode, SDPatternOperator node> {
   let BaseOpcode = opcode.Name in {
 
-  def rrr_s : Irr_r<opcode, NoSwap, PreserveFlags,
-                   (outs GRPTR:$rd0), (ins GRPTR:$rs0, GR256:$rs1),
-                   "$rs0, $rs1, $rd0",
+  def rrr_s : Ipr_p<opcode, NoSwap, PreserveFlags,
                    [(set GRPTR:$rd0, (node GRPTR:$rs0, GR256:$rs1))]>,
                    Swappable, AddrModeRel, RetAddrModeRel;
 
@@ -563,64 +474,42 @@ multiclass PtrInstr<EraVMOpcode opcode, SDPatternOperator node> {
   // "ptr.<op>.s rs0, rs1, rd0" instructions for the sake of uniformity, that
   // are otherwise redundant. *Rel base classes are dropped, as these
   // instructions are not intended to participate in InstrMappings.
-  def rrr_s_alias : Irr_r<opcode, Swap, PreserveFlags,
-                          (outs GRPTR:$rd0), (ins GRPTR:$rs0, GR256:$rs1),
-                          "$rs0, $rs1, $rd0", []>;
-  def rrs_s_alias : Irr_s<opcode, Swap, PreserveFlags,
-                          (outs), (ins GRPTR:$rs0, GR256:$rs1, stackout:$dst0),
-                          "$rs0, $rs1, $dst0", []>;
+  def rrr_s_alias : Ipr_p<opcode, Swap, PreserveFlags, []>;
+  def rrs_s_alias : Ipr_s<opcode, Swap, PreserveFlags, []>;
 
-  def srr_s : Isr_r<opcode, NoSwap, PreserveFlags,
-                   (outs GRPTR:$rd0), (ins stackin:$src0, GR256:$rs1),
-                   "$src0, $rs1, $rd0",
+  def srr_s : Isr_p<opcode, NoSwap, PreserveFlags,
                    [(set GRPTR:$rd0, (node (load_stack stackaddr:$src0), GR256:$rs1))]>,
                    Swappable, AddrModeRel, RetAddrModeRel;
 
-  def rrs_s : Irr_s<opcode, NoSwap, PreserveFlags,
-                   (outs), (ins GRPTR:$rs0, GR256:$rs1, stackout:$dst0),
-                   "$rs0, $rs1, $dst0",
+  def rrs_s : Ipr_s<opcode, NoSwap, PreserveFlags,
                    [(store_stack (node GRPTR:$rs0, GR256:$rs1), stackaddr:$dst0)]>,
                    Swappable, AddrModeRel, RetAddrModeRel;
 
   def srs_s : Isr_s<opcode, NoSwap, PreserveFlags,
-                   (outs), (ins stackin:$src0, GR256:$rs1, stackout:$dst0),
-                   "$src0, $rs1, $dst0",
                    [(store_stack (node (load_stack stackaddr:$src0), GR256:$rs1), stackaddr:$dst0)]>,
                    Swappable, AddrModeRel, RetAddrModeRel;
 
-  def xrr_s : Iir_r<opcode, Swap, PreserveFlags,
-                   (outs GRPTR:$rd0), (ins imm16:$imm, GRPTR:$rs1),
-                   "$imm, $rs1, $rd0",
+  def xrr_s : Iip_p<opcode, Swap, PreserveFlags,
                    [(set GRPTR:$rd0, (node GRPTR:$rs1, imm16:$imm))]>,
                    Swappable, AddrModeRel, RetAddrModeRel;
 
-  def yrr_s : Imr_r<opcode, Swap, PreserveFlags,
-                   (outs GRPTR:$rd0), (ins memop:$src0, GRPTR:$rs1),
-                   "$src0, $rs1, $rd0",
+  def yrr_s : Imp_p<opcode, Swap, PreserveFlags,
                    [(set GRPTR:$rd0, (node GRPTR:$rs1, (load_code memaddr:$src0)))]>,
                    Swappable, AddrModeRel, RetAddrModeRel;
 
-  def zrr_s : Isr_r<opcode, Swap, PreserveFlags,
-                   (outs GRPTR:$rd0), (ins stackin:$src0, GRPTR:$rs1),
-                   "$src0, $rs1, $rd0",
+  def zrr_s : Isp_p<opcode, Swap, PreserveFlags,
                    [(set GRPTR:$rd0, (node GRPTR:$rs1, (load_stack stackaddr:$src0)))]>,
                    Swappable, RetAddrModeRel;
 
-  def xrs_s : Iir_s<opcode, Swap, PreserveFlags,
-                   (outs), (ins imm16:$imm, GRPTR:$rs1, stackout:$dst0),
-                   "$imm, $rs1, $dst0",
+  def xrs_s : Iip_s<opcode, Swap, PreserveFlags,
                    [(store_stack (node GRPTR:$rs1, imm16:$imm), stackaddr:$dst0)]>,
                    Swappable, AddrModeRel, RetAddrModeRel;
 
-  def yrs_s : Imr_s<opcode, Swap, PreserveFlags,
-                   (outs), (ins memop:$src0, GRPTR:$rs1, stackout:$dst0),
-                   "$src0, $rs1, $dst0",
+  def yrs_s : Imp_s<opcode, Swap, PreserveFlags,
                    [(store_stack (node GRPTR:$rs1, (load_code memaddr:$src0)), stackaddr:$dst0)]>,
                    Swappable, AddrModeRel, RetAddrModeRel;
 
-  def zrs_s : Isr_s<opcode, Swap, PreserveFlags,
-                   (outs), (ins stackin:$src0, GRPTR:$rs1, stackout:$dst0),
-                   "$src0, $rs1, $dst0",
+  def zrs_s : Isp_s<opcode, Swap, PreserveFlags,
                    [(store_stack (node GRPTR:$rs1, (load_stack stackaddr:$src0)), stackaddr:$dst0)]>,
                    Swappable, RetAddrModeRel;
   }
@@ -641,57 +530,33 @@ def PTR_TO_INT : Pseudo<(outs GR256:$rd0), (ins GRPTR:$rs0),
 multiclass Arith2<EraVMOpcode opcode, SDPatternOperator node, bit commutes> {
   let BaseOpcode = opcode.Name, isCommutable = commutes in {
   def rrrr_s : Irr_rr<opcode, NoSwap, PreserveFlags,
-                     (outs GR256:$rd0, GR256:$rd1), (ins GR256:$rs0, GR256:$rs1),
-                     "$rs0, $rs1, $rd0, $rd1",
                      [(set GR256:$rd0, GR256:$rd1, (node GR256:$rs0, GR256:$rs1))]>,
                      FlagSetting, Swappable, AddrModeRel, RetAddrModeRel;
-  def rrrr_v : Irr_rr<opcode, NoSwap, SetFlags,
-                     (outs GR256:$rd0, GR256:$rd1), (ins GR256:$rs0, GR256:$rs1),
-                     "$rs0, $rs1, $rd0, $rd1", []>,
+  def rrrr_v : Irr_rr<opcode, NoSwap, SetFlags, []>,
                      FlagSetting, Swappable, AddrModeRel, RetAddrModeRel;
 
   def crrr_s : Imr_rr<opcode, NoSwap, PreserveFlags,
-                     (outs GR256:$rd0, GR256:$rd1), (ins memop:$src0, GR256:$rs1),
-                     "$src0, $rs1, $rd0, $rd1",
                      [(set GR256:$rd0, GR256:$rd1, (node (load_code memaddr:$src0), GR256:$rs1))]>,
                      FlagSetting, Swappable, AddrModeRel, RetAddrModeRel;
-  def crrr_v : Imr_rr<opcode, NoSwap, SetFlags,
-                     (outs GR256:$rd0, GR256:$rd1), (ins memop:$src0, GR256:$rs1),
-                     "$src0, $rs1, $rd0, $rd1", []>,
+  def crrr_v : Imr_rr<opcode, NoSwap, SetFlags, []>,
                      FlagSetting, Swappable, AddrModeRel, RetAddrModeRel;
   def srrr_s : Isr_rr<opcode, NoSwap, PreserveFlags,
-                     (outs GR256:$rd0, GR256:$rd1), (ins stackin:$src0, GR256:$rs1),
-                     "$src0, $rs1, $rd0, $rd1",
                      [(set GR256:$rd0, GR256:$rd1, (node (load_stack stackaddr:$src0), GR256:$rs1))]>,
                      FlagSetting, Swappable, AddrModeRel, RetAddrModeRel;
-  def srrr_v : Isr_rr<opcode, NoSwap, SetFlags,
-                     (outs GR256:$rd0, GR256:$rd1), (ins stackin:$src0, GR256:$rs1),
-                     "$src0, $rs1, $rd0, $rd1", []>,
+  def srrr_v : Isr_rr<opcode, NoSwap, SetFlags, []>,
                      FlagSetting, Swappable, AddrModeRel, RetAddrModeRel;
 
-  def rrsr_s : Irr_sr<opcode, NoSwap, PreserveFlags,
-                     (outs GR256:$rd1), (ins GR256:$rs0, GR256:$rs1, stackout:$dst0),
-                     "$rs0, $rs1, $dst0, $rd1", []>,
+  def rrsr_s : Irr_sr<opcode, NoSwap, PreserveFlags, []>,
                      FlagSetting, Swappable, AddrModeRel, RetAddrModeRel;
-  def rrsr_v : Irr_sr<opcode, NoSwap, SetFlags,
-                     (outs GR256:$rd1), (ins GR256:$rs0, GR256:$rs1, stackout:$dst0),
-                     "$rs0, $rs1, $dst0, $rd1", []>,
+  def rrsr_v : Irr_sr<opcode, NoSwap, SetFlags, []>,
                      FlagSetting, Swappable, AddrModeRel, RetAddrModeRel;
-  def crsr_s : Imr_sr<opcode, NoSwap, PreserveFlags,
-                     (outs GR256:$rd1), (ins memop:$src0, GR256:$rs1, stackout:$dst0),
-                     "$src0, $rs1, $dst0, $rd1", []>,
+  def crsr_s : Imr_sr<opcode, NoSwap, PreserveFlags, []>,
                      FlagSetting, Swappable, AddrModeRel, RetAddrModeRel;
-  def crsr_v : Imr_sr<opcode, NoSwap, SetFlags,
-                     (outs GR256:$rd1), (ins memop:$src0, GR256:$rs1, stackout:$dst0),
-                     "$src0, $rs1, $dst0, $rd1", []>,
+  def crsr_v : Imr_sr<opcode, NoSwap, SetFlags, []>,
                      FlagSetting, Swappable, AddrModeRel, RetAddrModeRel;
-  def srsr_s : Isr_sr<opcode, NoSwap, PreserveFlags,
-                     (outs GR256:$rd1), (ins stackin:$src0, GR256:$rs1, stackout:$dst0),
-                     "$src0, $rs1, $dst0, $rd1", []>,
+  def srsr_s : Isr_sr<opcode, NoSwap, PreserveFlags, []>,
                      FlagSetting, Swappable, AddrModeRel, RetAddrModeRel;
-  def srsr_v : Isr_sr<opcode, NoSwap, SetFlags,
-                     (outs GR256:$rd1), (ins stackin:$src0, GR256:$rs1, stackout:$dst0),
-                     "$src0, $rs1, $dst0, $rd1", []>,
+  def srsr_v : Isr_sr<opcode, NoSwap, SetFlags, []>,
                      FlagSetting, Swappable, AddrModeRel, RetAddrModeRel;
   }
 }
@@ -700,21 +565,13 @@ multiclass Arith2ICommutable<EraVMOpcode opcode, SDPatternOperator node>
          : Arith2<opcode, node, 1> {
   let BaseOpcode = opcode.Name, isCommutable = 1 in {
   def irrr_s : Iir_rr<opcode, NoSwap, PreserveFlags,
-                     (outs GR256:$rd0, GR256:$rd1), (ins imm16:$imm, GR256:$rs1),
-                     "$imm, $rs1, $rd0, $rd1",
                      [(set GR256:$rd0, GR256:$rd1, (node GR256:$rs1, imm16:$imm))]>,
                      FlagSetting, AddrModeRel, RetAddrModeRel;
-  def irrr_v : Iir_rr<opcode, NoSwap, SetFlags,
-                     (outs GR256:$rd0, GR256:$rd1), (ins imm16:$imm, GR256:$rs1),
-                     "$imm, $rs1, $rd0, $rd1", []>,
+  def irrr_v : Iir_rr<opcode, NoSwap, SetFlags, []>,
                      FlagSetting, AddrModeRel, RetAddrModeRel;
-  def irsr_s : Iir_sr<opcode, NoSwap, PreserveFlags,
-                     (outs GR256:$rd1), (ins imm16:$imm, GR256:$rs1, stackout:$dst0),
-                     "$imm, $rs1, $dst0, $rd1", []>,
+  def irsr_s : Iir_sr<opcode, NoSwap, PreserveFlags, []>,
                      FlagSetting, AddrModeRel, RetAddrModeRel;
-  def irsr_v : Iir_sr<opcode, NoSwap, SetFlags,
-                     (outs GR256:$rd1), (ins imm16:$imm, GR256:$rs1, stackout:$dst0),
-                     "$imm, $rs1, $dst0, $rd1", []>,
+  def irsr_v : Iir_sr<opcode, NoSwap, SetFlags, []>,
                      FlagSetting, AddrModeRel, RetAddrModeRel;
   }
 
@@ -727,91 +584,51 @@ multiclass Arith2INonCommutable<EraVMOpcode opcode, SDPatternOperator node>
          : Arith2<opcode, node, 0> {
   let BaseOpcode = opcode.Name in {
   def irrr_s : Iir_rr<opcode, NoSwap, PreserveFlags,
-                     (outs GR256:$rd0, GR256:$rd1), (ins imm16:$imm, GR256:$rs1),
-                     "$imm, $rs1, $rd0, $rd1",
                      [(set GR256:$rd0, GR256:$rd1, (node imm16:$imm, GR256:$rs1))]>,
                      FlagSetting, Swappable, AddrModeRel, RetAddrModeRel;
   def xrrr_s : Iir_rr<opcode, Swap, PreserveFlags,
-                     (outs GR256:$rd0, GR256:$rd1), (ins imm16:$imm, GR256:$rs1),
-                     "$imm, $rs1, $rd0, $rd1",
                      [(set GR256:$rd0, GR256:$rd1, (node GR256:$rs1, imm16:$imm))]>,
                      FlagSetting, Swappable, RetAddrModeRel;
-  def irrr_v : Iir_rr<opcode, NoSwap, SetFlags,
-                     (outs GR256:$rd0, GR256:$rd1), (ins imm16:$imm, GR256:$rs1),
-                     "$imm, $rs1, $rd0, $rd1", []>,
+  def irrr_v : Iir_rr<opcode, NoSwap, SetFlags, []>,
                      FlagSetting, Swappable, AddrModeRel, RetAddrModeRel;
-  def xrrr_v : Iir_rr<opcode, Swap, SetFlags,
-                     (outs GR256:$rd0, GR256:$rd1), (ins imm16:$imm, GR256:$rs1),
-                     "$imm, $rs1, $rd0, $rd1", []>,
+  def xrrr_v : Iir_rr<opcode, Swap, SetFlags, []>,
                      FlagSetting, Swappable, RetAddrModeRel;
 
   // The four *_alias instructions below are defined to make asm parser handle
   // "mnemonic.s rs0, rs1, rd0, rd1" instructions for the sake of uniformity, that
   // are otherwise redundant. *Rel base classes are dropped, as these
   // instructions are not intended to participate in InstrMappings.
-  def rrrr_s_alias : Irr_rr<opcode, Swap, PreserveFlags,
-                           (outs GR256:$rd0, GR256:$rd1), (ins GR256:$rs0, GR256:$rs1),
-                           "$rs0, $rs1, $rd0, $rd1", []>;
-  def rrrr_v_alias : Irr_rr<opcode, Swap, SetFlags,
-                           (outs GR256:$rd0, GR256:$rd1), (ins GR256:$rs0, GR256:$rs1),
-                           "$rs0, $rs1, $rd0, $rd1", []>;
-  def rrsr_s_alias : Irr_sr<opcode, Swap, PreserveFlags,
-                           (outs GR256:$rd1), (ins GR256:$rs0, GR256:$rs1, stackout:$dst0),
-                           "$rs0, $rs1, $dst0, $rd1", []>;
-  def rrsr_v_alias : Irr_sr<opcode, Swap, SetFlags,
-                           (outs GR256:$rd1), (ins GR256:$rs0, GR256:$rs1, stackout:$dst0),
-                           "$rs0, $rs1, $dst0, $rd1", []>;
+  def rrrr_s_alias : Irr_rr<opcode, Swap, PreserveFlags, []>;
+  def rrrr_v_alias : Irr_rr<opcode, Swap, SetFlags, []>;
+  def rrsr_s_alias : Irr_sr<opcode, Swap, PreserveFlags, []>;
+  def rrsr_v_alias : Irr_sr<opcode, Swap, SetFlags, []>;
 
   def yrrr_s : Imr_rr<opcode, Swap, PreserveFlags,
-                     (outs GR256:$rd0, GR256:$rd1), (ins memop:$src0, GR256:$rs1),
-                     "$src0, $rs1, $rd0, $rd1",
                      [(set GR256:$rd0, GR256:$rd1, (node GR256:$rs1, (load_code memaddr:$src0)))]>,
                      FlagSetting, Swappable, RetAddrModeRel;
-  def yrrr_v : Imr_rr<opcode, Swap, SetFlags,
-                     (outs GR256:$rd0, GR256:$rd1), (ins memop:$src0, GR256:$rs1),
-                     "$src0, $rs1, $rd0, $rd1", []>,
+  def yrrr_v : Imr_rr<opcode, Swap, SetFlags, []>,
                      FlagSetting, Swappable, RetAddrModeRel;
   def zrrr_s : Isr_rr<opcode, Swap, PreserveFlags,
-                     (outs GR256:$rd0, GR256:$rd1), (ins stackin:$src0, GR256:$rs1),
-                     "$src0, $rs1, $rd0, $rd1",
                      [(set GR256:$rd0, GR256:$rd1, (node GR256:$rs1, (load_stack stackaddr:$src0)))]>,
                      FlagSetting, Swappable, RetAddrModeRel;
-  def zrrr_v : Isr_rr<opcode, Swap, SetFlags,
-                     (outs GR256:$rd0, GR256:$rd1), (ins stackin:$src0, GR256:$rs1),
-                     "$src0, $rs1, $rd0, $rd1", []>,
+  def zrrr_v : Isr_rr<opcode, Swap, SetFlags, []>,
                      FlagSetting, Swappable, RetAddrModeRel;
 
-  def irsr_s : Iir_sr<opcode, NoSwap, PreserveFlags,
-                     (outs GR256:$rd1), (ins imm16:$imm, GR256:$rs1, stackout:$dst0),
-                     "$imm, $rs1, $dst0, $rd1", []>,
+  def irsr_s : Iir_sr<opcode, NoSwap, PreserveFlags, []>,
                      FlagSetting, Swappable, AddrModeRel, RetAddrModeRel;
-  def xrsr_s : Iir_sr<opcode, Swap, PreserveFlags,
-                     (outs GR256:$rd1), (ins imm16:$imm, GR256:$rs1, stackout:$dst0),
-                     "$imm, $rs1, $dst0, $rd1", []>,
+  def xrsr_s : Iir_sr<opcode, Swap, PreserveFlags, []>,
                      FlagSetting, Swappable, RetAddrModeRel;
-  def irsr_v : Iir_sr<opcode, NoSwap, SetFlags,
-                     (outs GR256:$rd1), (ins imm16:$imm, GR256:$rs1, stackout:$dst0),
-                     "$imm, $rs1, $dst0, $rd1", []>,
+  def irsr_v : Iir_sr<opcode, NoSwap, SetFlags, []>,
                      FlagSetting, Swappable, AddrModeRel, RetAddrModeRel;
-  def xrsr_v : Iir_sr<opcode, Swap, SetFlags,
-                     (outs GR256:$rd1), (ins imm16:$imm, GR256:$rs1, stackout:$dst0),
-                     "$imm, $rs1, $dst0, $rd1", []>,
+  def xrsr_v : Iir_sr<opcode, Swap, SetFlags, []>,
                      FlagSetting, Swappable, RetAddrModeRel;
-  def yrsr_s : Imr_sr<opcode, Swap, PreserveFlags,
-                     (outs GR256:$rd1), (ins memop:$src0, GR256:$rs1, stackout:$dst0),
-                     "$src0, $rs1, $dst0, $rd1", []>,
+  def yrsr_s : Imr_sr<opcode, Swap, PreserveFlags, []>,
                      FlagSetting, Swappable, RetAddrModeRel;
-  def yrsr_v : Imr_sr<opcode, Swap, SetFlags,
-                     (outs GR256:$rd1), (ins memop:$src0, GR256:$rs1, stackout:$dst0),
-                     "$src0, $rs1, $dst0, $rd1", []>,
+  def yrsr_v : Imr_sr<opcode, Swap, SetFlags, []>,
                      FlagSetting, Swappable, RetAddrModeRel;
-  def zrsr_s : Isr_sr<opcode, Swap, PreserveFlags,
-                     (outs GR256:$rd1), (ins stackin:$src0, GR256:$rs1, stackout:$dst0),
-                     "$src0, $rs1, $dst0, $rd1", []>,
+  def zrsr_s : Isr_sr<opcode, Swap, PreserveFlags, []>,
                      FlagSetting, Swappable, RetAddrModeRel;
-  def zrsr_v : Isr_sr<opcode, Swap, SetFlags,
-                     (outs GR256:$rd1), (ins stackin:$src0, GR256:$rs1, stackout:$dst0),
-                     "$src0, $rs1, $dst0, $rd1", []>,
+  def zrsr_v : Isr_sr<opcode, Swap, SetFlags, []>,
                      FlagSetting, Swappable, RetAddrModeRel;
   }
 
@@ -876,19 +693,13 @@ def : Pat<(EraVMcmp GR256:$lhs, (load_stack stackaddr:$rhs)), (SUBzrr_v stackadd
 
 let mayLoad = 1 in {
 multiclass HeapLoad<EraVMOpcode opcode, SDPatternOperator node> {
-  def r : IUMAr_r<opcode, (outs GR256:$rd0), (ins GR256:$rs0),
-                 "$rs0, $rd0",
-                 [(set GR256:$rd0, (node GR256:$rs0))]>;
-  def i : IUMAi_r<opcode, (outs GR256:$rd0), (ins imm16:$addr),
-                 "$addr, $rd0",
-                 [(set GR256:$rd0, (node imm16:$addr))]>;
+  def r : IUMAr_r<opcode, [(set GR256:$rd0, (node GR256:$rs0))]>;
+  def i : IUMAi_r<opcode, [(set GR256:$rd0, (node imm16:$addr))]>;
 }
 
 multiclass HeapLoadInc<EraVMOpcode opcode> {
-  def r : IUMAr_rr<opcode, (outs GR256:$rd0, GR256:$rd1), (ins GR256:$rs0),
-                 "$rs0, $rd0, $rd1", []>;
-  def i : IUMAi_rr<opcode, (outs GR256:$rd0, GR256:$rd1), (ins imm16:$addr),
-                  "$addr, $rd0, $rd1", []>;
+  def r : IUMAr_rr<opcode, []>;
+  def i : IUMAi_rr<opcode, []>;
 }
 }
 
@@ -901,27 +712,19 @@ defm LDMst  : HeapLoad<OpStaticRead, load_static>;
 defm LDMIst : HeapLoadInc<OpStaticReadInc>;
 
 let mayLoad = 1 in {
-def LDP      : IUMAr_r<OpLoadPtr, (outs GR256:$rd0), (ins GRPTR:$rs0),
-                     "$rs0, $rd0", []>;
-def LDPI   : IUMAr_rr<OpLoadPtrInc, (outs GR256:$rd0, GRPTR:$rd1), (ins GRPTR:$rs0),
-                      "$rs0, $rd0, $rd1", []>;
+def LDP     : IUMAp_r<OpLoadPtr, []>;
+def LDPI    : IUMAp_rp<OpLoadPtrInc, []>;
 }
 
 let mayStore = 1 in {
 multiclass HeapStore<EraVMOpcode opcode, SDPatternOperator node> {
-  def r : IUMArr_<opcode, (outs), (ins GR256:$rs0, GR256:$rs1),
-                  "$rs0, $rs1",
-                  [(node GR256:$rs1, GR256:$rs0)]>;
-  def i : IUMAir_<opcode, (outs), (ins imm16:$addr, GR256:$rs1),
-                  "$addr, $rs1",
-                  [(node GR256:$rs1, imm16:$addr)]>;
+  def r : IUMArr_<opcode, [(node GR256:$rs1, GR256:$rs0)]>;
+  def i : IUMAir_<opcode, [(node GR256:$rs1, imm16:$addr)]>;
 }
 
 multiclass HeapStoreInc<EraVMOpcode opcode> {
-  def r : IUMArr_r<opcode, (outs GR256:$rd0), (ins GR256:$rs0, GR256:$rs1),
-                  "$rs0, $rs1, $rd0", []>;
-  def i : IUMAir_r<opcode, (outs GR256:$rd0), (ins imm16:$addr, GR256:$rs1),
-                  "$addr, $rs1, $rd0", []>;
+  def r : IUMArr_r<opcode, []>;
+  def i : IUMAir_r<opcode, []>;
 }
 }
 
@@ -972,25 +775,24 @@ class JumpViaStack : JumpViaConst;
 // so it may be worth making it non-terminator in the future.
 
 let Uses = [Flags] in // TODO Do not set implicit use unconditionally.
-def JCl  : IJump<OpJump, SrcImm, (outs), (ins jmptarget:$dest), "$dest",
-                 [(EraVMbrcc bb:$dest, imm:$cc)]>,
+def JCl  : IJump<OpJump, SrcImm, [dest_label], [(EraVMbrcc bb:$dest, imm:$cc)]>,
            JumpWithoutRetAddr, JumpViaLabel;
-def JClr : IJump<OpJump, SrcImm, (outs GR256:$ret_addr), (ins jmptarget:$dest), "$dest, $ret_addr", []>,
+def JClr : IJump<OpJump, SrcImm, [dest_label, ret_addr], []>,
            JumpWithRetAddr, JumpViaLabel;
 
-def JCr  : IJump<OpJump, SrcReg, (outs), (ins GR256:$dest), "$dest", []>,
+def JCr  : IJump<OpJump, SrcReg, [dest_reg], []>,
            JumpWithoutRetAddr, JumpViaReg;
-def JCrr : IJump<OpJump, SrcReg, (outs GR256:$ret_addr), (ins GR256:$dest), "$dest, $ret_addr", []>,
+def JCrr : IJump<OpJump, SrcReg, [dest_reg, ret_addr], []>,
            JumpWithRetAddr, JumpViaReg;
 
-def JCc  : IJump<OpJump, SrcCodeAddr, (outs), (ins memop:$dest), "$dest", []>,
+def JCc  : IJump<OpJump, SrcCodeAddr, [dest_code], []>,
            JumpWithoutRetAddr, JumpViaConst;
-def JCcr : IJump<OpJump, SrcCodeAddr, (outs GR256:$ret_addr), (ins memop:$dest), "$dest, $ret_addr", []>,
+def JCcr : IJump<OpJump, SrcCodeAddr, [dest_code, ret_addr], []>,
            JumpWithRetAddr, JumpViaConst;
 
-def JCs  : IJump<OpJump, SrcStackAbsolute, (outs), (ins stackin:$dest), "$dest", []>,
+def JCs  : IJump<OpJump, SrcStackAbsolute, [dest_stack], []>,
            JumpWithoutRetAddr, JumpViaStack;
-def JCsr : IJump<OpJump, SrcStackAbsolute, (outs GR256:$ret_addr), (ins stackin:$dest), "$dest, $ret_addr", []>,
+def JCsr : IJump<OpJump, SrcStackAbsolute, [dest_stack, ret_addr], []>,
            JumpWithRetAddr, JumpViaStack;
 
 // Unconditional jump
@@ -1010,15 +812,15 @@ let isCall = 1 in
 def JCALL: Pseudo<(outs), (ins jmptarget:$dest), []>,
            PseudoInstExpansion<(JCl jmptarget:$dest, 0)>;
 
-def RETr : IRet<OpRet, (ins GR256:$rs0), "$rs0", []>;
-def RETrl : IRetToLabel<OpRetToLabel, (ins GR256:$rs0, jmptarget:$dest), "$rs0, $dest", []>;
+def RETr : IRet<OpRet, [rs0], []>;
+def RETrl : IRetToLabel<OpRetToLabel, [rs0, dest_label], []>;
 
-def REVERTr : IRet<OpRevert, (ins GR256:$rs0), "$rs0", []>;
-def REVERTrl : IRetToLabel<OpRevertToLabel, (ins GR256:$rs0, jmptarget:$dest), "$rs0, $dest", []>;
+def REVERTr : IRet<OpRevert, [rs0], []>;
+def REVERTrl : IRetToLabel<OpRevertToLabel, [rs0, dest_label], []>;
 
 let rs0 = 0 in {
-def PANIC  : IRet<OpPanic, (ins), "", []>;
-def PANICl : IRetToLabel<OpPanicToLabel, (ins jmptarget:$dest), "$dest", []>;
+def PANIC  : IRet<OpPanic, [], []>;
+def PANICl : IRetToLabel<OpPanicToLabel, [dest_label], []>;
 }
 
 let isReturn = 1, isTerminator = 1, isBarrier = 1  in {
@@ -1066,94 +868,51 @@ def MOVEIMM : Pseudo<(outs GR256:$out), (ins i256imm:$val),
 //===----------------------------------------------------------------------===//
 
 let isReMaterializable = 1, hasSideEffects = 0 in {
-def CTXThis : IContext_r<OpContextThis, (outs GR256:$rd0), (ins),
-                         "$rd0",
-                         [(set GR256:$rd0, (int_eravm_this))]>;
-def CTXCaller : IContext_r<OpContextCaller, (outs GR256:$rd0), (ins),
-                           "$rd0",
-                           [(set GR256:$rd0, (int_eravm_caller))]>;
-def CTXCodeSource : IContext_r<OpContextCodeAddress, (outs GR256:$rd0), (ins),
-                               "$rd0",
-                               [(set GR256:$rd0, (int_eravm_codesource))]>;
-def CTXGetU128 : IContext_r<OpContextGetContextU128, (outs GR256:$rd0), (ins),
-                            "$rd0",
-                            [(set GR256:$rd0, (int_eravm_getu128))]>;
+def CTXThis : IContext_r<OpContextThis, [(set GR256:$rd0, (int_eravm_this))]>;
+def CTXCaller : IContext_r<OpContextCaller, [(set GR256:$rd0, (int_eravm_caller))]>;
+def CTXCodeSource : IContext_r<OpContextCodeAddress, [(set GR256:$rd0, (int_eravm_codesource))]>;
+def CTXGetU128 : IContext_r<OpContextGetContextU128, [(set GR256:$rd0, (int_eravm_getu128))]>;
 }
 
-def CTXMeta : IContext_r<OpContextMeta, (outs GR256:$rd0), (ins),
-                         "$rd0",
-                         [(set GR256:$rd0, (int_eravm_meta))]>;
+def CTXMeta : IContext_r<OpContextMeta, [(set GR256:$rd0, (int_eravm_meta))]>;
 
 let hasSideEffects = 1 in {
-def CTXSetU128 : IContextr_<OpContextSetContextU128, (outs), (ins GR256:$rs0),
-                            "$rs0",
-                            [(int_eravm_setu128 GR256:$rs0)]>;
-def CTXSetPubDP : IContextr_<OpContextSetErgsPerPubdataByte, (outs), (ins GR256:$rs0),
-                             "$rs0",
-                             [(int_eravm_setpubdataprice GR256:$rs0)]>;
+def CTXSetU128 : IContextr_<OpContextSetContextU128, [(int_eravm_setu128 GR256:$rs0)]>;
+def CTXSetPubDP : IContextr_<OpContextSetErgsPerPubdataByte, [(int_eravm_setpubdataprice GR256:$rs0)]>;
 let hasPostISelHook = 1 in
-def CTXGasLeft : IContext_r<OpContextErgsLeft, (outs GR256:$rd0), (ins),
-                            "$rd0",
-                            [(set GR256:$rd0, (int_eravm_gasleft))]>;
-def CTXGetSp   : IContext_r<OpContextSp, (outs GR256:$rd0), (ins),
-                            "$rd0",
-                            [(set GR256:$rd0, (EraVMget_sp))]>;
-def CTXIncTx   : IContext_<OpContextIncrementTxNumber, (outs), (ins), "", [(int_eravm_inctx)]>;
+def CTXGasLeft : IContext_r<OpContextErgsLeft, [(set GR256:$rd0, (int_eravm_gasleft))]>;
+def CTXGetSp   : IContext_r<OpContextSp, [(set GR256:$rd0, (EraVMget_sp))]>;
+def CTXIncTx   : IContext_<OpContextIncrementTxNumber, [(int_eravm_inctx)]>;
 }
 
 //===----------------------------------------------------------------------===//
 // Fat Pointer
 //===----------------------------------------------------------------------===//
-def LDS : ILogRr_r<OpSload, (outs GR256:$rd0), (ins GR256:$rs0),
-                     "$rs0, $rd0",
-                     [(set GR256:$rd0, (load_storage GR256:$rs0))]>;
-def LDT : ILogRr_r<OpTransientLoad, (outs GR256:$rd0), (ins GR256:$rs0),
-                     "$rs0, $rd0",
-                     [(set GR256:$rd0, (load_transient GR256:$rs0))]>;
+def LDS : ILogRr_r<OpSload, [(set GR256:$rd0, (load_storage GR256:$rs0))]>;
+def LDT : ILogRr_r<OpTransientLoad, [(set GR256:$rd0, (load_transient GR256:$rs0))]>;
 
 let hasSideEffects = 1 in {
-  def STS : ILogRrr_<OpSstore, (outs), (ins GR256:$rs0, GR256:$rs1),
-                      "$rs0, $rs1",
-                      [(store_storage GR256:$rs1, GR256:$rs0)]>;
-  def STT : ILogRrr_<OpTransientStore, (outs), (ins GR256:$rs0, GR256:$rs1),
-                      "$rs0, $rs1",
-                      [(store_transient GR256:$rs1, GR256:$rs0)]>;
+  def STS : ILogRrr_<OpSstore, [(store_storage GR256:$rs1, GR256:$rs0)]>;
+  def STT : ILogRrr_<OpTransientStore, [(store_transient GR256:$rs1, GR256:$rs0)]>;
 }
 
 let hasSideEffects = 1 in {
-def LOGL1 : ILogRrr_<OpLogToL1, (outs), (ins GR256:$rs0, GR256:$rs1),
-                        "$rs0, $rs1",
-                        [(int_eravm_tol1 GR256:$rs0, GR256:$rs1, 0)]>;
-def LOGL1I : ILogRrr_<OpLogToL1Initial, (outs), (ins GR256:$rs0, GR256:$rs1),
-                             "$rs0, $rs1",
-                             [(int_eravm_tol1 GR256:$rs0, GR256:$rs1, 1)]>;
+def LOGL1 : ILogRrr_<OpLogToL1, [(int_eravm_tol1 GR256:$rs0, GR256:$rs1, 0)]>;
+def LOGL1I : ILogRrr_<OpLogToL1Initial, [(int_eravm_tol1 GR256:$rs0, GR256:$rs1, 1)]>;
 
-def LOG : ILogRrr_<OpLogEvent, (outs), (ins GR256:$rs0, GR256:$rs1),
-                         "$rs0, $rs1",
-                         [(int_eravm_event GR256:$rs0, GR256:$rs1, 0)]>;
+def LOG : ILogRrr_<OpLogEvent, [(int_eravm_event GR256:$rs0, GR256:$rs1, 0)]>;
+def LOGI : ILogRrr_<OpLogEventInitial, [(int_eravm_event GR256:$rs0, GR256:$rs1, 1)]>;
 
-def LOGI : ILogRrr_<OpLogEventInitial, (outs), (ins GR256:$rs0, GR256:$rs1),
-                              "$rs0, $rs1",
-                              [(int_eravm_event GR256:$rs0, GR256:$rs1, 1)]>;
-
-def CALLP : ILogRrr_r<OpLogPrecompile, (outs GR256:$rd0), (ins GR256:$rs0, GR256:$rs1),
-                       "$rs0, $rs1, $rd0",
-                       [(set GR256:$rd0, (int_eravm_precompile GR256:$rs0, GR256:$rs1))]>;
+def CALLP : ILogRrr_r<OpLogPrecompile, [rs0, rs1, rd0], [(set GR256:$rd0, (int_eravm_precompile GR256:$rs0, GR256:$rs1))]>;
 }
 
-def DCMT : ILogRrr_r<OpDecommit, (outs GRPTR:$rd0), (ins GR256:$rs0, GR256:$rs1),
-                          "$rs0, $rs1, $rd0",
-                          [(set GRPTR:$rd0, (EraVMlog_decommit GR256:$rs0, GR256:$rs1))]>;
+def DCMT : ILogRrr_r<OpDecommit, [rs0, rs1, rd0_ptr], [(set GRPTR:$rd0, (EraVMlog_decommit GR256:$rs0, GR256:$rs1))]>;
 
 multiclass FarCallInst<EraVMOpcode opcode> {
-  def rrl : IFarCall<opcode, 0, 0, (ins GR256:$rs0, GR256:$rs1, jmptarget:$unwind),
-                    "$rs0, $rs1, $unwind", []>;
-  def _STATICrrl : IFarCall<opcode, 0, 1, (ins GR256:$rs0, GR256:$rs1, jmptarget:$unwind),
-                           "$rs0, $rs1, $unwind", []>;
-  def _SHARDrrl  : IFarCall<opcode, 1, 0, (ins GR256:$rs0, GR256:$rs1, jmptarget:$unwind),
-                           "$rs0, $rs1, $unwind", []>;
-  def _STATIC_SHARDrrl : IFarCall<opcode, 1, 1, (ins GR256:$rs0, GR256:$rs1, jmptarget:$unwind),
-                                 "$rs0, $rs1, $unwind", []>;
+  def rrl : IFarCall<opcode, 0, 0, []>;
+  def _STATICrrl : IFarCall<opcode, 0, 1, []>;
+  def _SHARDrrl  : IFarCall<opcode, 1, 0, []>;
+  def _STATIC_SHARDrrl : IFarCall<opcode, 1, 1, []>;
 }
 
 let Defs = [R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, Flags],
@@ -1162,8 +921,7 @@ let Defs = [R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14, R15, Fl
                      [(EraVMcall GR256:$in1, (EraVMGAStack tglobaladdr:$callee))]>;
   def INVOKE : Pseudo<(outs), (ins GR256:$in1, imm16:$callee, jmptarget:$unwind),
                       [(EraVMinvoke GR256:$in1, (EraVMGAStack tglobaladdr:$callee), bb:$unwind)]>;
-  def NEAR_CALL : ICall<OpCall, (ins GR256:$in1, jmptarget:$callee, jmptarget:$unwind),
-                        "$in1, $callee, $unwind", []>;
+  def NEAR_CALL : ICall<OpCall, []>;
 
   // Unfortunately, we cannot encode @DEFAULT_UNWIND_DEST here, so we have to alias to pseudo
   def NEAR_CALL_default_unwind : AsmParserPseudo<(outs), (ins GR256:$in1, jmptarget:$callee),


### PR DESCRIPTION
Do not repeat in/out dags and operand strings in definition of each particular instruction. Most of the times, instruction class already defines fields such as `bits<4> rs0` and hooks them to encoded fields (such as `Src0`), and then dags and operand string mirror these definitions. In a few places definitions are custom enough (such as eight variants of jump instruction) - in that case a more flexible way to describe the operands is exposed.

Several `Ixx_x` classes are split into r- and p-versions of operands: both are register operands but the former is `GR256` register and the latter is `GRPTR`. For example, `ADDrrr_s` is an instance of `Irr_r` class and `PTR_ADDrrr_s` is an instance of `Ipr_p` class.

A number of shortcuts are defined for specifying an operand (except for the special `${cc}` predicate): `EraVMOperand` tablegen class incapsulates both operand string and in/out dags (actually, one of the two dags is always empty and the other defines exactly one operand). For example, the output register of `PTR_ADDrrr_s` is `rd0_ptr` defined as `EraVMOperand<"$rd0", (ins), (outs GRPTR:$rd0)>`.