### PR TITLE
fixup! [EraVM] Enable main induction variable removal in LSR

### DIFF
--- a/llvm/lib/Target/EraVM/EraVMIndexedMemOpsPrepare.cpp
+++ b/llvm/lib/Target/EraVM/EraVMIndexedMemOpsPrepare.cpp
@@ -60,12 +60,6 @@
 //       functions of memory intrinsic, hence this pass is supposed to be run
 //       after the memory intrinsic expansion pass, the generated loops can
 //       benefit from this pass.
-//
-// TODO: CPR-1421 Remove loop index
-//       The pointers inside the loop will be increased per iteration.
-//       We can use them to judge whether loop should exit. In this way, if
-//       loop index isn't used by any other places, we can optimize out loop
-//       index along with instruction used to increase its value.
 //===----------------------------------------------------------------------===//
 
 #include "EraVM.h"

--- a/llvm/test/CodeGen/EraVM/indexed-memops.ll
+++ b/llvm/test/CodeGen/EraVM/indexed-memops.ll
@@ -3,10 +3,6 @@
 target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
 target triple = "eravm"
 
-; TODO: CPR-1421 Remove loop index
-; The register r2 and r1 are pointers and will be increased per iteration,
-; we can use them to judge whether loop should exit, the add instruction used
-; to increase loop index r4 can be optimized out.
 define void @loop1(i256 addrspace(1)* %dest, i256 addrspace(1)* %src, i256 %size) {
 ; CHECK-LABEL: loop1:
 ; CHECK:       ; %bb.0:


### PR DESCRIPTION
Remove TODOs.