### PR TITLE
ci: enable check-lld in regression tests

### DIFF
--- a/llvm/test/CMakeLists.txt
+++ b/llvm/test/CMakeLists.txt
@@ -241,7 +241,7 @@ set_target_properties(check-llvm PROPERTIES FOLDER "Tests")
 
 add_lit_testsuite(verify-llvm-codegen-opt "Running CodeGen LLVM regression tests with ZKsync opt options set"
   ${CMAKE_CURRENT_BINARY_DIR}
-  ${exclude_from_check_all}
+  EXCLUDE_FROM_CHECK_ALL
   PARAMS "opt=${LLVM_BINARY_DIR}/bin/opt \
 --cgp-verify-bfi-updates \
 --earlycse-debug-hash \
@@ -272,7 +272,7 @@ add_lit_testsuite(verify-llvm-codegen-opt "Running CodeGen LLVM regression tests
 
 add_lit_testsuite(verify-llvm-codegen-llc "Running EraVM LLVM regression tests with ZKsync llc options set"
   ${CMAKE_CURRENT_BINARY_DIR}
-  ${exclude_from_check_all}
+  EXCLUDE_FROM_CHECK_ALL
   PARAMS "llc=${LLVM_BINARY_DIR}/bin/llc \
 --cgp-verify-bfi-updates \
 --compile-twice \
@@ -311,6 +311,6 @@ add_dependencies(check check-all)
 set_target_properties(check PROPERTIES FOLDER "Tests")
 
 # Setup an alias for 'verify-llvm'.
-add_custom_target(verify-llvm DEPENDS check-llvm verify-llvm-codegen-opt verify-llvm-codegen-llc)
-add_dependencies(check-llvm verify-llvm-codegen-opt verify-llvm-codegen-llc)
+add_custom_target(verify-llvm DEPENDS check verify-llvm-codegen-opt verify-llvm-codegen-llc)
+add_dependencies(check verify-llvm-codegen-opt verify-llvm-codegen-llc)
 set_target_properties(verify-llvm PROPERTIES FOLDER "Tests")


### PR DESCRIPTION
# Code Review Checklist


## Purpose

Enables missing `check-lld` tests by running `check-all` as part of `verify-llvm`, instead of `check-llvm` only.

