### PR TITLE
ci: support target-specific tests

### DIFF
--- a/.github/workflows/benchmarks-integration-tests.yml
+++ b/.github/workflows/benchmarks-integration-tests.yml
@@ -1,4 +1,4 @@
-name: Benchmarks and integration tests
+name: Integration tests and benchmarks
 
 on:
   pull_request:
@@ -46,7 +46,6 @@ jobs:
 
   compiler-tester-ref:
     runs-on: ubuntu-latest
-    name: Compiler tester ref
     outputs:
       reference-ref: ${{ steps.compiler_tester_ref.outputs.reference-ref }}
       candidate-ref: ${{ steps.compiler_tester_ref.outputs.candidate-ref }}
@@ -77,14 +76,44 @@ jobs:
             echo "candidate-ref=${{ env.ERA_COMPILER_LLVM_REF_DEFAULT }}" | tee -a "${GITHUB_OUTPUT}"
           fi
 
+  target-machine:
+    runs-on: ubuntu-latest
+    outputs:
+      evm: ${{ steps.evm.outputs.machine }}
+      eravm: ${{ steps.eravm.outputs.machine }}
+      evmemulator: ${{ steps.eravm.outputs.machine }}
+      default: ${{ steps.default.outputs.machine }}
+    steps:
+
+      - name: Check for EraVM target
+        id: eravm
+        if: contains(github.event.pull_request.title, '[EraVM]')
+        run: echo "machine=EraVM" | tee -a "${GITHUB_OUTPUT}"
+
+      - name: Check for EVM target
+        id: evm
+        if: contains(github.event.pull_request.title, '[EVM]')
+        run: echo "machine=EVM" | tee -a "${GITHUB_OUTPUT}"
+
+      - name: Check for default target
+        id: default
+        shell: bash -ex {0}
+        run: |
+          if [[ "${{ join(steps.*.outputs.*) }}" == "" ]]; then
+            echo "machine=default" | tee -a "${GITHUB_OUTPUT}"
+          fi
 
   # Benchmarks workflow call from the era-compiler-ci repository
   # This is a common part of the benchmarks workflow for all repositories
   # If you would like to make a change to the benchmarks workflow, please do it in the era-compiler-ci repository
   benchmarks:
-    needs: compiler-tester-ref
+    needs: [compiler-tester-ref, target-machine]
     uses: matter-labs/era-compiler-ci/.github/workflows/benchmarks.yml@v1
     secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ needs.target-machine.outputs.* }}
     with:
       llvm_build_type: ${{ github.event.inputs.llvm_build_type }}
       compiler_tester_reference_branch: ${{ needs.compiler-tester-ref.outputs.reference-ref }}
@@ -95,16 +124,22 @@ jobs:
       compiler_llvm_benchmark_path: ${{ github.event.inputs.compiler_llvm_benchmark_path || '' }}
       ccache-key-type: 'static' # rotate ccache key every month
       compiler-llvm-repo: ${{ github.event.pull_request.head.repo.full_name }} # required to properly test forks
+      target-machine: ${{ matrix.target }}
 
   # Integration tests workflow call from the era-compiler-ci repository
   # This is a common part of the integration tests workflow for all repositories
   # If you would like to make a change to the integration tests workflow, please do it in the era-compiler-ci repository
   integration-tests:
-    needs: compiler-tester-ref
+    needs: [compiler-tester-ref, target-machine]
     uses: matter-labs/era-compiler-ci/.github/workflows/integration-tests.yaml@v1
     secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ needs.target-machine.outputs.* }}
     with:
       compiler-tester-ref: ${{ needs.compiler-tester-ref.outputs.candidate-ref }}
       llvm-ref: ${{ github.event.inputs.compiler_llvm_candidate_branch || github.head_ref || github.event.repository.default_branch }}
       ccache-key-type: 'static' # rotate ccache key every month
       compiler-llvm-repo: ${{ github.event.pull_request.head.repo.full_name }} # required to properly test forks
+      target-machine: ${{ matrix.target }}

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -20,10 +20,39 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  prepare-test-matrix:
+
+  target-machine:
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.prepare.outputs.matrix }}
+      evm: ${{ steps.evm.outputs.machine }}
+      eravm: ${{ steps.eravm.outputs.machine }}
+      default: ${{ steps.default.outputs.machine }}
+    steps:
+
+      - name: Check for EraVM target
+        id: eravm
+        if: contains(github.event.pull_request.title, '[EraVM]')
+        run: echo "machine=eravm" | tee -a "${GITHUB_OUTPUT}"
+
+      - name: Check for EVM target
+        id: evm
+        if: contains(github.event.pull_request.title, '[EVM]')
+        run: echo "machine=evm" | tee -a "${GITHUB_OUTPUT}"
+
+      - name: Check for default target
+        id: default
+        shell: bash -ex {0}
+        run: |
+          if [[ "${{ join(steps.*.outputs.*) }}" == "" ]]; then
+            echo "machine=default" | tee -a "${GITHUB_OUTPUT}"
+          fi
+
+  prepare-test-matrix:
+    needs: target-machine
+    runs-on: ubuntu-latest
+    outputs:
+      matrix-formatting: ${{ steps.prepare.outputs.matrix-formatting }}
+      matrix-tests: ${{ steps.prepare.outputs.matrix-tests }}
       fetch_depth: ${{ steps.extract_branch.outputs.fetch_depth }}
 
     steps:
@@ -43,11 +72,14 @@ jobs:
 
       - name: Prepare commits
         id: prepare
+        shell: bash -ex {0}
         env:
           TEST_COMMITS_LIMIT: 25 # Limit the number of commits to test
         run: |
           COMMITS_TO_TEST=$(git log -n ${{ github.event.pull_request.commits || github.event.inputs.commits-to-test }} --pretty='"%H"' | head -n ${TEST_COMMITS_LIMIT})
-          echo "matrix={ \"commit\": [${COMMITS_TO_TEST//$'\n'/, }] }" | tee -a "${GITHUB_OUTPUT}"
+          echo "matrix-formatting={ \"commit\": [${COMMITS_TO_TEST//$'\n'/, }] }" | tee -a "${GITHUB_OUTPUT}"
+          TARGETS=$(echo '${{ toJSON(needs.target-machine.outputs) }}' | jq '.[]')
+          echo "matrix-tests={ \"commit\": [${COMMITS_TO_TEST//$'\n'/, }], \"target\": [${TARGETS//$'\n'/, }] }" | tee -a "${GITHUB_OUTPUT}"
 
   check-formatting:
     if: github.event_name == 'pull_request'
@@ -59,7 +91,7 @@ jobs:
     strategy:
       fail-fast: false
       max-parallel: 3
-      matrix: ${{ fromJson(needs.prepare-test-matrix.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.prepare-test-matrix.outputs.matrix-formatting) }}
     steps:
 
       - uses: actions/checkout@v4
@@ -106,7 +138,7 @@ jobs:
     strategy:
       fail-fast: false
       max-parallel: 3
-      matrix: ${{ fromJson(needs.prepare-test-matrix.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.prepare-test-matrix.outputs.matrix-tests) }}
     steps:
 
       - uses: actions/checkout@v4
@@ -125,7 +157,7 @@ jobs:
       - name: Build LLVM
         uses: matter-labs/era-compiler-ci/.github/actions/build-llvm@v1
         with:
-          extra-args: "\\-DLLVM_ENABLE_WERROR=On \\-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
+          default-target-triple: ${{ matrix.target }}
           enable-tests: true
           enable-assertions: true
           clone-llvm: false


### PR DESCRIPTION
## What?

Add target-specific testing workflows:
* [x] Regression tests are now dynamically running `eravm` and/or `evm` checks depending on the presence of the `[EraVM]` and `[EVM]` tags in the PR title. Default triple (`eravm` for now`) is used if no labels are specified.
* [x] Integration tests and benchmarks are now dynamically running with `--target-machine EraVM` and/or `--target-machine EVM` depending on the presence of the `[EraVM]` and `[EVM]` tags in the PR title. If no labels are specified, the default mode without `--target` parameter is executed.

## Tests

### Regression tests

* [Regression tests `[EVM]` only](https://github.com/matter-labs/era-compiler-llvm/actions/runs/9906787388)
* [Regression tests `[EraVM]` + `[EVM]`](https://github.com/matter-labs/era-compiler-llvm/actions/runs/9906221398)
* [Regression tests `[EraVM]` only](https://github.com/matter-labs/era-compiler-llvm/actions/runs/9906568379)
* [Regression tests default (no labels)](https://github.com/matter-labs/era-compiler-llvm/actions/runs/9906009167)

Restrictions:
* `EVM` regression tests are now failing. It is expected until CPR-1787 fix
* If no labels are specified, there will be only one default regression tests workflow with the default triple `eravm` for now triggered. It will be changed to running both `eravm` and `evm` after CPR-1787 regression is fixed.