### PR TITLE
llvm: [NFC] Robustify testcase (#71120)

### DIFF
--- a/llvm/test/Verifier/alias.ll
+++ b/llvm/test/Verifier/alias.ll
@@ -1,5 +1,7 @@
-; RUN:  not llvm-as %s -o /dev/null 2>&1 | FileCheck %s --implicit-check-not=alias --implicit-check-not=Alias
+; RUN:  not llvm-as %s -o /dev/null 2>&1 | FileCheck %s
 
+; CHECK: : assembly parsed, but does not verify as correct!
+; CHECK-NOT: {{(^A| a)lias(es)? }}
 
 declare void @f()
 @fa = alias void (), ptr @f


### PR DESCRIPTION
# Code Review Checklist

Robustify the check-not to not trigger on llvm-as's pathname in its initial error message.

## Purpose

Cherry-pick from the upstream a local fix for `llvm-as` test that fails locally if `alias` string is in the path.