### PR TITLE
ci: use docker image from github registry

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -50,8 +50,8 @@ jobs:
           WINDOWS='{"name":"Windows","runner":"windows-2022-github-hosted-64core"}'
           MACOS_AMD64='{"name":"MacOS-x86","runner":"macos-12-large"}'
           MACOS_ARM64='{"name":"MacOS-arm64","runner":["self-hosted","macOS","ARM64"]}'
-          LINUX_AMD64='{"name":"Linux-AMD64","runner":"matterlabs-ci-runner","image":"matterlabs/llvm_runner:ubuntu22-llvm17-latest"}'
-          LINUX_ARM64='{"name":"Linux-ARM64","runner":"matterlabs-ci-runner-arm","image":"matterlabs/llvm_runner:ubuntu22-llvm17-latest"}'
+          LINUX_AMD64='{"name":"Linux-AMD64","runner":"matterlabs-ci-runner","image":"ghcr.io/matter-labs/llvm_runner/ubuntu22-llvm17:latest"}'
+          LINUX_ARM64='{"name":"Linux-ARM64","runner":"matterlabs-ci-runner-arm","image":"ghcr.io/matter-labs/llvm_runner/ubuntu22-llvm17:latest"}'
           # Disable platforms for non-tag builds if user requested
           if [ ${GITHUB_EVENT_NAME} = workflow_dispatch ]; then
             [ ${{ github.event.inputs.build_windows_amd64 }} != true ] && WINDOWS=

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -51,9 +51,9 @@ jobs:
 
   check-formatting:
     if: github.event_name == 'pull_request'
-    runs-on: ci-runner-compiler
+    runs-on: [ci-runner-compiler, Linux]
     container:
-      image: matterlabs/llvm_runner:ubuntu22-llvm17-latest
+      image: ghcr.io/matter-labs/llvm_runner/ubuntu22-llvm17:latest
       options: -m 110g
     needs: prepare-test-matrix
     strategy:
@@ -98,9 +98,9 @@ jobs:
             --changed-files ${{ steps.changed-files.outputs.all_changed_files }}
 
   regression-tests:
-    runs-on: ci-runner-compiler
+    runs-on: [ci-runner-compiler, Linux]
     container:
-      image: matterlabs/llvm_runner:ubuntu22-llvm17-latest
+      image: ghcr.io/matter-labs/llvm_runner/ubuntu22-llvm17:latest
       options: -m 110g
     needs: prepare-test-matrix
     strategy:


### PR DESCRIPTION
# Code Review Checklist

Use Docker image from github registry to fix the issue with restricted number of pulls from Dockerhub.
