### PR TITLE
[EraVM] Only generate GEPs that dominate latch BB in EraVMIndexedMemOpsPrepare

### DIFF
--- a/llvm/lib/Target/EraVM/EraVMIndexedMemOpsPrepare.cpp
+++ b/llvm/lib/Target/EraVM/EraVMIndexedMemOpsPrepare.cpp
@@ -71,10 +71,6 @@
 #include "llvm/Analysis/LoopPass.h"
 #include "llvm/Analysis/ScalarEvolution.h"
 #include "llvm/Analysis/ScalarEvolutionExpressions.h"
-#include "llvm/Analysis/TargetLibraryInfo.h"
-#include "llvm/Analysis/TargetTransformInfo.h"
-#include "llvm/CodeGen/TargetInstrInfo.h"
-#include "llvm/CodeGen/TargetPassConfig.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/Support/CommandLine.h"
@@ -108,8 +104,6 @@ public:
   void getAnalysisUsage(AnalysisUsage &AU) const override {
     AU.addRequired<ScalarEvolutionWrapperPass>();
     AU.addRequired<LoopInfoWrapperPass>();
-    AU.addRequired<TargetPassConfig>();
-    AU.addRequired<TargetTransformInfoWrapperPass>();
     AU.addPreserved<LoopInfoWrapperPass>();
     AU.setPreservesCFG();
   }
@@ -279,5 +273,7 @@ char EraVMIndexedMemOpsPrepare::ID = 0;
 
 INITIALIZE_PASS_BEGIN(EraVMIndexedMemOpsPrepare, DEBUG_TYPE,
                       ERAVM_PREPARE_INDEXED_MEMOPS_NAME, false, false)
+INITIALIZE_PASS_DEPENDENCY(ScalarEvolutionWrapperPass)
+INITIALIZE_PASS_DEPENDENCY(LoopInfoWrapperPass)
 INITIALIZE_PASS_END(EraVMIndexedMemOpsPrepare, DEBUG_TYPE,
                     ERAVM_PREPARE_INDEXED_MEMOPS_NAME, false, false)

--- a/llvm/test/CodeGen/EraVM/indexed-memops-gep-dominate-bug.ll
+++ b/llvm/test/CodeGen/EraVM/indexed-memops-gep-dominate-bug.ll
@@ -1,0 +1,43 @@
+; RUN: llc -O3 -stop-after=verify -compile-twice=false < %s | FileCheck %s
+
+target datalayout = "E-p:256:256-i256:256:256-S32-a:256:256"
+target triple = "eravm"
+
+define i256 @test(i256 %arg, ptr addrspace(1) %arg1, ptr addrspace(1) %arg2) {
+; CHECK-LABEL: @test(
+entry:
+  %icmp1 = icmp eq i256 %arg, 0
+  br i1 %icmp1, label %bb7, label %bb1
+
+bb1:
+  br label %bb2
+
+bb2:
+  %phi1 = phi i256 [ %add, %bb5 ], [ 0, %bb1 ]
+  %icmp2 = icmp ugt i256 %phi1, 100
+  br i1 %icmp2, label %bb3, label %bb4
+
+bb3:
+  ; CHECK: getelementptr inbounds i256, ptr addrspace(1) %arg1, i256 %phi1
+  %gep1 = getelementptr inbounds i256, ptr addrspace(1) %arg1, i256 %phi1
+  store i256 5, ptr addrspace(1) %gep1, align 32
+  br label %bb5
+
+bb4:
+  ; CHECK: getelementptr inbounds i256, ptr addrspace(1) %arg2, i256 %phi1
+  %gep2 = getelementptr inbounds i256, ptr addrspace(1) %arg2, i256 %phi1
+  store i256 10, ptr addrspace(1) %gep2, align 32
+  br label %bb5
+
+bb5:
+  %add = add i256 %phi1, 1
+  %cmp3 = icmp eq i256 %add, 0
+  br i1 %cmp3, label %bb6, label %bb2
+
+bb6:
+  br label %bb7
+
+bb7:
+  %phi2 = phi i256 [ 0, %entry ], [ %add, %bb6 ]
+  ret i256 %phi2
+}


### PR DESCRIPTION
…OpsPrepare

In case we generate GEP that doesn't dominate latch BB, we will run into an issue and verifier will complain:
```
Instruction does not dominate all uses!
  %3 = getelementptr inbounds i256, ptr addrspace(1) %0, i256 1
  %0 = phi ptr addrspace(1) [ %arg3, %bb1 ], [ %3, %bb5 ]
```
This patch fixes this issue.