### PR TITLE
ci: add sanitizers support for regression tests

### DIFF
--- a/.github/workflows/benchmarks-integration-tests.yml
+++ b/.github/workflows/benchmarks-integration-tests.yml
@@ -81,7 +81,6 @@ jobs:
     outputs:
       evm: ${{ steps.evm.outputs.machine }}
       eravm: ${{ steps.eravm.outputs.machine }}
-      evmemulator: ${{ steps.eravm.outputs.machine }}
       default: ${{ steps.default.outputs.machine }}
     steps:
 

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -86,7 +86,6 @@ jobs:
       - name: Build LLVM
         uses: matter-labs/era-compiler-ci/.github/actions/build-llvm@v1
         with:
-          extra-args: "\\-DLLVM_ENABLE_WERROR=On \\-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
           enable-tests: true
           enable-assertions: true
           clone-llvm: false

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -10,6 +10,13 @@ on:
         description: "Number of commits to test"
         required: true
         default: '1'
+      # For more information about the supported sanitizers in LLVM, see `LLVM_USE_SANITIZER` option in:
+      # https://www.llvm.org/docs/CMake.html
+      llvm-sanitizer:
+        required: false
+        default: 'Address'
+        type: string
+        description: 'A sanitizer to build LLVM with. Possible values are Address, Memory, MemoryWithOrigins, Undefined, Thread, DataFlow, and Address;Undefined'
 
 defaults:
   run:
@@ -162,6 +169,7 @@ jobs:
           enable-assertions: true
           clone-llvm: false
           ccache-key-type: 'static' # rotate ccache key every month
+          sanitizer: ${{ inputs.llvm-sanitizer }}
 
       # `verify-llvm` is a special target that runs all the regression tests
       # it includes `check-llvm` and special codegen tests


### PR DESCRIPTION
# Code Review Checklist

* [x] Adds sanitizer supports for regression tests with a manual trigger.
* [x] Removed  explicit `LLVM_ENABLE_WERROR` and `CMAKE_EXPORT_COMPILE_COMMANDS` as it's now [default behavior](https://github.com/matter-labs/era-compiler-llvm-builder/blob/3306a837602f91e73fa3bf9c9a4218d632cf0ae5/src/platforms/shared.rs#L28-L29)
* [x] Fix typo for `evmemulator` output 

## Purpose

To be able to run regression tests with a sanitizer in debugging purposes.