### PR TITLE
[EraVM] Disable generation of .note.GNU-stack

### DIFF
--- a/llvm/lib/Target/EraVM/MCTargetDesc/EraVMMCAsmInfo.cpp
+++ b/llvm/lib/Target/EraVM/MCTargetDesc/EraVMMCAsmInfo.cpp
@@ -15,8 +15,6 @@
 
 using namespace llvm;
 
-void EraVMMCAsmInfo::anchor() {}
-
 EraVMMCAsmInfo::EraVMMCAsmInfo(const Triple &TheTriple) {
   IsLittleEndian = false;
   HasFunctionAlignment = false;

--- a/llvm/lib/Target/EraVM/MCTargetDesc/EraVMMCAsmInfo.h
+++ b/llvm/lib/Target/EraVM/MCTargetDesc/EraVMMCAsmInfo.h
@@ -13,19 +13,20 @@
 #ifndef LLVM_LIB_TARGET_ERAVM_MCTARGETDESC_ERAVMMCASMINFO_H
 #define LLVM_LIB_TARGET_ERAVM_MCTARGETDESC_ERAVMMCASMINFO_H
 
+#include "llvm/MC/MCAsmInfo.h"
 #include "llvm/MC/MCAsmInfoCOFF.h"
 #include "llvm/MC/MCAsmInfoDarwin.h"
-#include "llvm/MC/MCAsmInfoELF.h"
 
 namespace llvm {
 class Triple;
 
-class EraVMMCAsmInfo : public MCAsmInfoELF {
-  void anchor() override;
-
+class EraVMMCAsmInfo : public MCAsmInfo {
 public:
   explicit EraVMMCAsmInfo(const Triple &TheTriple);
   bool shouldOmitSectionDirective(StringRef) const override { return true; }
+  MCSection *getNonexecutableStackSection(MCContext &Ctx) const override {
+    return nullptr;
+  }
 };
 
 } // namespace llvm


### PR DESCRIPTION
This section is not used, so disable generation of it.