### PR TITLE
[EraVM] Add disassembler C-API.

### DIFF
--- a/llvm/include/llvm-c/Assembler.h
+++ b/llvm/include/llvm-c/Assembler.h
@@ -32,6 +32,19 @@ LLVMBool LLVMAssembleEraVM(LLVMTargetMachineRef T, LLVMMemoryBufferRef InBuffer,
 LLVMBool LLVMExceedsSizeLimitEraVM(LLVMMemoryBufferRef MemBuf,
                                    uint64_t MetadataSize);
 
+/** Disassembles the bytecode passed in \p InBuffer starting at
+ *  the offset \p PC. The result is returned via \p OutBuffer.
+ *  In case of an error the function returns 'true' and an error
+ *  message is passes via \p ErrorMessage. The message should be disposed
+ *  by LLVMDisposeMessage. **/
+LLVMBool LLVMDisassembleEraVM(LLVMTargetMachineRef T,
+                              LLVMMemoryBufferRef InBuffer, uint64_t PC,
+                              uint64_t Options, LLVMMemoryBufferRef *OutBuffer,
+                              char **ErrorMessage);
+
+/* The option to output offset and encoding of a instruction. */
+#define LLVMDisassemblerEraVM_Option_OutputEncoding 1
+
 LLVM_C_EXTERN_C_END
 
 #endif // LLVM_C_ASSEMBLER_H

--- a/llvm/lib/Target/EraVM/EraVMAsmPrinter.cpp
+++ b/llvm/lib/Target/EraVM/EraVMAsmPrinter.cpp
@@ -469,8 +469,11 @@ void EraVMAsmPrinter::emitStartOfAsmFile(Module &M) {
     // initializers. The checks for linkage and the presense of an initilizer
     // are mainly to pass target independent LLVM IR tests.
     // The 'constant' globals go to .rodata section, so skip them.
+    // Only variables with the default address space (AS_STACK) should be
+    // initialized this way.
     if ((G.getLinkage() != GlobalValue::AvailableExternallyLinkage) &&
-        !G.isConstant() && G.hasInitializer())
+        !G.isConstant() && G.hasInitializer() &&
+        G.getAddressSpace() == EraVMAS::AS_STACK)
       NumStackElmsToReserve += createInitializeInsts(&G, InitInsts);
   }
 

--- a/llvm/lib/Target/EraVM/EraVMInstrInfo.td
+++ b/llvm/lib/Target/EraVM/EraVMInstrInfo.td
@@ -953,8 +953,8 @@ def THROW : Pseudo<(outs), (ins GR256:$rs0, pred:$cc), [(EraVMthrow GR256:$rs0)]
 def : InstAlias<"ret${cc}", (RETr R1, pred:$cc)>;
 def : InstAlias<"rev${cc}", (REVERTr R1, pred:$cc)>;
 
-def : InstAlias<"retl${cc} $dest", (RETrl R1, jmptarget:$dest, pred:$cc)>;
-def : InstAlias<"revl${cc} $dest", (REVERTrl R1, jmptarget:$dest, pred:$cc)>;
+def : InstAlias<"retl${cc}\t$dest", (RETrl R1, jmptarget:$dest, pred:$cc)>;
+def : InstAlias<"revl${cc}\t$dest", (REVERTrl R1, jmptarget:$dest, pred:$cc)>;
 
 def : Pat<(EraVMreturn GR256:$rs0), (RETrl GR256:$rs0, (default_far_return 0))>;
 def : Pat<(EraVMrevert GR256:$rs0), (REVERTrl GR256:$rs0, (default_far_revert 0))>;
@@ -1052,7 +1052,7 @@ foreach Op = [OpFarcall, OpDelegate, OpMimic] in {
                       !strconcat(Op.Name, ".st.sh")>;
 }
 
-def : InstAlias<"call${cc} ${callee}",
+def : InstAlias<"call${cc}\t${callee}",
                 (NEAR_CALL_default_unwind R0, jmptarget:$callee, pred:$cc)>;
 
 def : Pat<(EraVMfarcall bb:$unwind), (FAR_CALLrrl R1, R2, bb:$unwind)>;

--- a/llvm/test/CodeGen/EraVM/global_initializers.ll
+++ b/llvm/test/CodeGen/EraVM/global_initializers.ll
@@ -10,7 +10,7 @@ target triple = "eravm"
 @glob.const = constant i256 737
 
 ; CHECK-LABEL: .text
-; CHECK-NEXT: incsp 10
+; CHECK-NEXT: incsp 6
 ; CHECK-NEXT: add	code[@glob_initializer_0], r0, stack[@glob]
 ; CHECK-NEXT: add	code[@glob.arr_initializer_1], r0, stack[@glob.arr + 1]
 ; CHECK-NEXT: add	code[@glob.arr_initializer_3], r0, stack[@glob.arr + 3]

--- a/llvm/unittests/MC/EraVM/AssemblerTest.cpp
+++ b/llvm/unittests/MC/EraVM/AssemblerTest.cpp
@@ -21,6 +21,7 @@ class AssemblerCTest : public testing::Test {
     LLVMInitializeEraVMTargetMC();
     LLVMInitializeEraVMAsmParser();
     LLVMInitializeEraVMAsmPrinter();
+    LLVMInitializeEraVMDisassembler();
 
     LLVMTargetRef Target = nullptr;
     const char *Triple = "eravm";
@@ -173,4 +174,179 @@ TEST_F(AssemblerCTest, BytecodeIsTooBigError) {
 
   LLVMDisposeMemoryBuffer(AsmMemBuffer);
   LLVMDisposeMemoryBuffer(ObjMemBuffer);
+}
+
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)
+TEST_F(AssemblerCTest, Disassembler) {
+  std::array<char, 12 * 8> Code = {
+      0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x02,
+      0x00, 0x00, 0x00, 0x47, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x31,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x04, 0x2d, 0x00, 0x00, 0x00, 0x04,
+      0x00, 0x00, 0x04, 0x32, 0x00, 0x00, 0x00, 0x05, 0x00, 0x01, 0x04, 0x2e,
+      0x00, 0x00, 0x00, 0x06, 0x00, 0x01, 0x04, 0x30, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x71};
+
+  LLVMMemoryBufferRef BinMemBuffer = LLVMCreateMemoryBufferWithMemoryRange(
+      Code.data(), Code.size(), "test", 0);
+  char *ErrMsg = nullptr;
+  LLVMMemoryBufferRef DisasmMemBuffer = nullptr;
+  // Return code 'true' denotes an error.
+  if (LLVMDisassembleEraVM(TM, BinMemBuffer, 0,
+                           LLVMDisassemblerEraVM_Option_OutputEncoding,
+                           &DisasmMemBuffer, &ErrMsg)) {
+    FAIL() << "Failed to disassembly:" << ErrMsg;
+    LLVMDisposeMessage(ErrMsg);
+    return;
+  }
+
+  StringRef Result(LLVMGetBufferStart(DisasmMemBuffer),
+                   LLVMGetBufferSize(DisasmMemBuffer));
+  EXPECT_TRUE(Result.contains("0: 00 01 00 00 00 00 00 02	incsp	1"));
+  EXPECT_TRUE(Result.contains(
+      "8: 00 00 00 02 00 00 00 47	add	code[2], r0, stack[r0]"));
+  EXPECT_TRUE(Result.contains(
+      "10: 00 00 00 00 01 00 00 31	add	stack[r0], r0, r1"));
+  EXPECT_TRUE(Result.contains("18: 00 00 00 00 00 01 04 2d	ret"));
+  EXPECT_TRUE(Result.contains("20: 00 00 00 04 00 00 04 32	pncl	4"));
+  EXPECT_TRUE(Result.contains("28: 00 00 00 05 00 01 04 2e	retl	5"));
+  EXPECT_TRUE(Result.contains("30: 00 00 00 06 00 01 04 30	revl	6"));
+  EXPECT_TRUE(Result.contains("2:"));
+  EXPECT_TRUE(Result.contains("	.cell 113"));
+
+  LLVMDisposeMemoryBuffer(BinMemBuffer);
+  LLVMDisposeMemoryBuffer(DisasmMemBuffer);
+}
+
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)
+TEST_F(AssemblerCTest, DisassemblerNoConstants) {
+  std::array<uint8_t, 12 * 8> Code = {
+      0x00, 0x00, 0x00, 0x01, 0x01, 0x10, 0x00, 0x39, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x01, 0x04, 0x2d, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x04, 0x32,
+      0x00, 0x00, 0x00, 0x03, 0x00, 0x01, 0x04, 0x2e, 0x00, 0x00, 0x00, 0x04,
+      0x00, 0x01, 0x04, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x3a, 0xc2, 0x25, 0x16, 0x8d, 0xf5, 0x42, 0x12,
+      0xa2, 0x5c, 0x1c, 0x01, 0xfd, 0x35, 0xbe, 0xbf, 0xea, 0x40, 0x8f, 0xda,
+      0xc2, 0xe3, 0x1d, 0xdd, 0x6f, 0x80, 0xa4, 0xbb, 0xf9, 0xa5, 0xf1, 0xcb};
+
+  LLVMMemoryBufferRef BinMemBuffer = LLVMCreateMemoryBufferWithMemoryRange(
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+      reinterpret_cast<const char *>(Code.data()), Code.size(), "test", 0);
+  char *ErrMsg = nullptr;
+  LLVMMemoryBufferRef DisasmMemBuffer = nullptr;
+  // Return code 'true' denotes an error.
+  if (LLVMDisassembleEraVM(TM, BinMemBuffer, 0,
+                           LLVMDisassemblerEraVM_Option_OutputEncoding,
+                           &DisasmMemBuffer, &ErrMsg)) {
+    FAIL() << "Failed to disassembly:" << ErrMsg;
+    LLVMDisposeMessage(ErrMsg);
+    return;
+  }
+
+  StringRef Result(LLVMGetBufferStart(DisasmMemBuffer),
+                   LLVMGetBufferSize(DisasmMemBuffer));
+  EXPECT_TRUE(
+      Result.contains("0: 00 00 00 01 01 10 00 39	add	1, r1, r1"));
+  EXPECT_TRUE(Result.contains("8: 00 00 00 00 00 01 04 2d	ret"));
+  EXPECT_TRUE(Result.contains("10: 00 00 00 02 00 00 04 32	pncl	2"));
+  EXPECT_TRUE(Result.contains("18: 00 00 00 03 00 01 04 2e	retl	3"));
+  EXPECT_TRUE(Result.contains("20: 00 00 00 04 00 01 04 30	revl	4"));
+  EXPECT_TRUE(Result.contains("28: 00 00 00 00 00 00 00 00	<padding>"));
+  EXPECT_TRUE(Result.contains("30: 00 00 00 00 00 00 00 00	<padding>"));
+  EXPECT_TRUE(Result.contains("38: 00 00 00 00 00 00 00 00	<padding>"));
+  EXPECT_TRUE(Result.contains("40: 3a c2 25 16 8d f5 42 12	<metadata>"));
+  EXPECT_TRUE(Result.contains("48: a2 5c 1c 01 fd 35 be bf	<metadata>"));
+  EXPECT_TRUE(Result.contains("50: ea 40 8f da c2 e3 1d dd	<metadata>"));
+  EXPECT_TRUE(Result.contains("58: 6f 80 a4 bb f9 a5 f1 cb	<metadata>"));
+
+  LLVMDisposeMemoryBuffer(BinMemBuffer);
+  LLVMDisposeMemoryBuffer(DisasmMemBuffer);
+}
+
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)
+TEST_F(AssemblerCTest, DisassemblerOffset8) {
+  std::array<char, 8 * 4> Code = {
+      0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
+      0x00, 0x01, 0x00, 0x00, 0x31, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+      0x00, 0x31, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+
+  LLVMMemoryBufferRef BinMemBuffer = LLVMCreateMemoryBufferWithMemoryRange(
+      Code.data(), Code.size(), "test", 0);
+  char *ErrMsg = nullptr;
+  LLVMMemoryBufferRef DisasmMemBuffer = nullptr;
+  // Return code 'true' denotes an error.
+  if (LLVMDisassembleEraVM(TM, BinMemBuffer, 8, 0, &DisasmMemBuffer, &ErrMsg)) {
+    FAIL() << "Failed to disassembly:" << ErrMsg;
+    LLVMDisposeMessage(ErrMsg);
+    return;
+  }
+
+  StringRef Result(LLVMGetBufferStart(DisasmMemBuffer),
+                   LLVMGetBufferSize(DisasmMemBuffer));
+  EXPECT_TRUE(Result.contains("add	stack[r0], r0, r1"));
+
+  LLVMDisposeMemoryBuffer(BinMemBuffer);
+  LLVMDisposeMemoryBuffer(DisasmMemBuffer);
+}
+
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)
+TEST_F(AssemblerCTest, DisassemblerErrPCIsNotMultiple8) {
+  std::array<char, 8 * 4> Code = {
+      0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
+      0x00, 0x01, 0x00, 0x00, 0x31, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+      0x00, 0x31, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+
+  LLVMMemoryBufferRef BinMemBuffer = LLVMCreateMemoryBufferWithMemoryRange(
+      Code.data(), Code.size(), "test", 0);
+  char *ErrMsg = nullptr;
+  LLVMMemoryBufferRef DisasmMemBuffer = nullptr;
+  // Return code 'true' denotes an error.
+  EXPECT_TRUE(
+      LLVMDisassembleEraVM(TM, BinMemBuffer, 1, 0, &DisasmMemBuffer, &ErrMsg));
+  EXPECT_TRUE(StringRef(ErrMsg).contains(
+      "Starting address isn't multiple of 8 (instruction size)"));
+
+  LLVMDisposeMessage(ErrMsg);
+  LLVMDisposeMemoryBuffer(BinMemBuffer);
+}
+
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)
+TEST_F(AssemblerCTest, DisassemblerErrPCExceedsCodeSize) {
+  std::array<char, 8 * 4> Code = {
+      0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
+      0x00, 0x01, 0x00, 0x00, 0x31, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+      0x00, 0x31, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+
+  LLVMMemoryBufferRef BinMemBuffer = LLVMCreateMemoryBufferWithMemoryRange(
+      Code.data(), Code.size(), "test", 0);
+  char *ErrMsg = nullptr;
+  LLVMMemoryBufferRef DisasmMemBuffer = nullptr;
+  // Return code 'true' denotes an error.
+  EXPECT_TRUE(
+      LLVMDisassembleEraVM(TM, BinMemBuffer, 64, 0, &DisasmMemBuffer, &ErrMsg));
+  EXPECT_TRUE(
+      StringRef(ErrMsg).contains("Starting address exceeds the bytecode size"));
+
+  LLVMDisposeMessage(ErrMsg);
+  LLVMDisposeMemoryBuffer(BinMemBuffer);
+}
+
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)
+TEST_F(AssemblerCTest, DisassemblerErrCodeSizeIsNotMultiple32) {
+  std::array<char, 9> Code = {0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02};
+
+  LLVMMemoryBufferRef BinMemBuffer = LLVMCreateMemoryBufferWithMemoryRange(
+      Code.data(), Code.size(), "test", 0);
+  char *ErrMsg = nullptr;
+  LLVMMemoryBufferRef DisasmMemBuffer = nullptr;
+  // Return code 'true' denotes an error.
+  EXPECT_TRUE(
+      LLVMDisassembleEraVM(TM, BinMemBuffer, 0, 0, &DisasmMemBuffer, &ErrMsg));
+  EXPECT_TRUE(StringRef(ErrMsg).contains(
+      "Bytecode size isn't multiple of 32 (word size)"));
+
+  LLVMDisposeMessage(ErrMsg);
+  LLVMDisposeMemoryBuffer(BinMemBuffer);
 }


### PR DESCRIPTION
Example:
Default mode:
```
       add	128, r0, r3
	stm.h	64, r3
	and!	1, r2, r0
	jump.ne	30
	add	r1, r0, r2
	shr.s	96, r2, r2
	and	code[11], r2, r2
	sub.s!	4, r2, r0
	jump.lt	38
	ldp	r1, r3
	and	code[13], r3, r3
	sub.s!	code[14], r3, r0
	jump.ne	38
	sub.s!	68, r2, r0
	jump.lt	38
	ldvl	r2
	sub!	r2, r0, r0
	jump.ne	38
	addp.s	36, r1, r2
	ldp	r2, r2
	rol	code[15], r2, r3
	sub.s	1, r0, r4
	sub.s!	255, r2, r0
	add.le	r3, r0, r4
	addp.s	4, r1, r1
	ldp	r1, r1
	and	r4, r1, r1
	stm.h	128, r1
	add	code[16], r0, r1
	retl 41
	ldvl	r1
	sub!	r1, r0, r0
	jump.ne	38
	add	32, r0, r1
	stm.ah	256, r1
	stm.ah	288, r0
	add	code[12], r0, r1
	retl 41
	add	r0, r0, r1
	revl 42
	pncl	40
	retl 41
	revl 42
	<unknown> // zero fill for padding
11:
	.cell 4294967295
12:
	.cell 53919893334301279589334030174039261352344891250716429051063678533632
13:
	.cell -26959946667150639794667015087019630673637144422540572481103610249216
14:
	.cell 6775656105105473604099007350066834251830933750474818692318744137155055976448
15:
	.cell 18446744073709551614
16:
	.cell 2535301202817642044428229017600
	<unknown> // Next four octets are zero fill for padding
	<unknown>
	<unknown>
	<unknown>
	<unknown> // Next four octets are the hash. 
	<unknown>
	<unknown>
	<unknown>
```

Verbose mode:
```
 0: 00 00 00 80 03 00 00 39	add	128, r0, r3
       8: 00 00 00 40 00 30 04 3f	stm.h	64, r3
      10: 00 00 00 01 00 20 01 90	and!	1, r2, r0
      18: 00 00 00 1e 00 00 c1 3d	jump.ne	30
      20: 00 00 00 00 02 01 00 19	add	r1, r0, r2
      28: 00 00 00 60 02 20 02 70	shr.s	96, r2, r2
      30: 00 00 00 0b 02 20 01 97	and	code[11], r2, r2
      38: 00 00 00 04 00 20 00 8c	sub.s!	4, r2, r0
      40: 00 00 00 26 00 00 41 3d	jump.lt	38
      48: 00 00 00 00 03 01 04 3b	ldp	r1, r3
      50: 00 00 00 0d 03 30 01 97	and	code[13], r3, r3
      58: 00 00 00 0e 00 30 00 9c	sub.s!	code[14], r3, r0
      60: 00 00 00 26 00 00 c1 3d	jump.ne	38
      68: 00 00 00 44 00 20 00 8c	sub.s!	68, r2, r0
      70: 00 00 00 26 00 00 41 3d	jump.lt	38
      78: 00 00 00 00 02 00 04 16	ldvl	r2
      80: 00 00 00 00 00 02 00 4b	sub!	r2, r0, r0
      88: 00 00 00 26 00 00 c1 3d	jump.ne	38
      90: 00 00 00 24 02 10 03 70	addp.s	36, r1, r2
      98: 00 00 00 00 02 02 04 3b	ldp	r2, r2
      a0: 00 00 00 0f 03 20 02 df	rol	code[15], r2, r3
      a8: 00 00 00 01 04 00 00 8a	sub.s	1, r0, r4
      b0: 00 00 00 ff 00 20 00 8c	sub.s!	255, r2, r0
      b8: 00 00 00 00 04 03 a0 19	add.le	r3, r0, r4
      c0: 00 00 00 04 01 10 03 70	addp.s	4, r1, r1
      c8: 00 00 00 00 01 01 04 3b	ldp	r1, r1
      d0: 00 00 00 00 01 14 01 6f	and	r4, r1, r1
      d8: 00 00 00 80 00 10 04 3f	stm.h	128, r1
      e0: 00 00 00 10 01 00 00 41	add	code[16], r0, r1
      e8: 00 00 00 29 00 01 04 2e	retl 41
      f0: 00 00 00 00 01 00 04 16	ldvl	r1
      f8: 00 00 00 00 00 01 00 4b	sub!	r1, r0, r0
     100: 00 00 00 26 00 00 c1 3d	jump.ne	38
     108: 00 00 00 20 01 00 00 39	add	32, r0, r1
     110: 00 00 01 00 00 10 04 43	stm.ah	256, r1
     118: 00 00 01 20 00 00 04 43	stm.ah	288, r0
     120: 00 00 00 0c 01 00 00 41	add	code[12], r0, r1
     128: 00 00 00 29 00 01 04 2e	retl 41
     130: 00 00 00 00 01 00 00 19	add	r0, r0, r1
     138: 00 00 00 2a 00 01 04 30	revl 42
     140: 00 00 00 28 00 00 04 32	pncl	40
     148: 00 00 00 29 00 01 04 2e	retl 41
     150: 00 00 00 2a 00 01 04 30	revl 42
     158: 00 00 00 00 00 00 00 00	<unknown>
11:
	.cell 4294967295
12:
	.cell 53919893334301279589334030174039261352344891250716429051063678533632
13:
	.cell -26959946667150639794667015087019630673637144422540572481103610249216
14:
	.cell 6775656105105473604099007350066834251830933750474818692318744137155055976448
15:
	.cell 18446744073709551614
16:
	.cell 2535301202817642044428229017600
     220: 00 00 00 00 00 00 00 00	<unknown>
     228: 00 00 00 00 00 00 00 00	<unknown>
     230: 00 00 00 00 00 00 00 00	<unknown>
     238: 00 00 00 00 00 00 00 00	<unknown>
     240: 3a c2 25 16 8d f5 42 12	<unknown>
     248: a2 5c 1c 01 fd 35 be bf	<unknown>
     250: ea 40 8f da c2 e3 1d dd	<unknown>
     258: 6f 80 a4 bb f9 a5 f1 cb	<unknown>
``` 

# Code Review Checklist



## Purpose


## Ticket Number


## Requirements
- [ ] Have the requirements been met?
- [ ] Have stakeholder(s) approved the change?

## Implementation
- [ ] Does this code change accomplish what it is supposed to do?
- [ ] Can this solution be simplified?
- [ ] Does this change add unwanted compile-time or run-time dependencies?
- [ ] Could an additional framework, API, library, or service improve the solution?
- [ ] Could we reuse part of LLVM instead of implementing the patch or a part of it?
- [ ] Is the code at the right abstraction level?
- [ ] Is the code modular enough?
- [ ] Can a better solution be found in terms of maintainability, readability, performance, or security?
- [ ] Does similar functionality already exist in the codebase? If yes, why isn’t it reused?
- [ ] Are there any best practices, design patterns or language-specific patterns that could substantially improve this code? 

## Logic Errors and Bugs
- [ ] Can you think of any use case in which the
code does not behave as intended?
- [ ] Can you think of any inputs or external events
that could break the code?

## Error Handling and Logging
- [ ] Is error handling done the correct way?
- [ ] Should any logging or debugging information
be added or removed?
- [ ] Are error messages user-friendly?
- [ ] Are there enough log events and are they
written in a way that allows for easy
debugging?

## Maintainability
- [ ] Is the code easy to read?
- [ ] Is the code not repeated (DRY Principle)?
- [ ] Is the code method/class not too long?

## Dependencies
- [ ] Were updates to documentation, configuration, or readme files made as required by this change?
- [ ] Are there any potential impacts on other parts of the system or backward compatibility?

## Security
- [ ] Does the code introduce any security vulnerabilities?

## Performance
- [ ] Do you think this code change decreases
system performance?
- [ ] Do you see any potential to improve the
performance of the code significantly?

## Testing and Testability
- [ ] Is the code testable?
- [ ] Have automated tests been added, or have related ones been updated to cover the change?
	- [ ] For changes to mutable state
- [ ] Do tests reasonably cover the code change (unit/integration/system tests)? 
	- [ ] Line Coverage
	- [ ] Region Coverage
	- [ ] Branch Coverage
- [ ] Are there some test cases, input or edge cases
that should be tested in addition?

## Readability
- [ ] Is the code easy to understand?
- [ ] Which parts were confusing to you and why?
- [ ] Can the readability of the code be improved by
smaller methods?
- [ ] Can the readability of the code be improved by
different function, method or variable names?
- [ ] Is the code located in the right
file/folder/package?
- [ ] Do you think certain methods should be
restructured to have a more intuitive control
flow?
- [ ] Is the data flow understandable?
- [ ] Are there redundant or outdated comments?
- [ ] Could some comments convey the message
better?
- [ ] Would more comments make the code more
understandable?
- [ ] Could some comments be removed by making the code itself more readable?
- [ ] Is there any commented-out code?
- [ ] Have you run a spelling and grammar checker?

## Documentation
- [ ] Is there sufficient documentation?
- [ ] Is the ReadMe.md file up to date?

## Best Practices
- [ ] Follow Single Responsibility principle?
- [ ] Are different errors handled correctly?
- [ ] Are errors and warnings logged?
- [ ] Magic values avoided?
- [ ] No unnecessary comments?
- [ ] Minimal nesting used?

## Experts' Opinion
- [ ] Do you think a specific expert, like a security
expert or a usability expert, should look over
the code before it can be accepted?
- [ ] Will this code change impact different teams, and should they review the change as well?

<!-- 
MIT License

Copyright (c) 2020 Michaela Greiler
from https://github.com/mgreiler/code-review-checklist/
Modified 2023– by Matter Labs,
some extracts from https://www.codereviewchecklist.com added,
Copyright (c) 2020 Lee Englestone
also MIT License.

Permission is hereby granted, free of charge, to any person obtaining a copy
of this software and associated documentation files (the "Software"), to deal
in the Software without restriction, including without limitation the rights
to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
copies of the Software, and to permit persons to whom the Software is
furnished to do so, subject to the following conditions:

The above copyright notice and this permission notice shall be included in all
copies or substantial portions of the Software.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
SOFTWARE.
 -->
