### PR TITLE
[EraVM] Fix EraVMCombineAddressingMode::mergeSelect for SEL with stac…

### DIFF
--- a/llvm/test/CodeGen/EraVM/def-spill.ll
+++ b/llvm/test/CodeGen/EraVM/def-spill.ll
@@ -17,6 +17,36 @@ define i256 @spill_addr(i256 %a, i256 %b) nounwind {
   ret i256 %res
 }
 
+; CHECK-LABEL: spill_addr_selirs_use
+define i256 @spill_addr_selirs_use(i256 %a, i256 %b, i1 %cond) nounwind {
+  %slot = alloca i256
+  ; CHECK: add r1, r2, stack-[1]
+  %x = add i256 %a, %b
+  ; CHECK: sub! r3, r0, r0
+  ; CHECK: add stack-[1], r0, stack-[2]
+  ; CHECK: add.ne 1234, r0, stack-[2]
+  %sel = select i1 %cond, i256 1234, i256 %x
+  store i256 %sel, i256* %slot
+  %c = call i256 @foo()
+  %res = add i256 %x, %c
+  ret i256 %res
+}
+
+; CHECK-LABEL: spill_addr_selris_use
+define i256 @spill_addr_selris_use(i256 %a, i256 %b, i1 %cond) nounwind {
+  %slot = alloca i256
+  ; CHECK: add r1, r2, stack-[1]
+  %x = add i256 %a, %b
+  ; CHECK: sub! r3, r0, r0
+  ; CHECK: add 1234, r0, stack-[2]
+  ; CHECK: add.ne stack-[1], r0, stack-[2]
+  %sel = select i1 %cond, i256 %x, i256 1234
+  store i256 %sel, i256* %slot
+  %c = call i256 @foo()
+  %res = add i256 %x, %c
+  ret i256 %res
+}
+
 ; CHECK-LABEL: spill_addi
 define i256 @spill_addi(i256 %a) nounwind {
   ; TODO: CPR-1221 add 42, r2, stack-[1]

--- a/llvm/test/CodeGen/EraVM/reload-use.ll
+++ b/llvm/test/CodeGen/EraVM/reload-use.ll
@@ -420,6 +420,30 @@ define i256 @spill_select(i256 %a, i1 %cond) nounwind {
   ret i256 %res
 }
 
+; CHECK-LABEL: spill_selrrs1
+define void @spill_selrrs1(i256 %a, i1 %cond) nounwind {
+  %slot = alloca i256
+  %b = call i256 @foo()
+; CHECK: sub! stack-[1], r0, r0
+; CHECK: add r1, r0, stack-[3]
+; CHECK: add.ne stack-[2], r0, stack-[3]
+  %sel = select i1 %cond, i256 %a, i256 %b
+  store i256 %sel, i256* %slot
+  ret void
+}
+
+; CHECK-LABEL: spill_selrrs2
+define void @spill_selrrs2(i256 %a, i1 %cond) nounwind {
+  %slot = alloca i256
+  %b = call i256 @foo()
+; CHECK: sub! stack-[1], r0, r0
+; CHECK: add stack-[2], r0, stack-[3]
+; CHECK: add.ne r1, r0, stack-[3]
+  %sel = select i1 %cond, i256 %b, i256 %a
+  store i256 %sel, i256* %slot
+  ret void
+}
+
 ; ==============================================================================
 ; CHECK-LABEL: spill_multiple_use
 define void @spill_multiple_use(i256 %a) nounwind {


### PR DESCRIPTION
…k as output

This patch fixes the issue in mergeSelect where Base is SEL with stack as output and that output operand is not copied to the newly created SEL. This happens when we are replacing second operand of SEL (IsIn0 is false) with In, and we are not copying rest of the operands, just conditional code.