### PR TITLE
ci: add capability to run regression tests under valgrind

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -34,6 +34,11 @@ on:
         required: false
         type: boolean
         default: true
+      enable-valgrind:
+        required: false
+        default: 'false'
+        type: string
+        description: 'Run LLVM regression tests under valgrind.'
 
 
 jobs:
@@ -91,6 +96,7 @@ jobs:
           clone-llvm: false
           ccache-key-type: 'static'
           save-ccache: ${{ matrix.name == 'Linux x86' }}
+          enable-valgrind: ${{ inputs.enable-valgrind }}
 
       # Required to keep executable permissions for binaries
       - name: Prepare tarball

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -17,6 +17,11 @@ on:
         default: 'Address'
         type: string
         description: 'A sanitizer to build LLVM with. Possible values are Address, Memory, MemoryWithOrigins, Undefined, Thread, DataFlow, and Address;Undefined'
+      enable-valgrind:
+        required: false
+        default: 'false'
+        type: string
+        description: 'Run LLVM regression tests under valgrind.'
 
 defaults:
   run:
@@ -170,6 +175,7 @@ jobs:
           clone-llvm: false
           ccache-key-type: 'static' # rotate ccache key every month
           sanitizer: ${{ inputs.llvm-sanitizer }}
+          enable-valgrind: ${{ inputs.enable-valgrind }}
 
       # `verify-llvm` is a special target that runs all the regression tests
       # it includes `check-llvm` and special codegen tests


### PR DESCRIPTION
# Code Review Checklist


## Purpose

Add the capability to run tests under `valgrind`.

