### PR TITLE
[APInt] Replace an assertion in constructor with fatal error

### DIFF
--- a/llvm/include/llvm/ADT/APInt.h
+++ b/llvm/include/llvm/ADT/APInt.h
@@ -16,6 +16,9 @@
 #define LLVM_ADT_APINT_H
 
 #include "llvm/Support/Compiler.h"
+// EraVM local begin
+#include "llvm/Support/ErrorHandling.h"
+// EraVM local end
 #include "llvm/Support/MathExtras.h"
 #include <cassert>
 #include <climits>
@@ -113,13 +116,21 @@ public:
       : BitWidth(numBits) {
     if (!implicitTrunc) {
       if (BitWidth == 0) {
-        assert(val == 0 && "Value must be zero for 0-bit APInt");
+        // EraVM local begin
+        if (val != 0)
+          report_fatal_error("APInt error: Value must be zero for 0-bit APInt");
+        // EraVM local end
       } else if (isSigned) {
-        assert(llvm::isIntN(BitWidth, val) &&
-               "Value is not an N-bit signed value");
+        // EraVM local begin
+        if (!llvm::isIntN(BitWidth, val))
+          report_fatal_error("APInt error: Value is not an N-bit signed value");
+        // EraVM local end
       } else {
-        assert(llvm::isUIntN(BitWidth, val) &&
-               "Value is not an N-bit unsigned value");
+        // EraVM local begin
+        if (!llvm::isUIntN(BitWidth, val))
+          report_fatal_error(
+              "APInt error: Value is not an N-bit unsigned value");
+        // EraVM local end
       }
     }
     if (isSingleWord()) {

--- a/llvm/unittests/ADT/APIntTest.cpp
+++ b/llvm/unittests/ADT/APIntTest.cpp
@@ -3193,4 +3193,13 @@ TEST(APIntTest, TryExt) {
   ASSERT_EQ(42, APInt(128, -1).trySExtValue().value_or(42));
 }
 
+// EraVM local begin
+#ifdef GTEST_HAS_DEATH_TEST
+TEST(APIntTest, DiagnoseZExt) {
+  EXPECT_DEATH((void)APInt(32, -1, false),
+               "Value is not an N-bit unsigned value");
+}
+#endif
+// EraVM local end
+
 } // end anonymous namespace


### PR DESCRIPTION
The patch replaces assertions in APInt constructor with `report_fatal_error` calls.
EraVM compiler is shipped to users w.o. assertions enabled, but zero extensions of negative numbers is a strong signal that a transformation which called the constructor has a bug. In that case we prefer to fail with diagnostic instead of miscompiling a module even if false positives could happen.