### PR TITLE
ci: update runner labels to high performance

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -55,7 +55,7 @@ jobs:
           WINDOWS='{"name":"Windows","runner":"windows-2022-github-hosted-64core"}'
           MACOS_AMD64='{"name":"MacOS-x86","runner":"macos-12-large"}'
           MACOS_ARM64='{"name":"MacOS-arm64","runner":["self-hosted","macOS","ARM64"]}'
-          LINUX_AMD64='{"name":"Linux-AMD64","runner":"matterlabs-ci-runner","image":"ghcr.io/matter-labs/zksync-llvm-runner:latest"}'
+          LINUX_AMD64='{"name":"Linux-AMD64","runner":"matterlabs-ci-runner-high-performance","image":"ghcr.io/matter-labs/zksync-llvm-runner:latest"}'
           LINUX_ARM64='{"name":"Linux-ARM64","runner":"matterlabs-ci-runner-arm","image":"ghcr.io/matter-labs/zksync-llvm-runner:latest"}'
           # Disable platforms for non-tag builds if user requested
           if [ ${GITHUB_EVENT_NAME} = workflow_dispatch ]; then

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   run-with-coverage:
-    runs-on: [ci-runner-compiler, Linux]
+    runs-on: matterlabs-ci-runner-high-performance
     container:
       image: ghcr.io/matter-labs/zksync-llvm-runner:latest
       options: -m 110g


### PR DESCRIPTION
# Code Review Checklist

Update CI runners labels for x86 to `high-performance` after runners rework by devops.
