### PR TITLE
ci: always use target machine with integration tests and benchmarks

### DIFF
--- a/.github/workflows/benchmarks-integration-tests.yml
+++ b/.github/workflows/benchmarks-integration-tests.yml
@@ -99,7 +99,7 @@ jobs:
         shell: bash -ex {0}
         run: |
           if [[ "${{ join(steps.*.outputs.*) }}" == "" ]]; then
-            echo "machine=default" | tee -a "${GITHUB_OUTPUT}"
+            echo "machine=eravm" | tee -a "${GITHUB_OUTPUT}"
           fi
 
   # Benchmarks workflow call from the era-compiler-ci repository


### PR DESCRIPTION
# Code Review Checklist

Always pass the default `--target` machine parameter to the `era-compiler-tester`.

Defaults to `eravm` for now.

