### PR TITLE
ci: fix mandatory target argument for LLVM coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Run tests with coverage for EraVM
         run: |
           ./target/${TARGET}/release/compiler-tester \
-            --target "${TARGET}" \
+            --target eravm \
             --zksolc "./target-zksolc/${TARGET}/debug/zksolc" \
             --zkvyper "./target-zksolc/${TARGET}/debug/zkvyper" \
             --path '${{ inputs.path || env.DEFAULT_BENCHMARKS_PATH }}' \


### PR DESCRIPTION
# Code Review Checklist

Fix mandatory target argument for LLVM coverage workflow.