### PR TITLE
ci: use llvm-18 docker image for code coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,7 +32,8 @@ jobs:
   run-with-coverage:
     runs-on: matterlabs-ci-runner-high-performance
     container:
-      image: ghcr.io/matter-labs/zksync-llvm-runner:latest
+      # Use LLVM 18 image for coverage for compatible profraw formats
+      image: ghcr.io/matter-labs/zksync-llvm-runner:1.0.2
       options: -m 110g
     env:
       TARGET: x86_64-unknown-linux-gnu


### PR DESCRIPTION
# Code Review Checklist

Use `llvm-18`-based Docker image for code coverage measurements workflow.

## Purpose

Fixes [code coverage workflow failures](https://github.com/matter-labs/era-compiler-llvm/actions/runs/11909273678/job/33186333784):

```
Profile uses raw profile format version = 9; expected version = 10
```
