### PR TITLE
[EraVM] Fix shared libs build

### DIFF
--- a/llvm/lib/MC/MCC/CMakeLists.txt
+++ b/llvm/lib/MC/MCC/CMakeLists.txt
@@ -3,8 +3,11 @@ add_llvm_component_library(LLVMMCC
 
   LINK_COMPONENTS
   AsmParser
+  Core
   MC
+  MCDisassembler
   MCParser
+  Object
   Support
 
   DEPENDS

--- a/llvm/lib/ObjCopy/ObjCopyC/CMakeLists.txt
+++ b/llvm/lib/ObjCopy/ObjCopyC/CMakeLists.txt
@@ -6,7 +6,9 @@ add_llvm_component_library(LLVMObjCopyC
 
   LINK_COMPONENTS
   BinaryFormat
+  Core
+  MC
+  ObjCopy
   Object
   Support
-  MC
 )

--- a/llvm/lib/Target/EraVM/Disassembler/CMakeLists.txt
+++ b/llvm/lib/Target/EraVM/Disassembler/CMakeLists.txt
@@ -2,7 +2,9 @@ add_llvm_component_library(LLVMEraVMDisassembler
   EraVMDisassembler.cpp
 
   LINK_COMPONENTS
+  EraVMDesc
   EraVMInfo
+  MC
   MCDisassembler
   Support
 


### PR DESCRIPTION
Add missing dependencies to CMakeLists.txt for the following components:
- EraVM disassembler
- C interface for MC (MCC)
- C interface for objcopy (ObjCopyC)

This resolves build issues when `-DBUILD_SHARED_LIBS=On` is enabled.