### PR TITLE
fix typo Update README.md

### DIFF
--- a/clang-tools-extra/pseudo/README.md
+++ b/clang-tools-extra/pseudo/README.md
@@ -14,7 +14,7 @@ with further discussion on the [RFC].
 ## Dependencies between pseudoparser and clang
 
 Dependencies are limited because they don't make sense, but also to avoid
-placing a burden on clang mantainers.
+placing a burden on clang maintainers.
 
 The pseudoparser reuses the clang lexer (clangLex and clangBasic libraries) but
 not the higher-level libraries (Parse, Sema, AST, Frontend...).


### PR DESCRIPTION
### Title:
Fix typo in README.md

### Description:
This pull request fixes the typo "mantainers" to "maintainers" in the `README.md` file.

### Changes:
- Corrected the typo: "mantainers" to "maintainers" in `clang-tools-extra/pseudo/README.md`.

---

Please let me know if any further modifications are required.
