### PR TITLE
typo fix Update DesignNotes.md

### DIFF
--- a/clang-tools-extra/pseudo/DesignNotes.md
+++ b/clang-tools-extra/pseudo/DesignNotes.md
@@ -94,7 +94,7 @@ will soon die, as will the parent GSS Node - the latter should trigger recovery.
 ```
      "the static cast's type starts at foo"
 ---> {expr := static_cast < . type > ( expr )}
-         |     "`foo bar baz` is an unparseable type"
+         |     "`foo bar baz` is an unparsable type"
          +---- {expr := static_cast < type . > (expr)}
 ```
 


### PR DESCRIPTION
### **Title**:  
Fix typo in DesignNotes.md

### **Description**:  
This pull request fixes a typo in the `DesignNotes.md` file, specifically replacing "unparseable" with the correct term "unparsable" for clarity and accuracy.

### **Changes Made**:  
- Corrected the typo in the following line:  
  From: "`foo bar baz` is an unparseable type"  
  To: "`foo bar baz` is an unparsable type"

### **Testing/Validation**:  
- No testing is required since this is a documentation fix.

### **Related Issues**:  
- No related issues.

### **Checklist**:  
- [x] Code follows the project's coding style
- [x] Documentation has been updated
- [x] PR is ready for review
