### PR TITLE
ci: use latest docker for code coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,8 +32,7 @@ jobs:
   run-with-coverage:
     runs-on: matterlabs-ci-runner-high-performance
     container:
-      # Use LLVM 18 image for coverage for compatible profraw formats
-      image: ghcr.io/matter-labs/zksync-llvm-runner:1.0.2
+      image: ghcr.io/matter-labs/zksync-llvm-runner:latest
       options: -m 110g
     env:
       TARGET: x86_64-unknown-linux-gnu


### PR DESCRIPTION
# Code Review Checklist

Use latest docker for code coverage.

Testing workflow:
* [x] https://github.com/matter-labs/era-compiler-llvm/actions/runs/12907043998

## Purpose

To fix code coverage job failures.