### PR TITLE
ci: add support for evm benchmarks

### DIFF
--- a/.github/workflows/benchmarks-integration-tests.yml
+++ b/.github/workflows/benchmarks-integration-tests.yml
@@ -1,13 +1,9 @@
-name: Integration tests and benchmarks
+name: Tests
 
 on:
   pull_request:
   workflow_dispatch:
     inputs:
-      llvm_build_type:
-        description: "LLVM build type: debug | release"
-        required: true
-        default: "release"
       compiler_tester_reference_rev:
         description: "compiler-tester revision to use as a benchmark reference"
         required: true
@@ -106,24 +102,31 @@ jobs:
   # This is a common part of the benchmarks workflow for all repositories
   # If you would like to make a change to the benchmarks workflow, please do it in the era-compiler-ci repository
   benchmarks:
-    needs: [compiler-tester-ref, target-machine]
+    needs: [compiler-tester-ref]
     uses: matter-labs/era-compiler-ci/.github/workflows/benchmarks.yml@v1
     secrets: inherit
     strategy:
       fail-fast: false
       matrix:
-        target: ${{ needs.target-machine.outputs.* }}
+        include:
+          - target: 'eravm'
+            toolchain: 'ir-llvm'
+            environment: 'zk_evm'
+          - target: 'evm'
+            toolchain: 'ir-llvm'
+            environment: 'EVMInterpreter'
     with:
-      llvm_build_type: ${{ github.event.inputs.llvm_build_type }}
       compiler_tester_reference_branch: ${{ needs.compiler-tester-ref.outputs.reference-ref }}
       compiler_tester_candidate_branch: ${{ needs.compiler-tester-ref.outputs.candidate-ref }}
       compiler_llvm_reference_branch: ${{ github.event.inputs.compiler_llvm_reference_branch || github.event.repository.default_branch }}
       compiler_llvm_candidate_branch: ${{ github.event.inputs.compiler_llvm_candidate_branch || github.head_ref }}
       compiler_llvm_benchmark_mode: ${{ github.event.inputs.compiler_llvm_benchmark_mode || '^M^B3' }}
       compiler_llvm_benchmark_path: ${{ github.event.inputs.compiler_llvm_benchmark_path || '' }}
-      ccache-key-type: 'static' # rotate ccache key every month
       compiler-llvm-repo: ${{ github.event.pull_request.head.repo.full_name }} # required to properly test forks
       target-machine: ${{ matrix.target }}
+      toolchain: ${{ matrix.toolchain }}
+      ccache-key: 'llvm-Linux-X64-gnu'
+      environment: ${{ matrix.environment }}
 
   # Integration tests workflow call from the era-compiler-ci repository
   # This is a common part of the integration tests workflow for all repositories
@@ -139,6 +142,6 @@ jobs:
     with:
       compiler-tester-ref: ${{ needs.compiler-tester-ref.outputs.candidate-ref }}
       llvm-ref: ${{ github.event.inputs.compiler_llvm_candidate_branch || github.head_ref || github.event.repository.default_branch }}
-      ccache-key-type: 'static' # rotate ccache key every month
       compiler-llvm-repo: ${{ github.event.pull_request.head.repo.full_name }} # required to properly test forks
       target-machine: ${{ matrix.target }}
+      ccache-key: 'llvm-Linux-X64-gnu'

--- a/.github/workflows/cache-regen.yml
+++ b/.github/workflows/cache-regen.yml
@@ -41,6 +41,11 @@ jobs:
     name: ${{ matrix.name }}
     steps:
 
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          path: "llvm"
+
       - name: Build LLVM for tests
         uses: matter-labs/era-compiler-ci/.github/actions/build-llvm@v1
         with:
@@ -49,6 +54,7 @@ jobs:
           save-ccache: 'false'
           enable-tests: 'true'
           enable-assertions: 'true'
+          clone-llvm: 'false'
           ccache-key: ${{ format('llvm-{0}-{1}-{2}', runner.os, runner.arch, 'gnu') }}
 
       - name: Build LLVM for benchmarks


### PR DESCRIPTION
# Code Review Checklist

Add support for `evm` benchmarks together with `eravm` with 2 reports in PRs.
