### PR TITLE
ci: add ccache regen workflow to update caches

### DIFF
--- a/.github/workflows/cache-regen.yml
+++ b/.github/workflows/cache-regen.yml
@@ -1,0 +1,62 @@
+name: Cache regen
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 20 * * *' # each day at 8 PM GMT
+
+# Cancel the workflow if any new changes pushed to a feature branch or the trunk
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  cleanup-ccache:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Clean up cache
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh cache list
+          gh cache delete --all || true
+
+  regen-ccache:
+    needs: cleanup-ccache
+    strategy:
+      fail-fast: false # finalize testing of all targets even if one failed
+      matrix:
+        include:
+          - name: "Linux x86 gnu"
+            runner: matterlabs-ci-runner-high-performance
+            image: ghcr.io/matter-labs/zksync-llvm-runner:latest
+            target: "x86_64-unknown-linux-gnu"
+    runs-on: ${{ matrix.runner }}
+    container:
+      image: ${{ matrix.image || '' }} # Special workaround to allow matrix builds with optional container
+    name: ${{ matrix.name }}
+    steps:
+
+      - name: Build LLVM for tests
+        uses: matter-labs/era-compiler-ci/.github/actions/build-llvm@v1
+        with:
+          target-env: ${{ contains(matrix.target, 'musl') && 'musl' || 'gnu' }}
+          build-type: RelWithDebInfo
+          save-ccache: 'false'
+          enable-tests: 'true'
+          enable-assertions: 'true'
+          ccache-key: ${{ format('llvm-{0}-{1}-{2}', runner.os, runner.arch, 'gnu') }}
+
+      - name: Build LLVM for benchmarks
+        uses: matter-labs/era-compiler-ci/.github/actions/build-llvm@v1
+        with:
+          target-env: ${{ contains(matrix.target, 'musl') && 'musl' || 'gnu' }}
+          enable-assertions: 'false'
+          build-type: Release
+          save-ccache: 'true'
+          clone-llvm: 'false'
+          ccache-key: ${{ format('llvm-{0}-{1}-{2}', runner.os, runner.arch, 'gnu') }}


### PR DESCRIPTION
# Code Review Checklist

Add `ccache` regen workflow to update caches.

## Purpose

To speed up LLVM builds.