### PR TITLE
ci: use pinned tj-actions/changed-files v39

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v39
+        uses: tj-actions/changed-files@fea790cb660e33aef4bdf07304e28fedd77dfa13 # v39
         with:
           separator: ","
           sha: ${{ matrix.commit }}


### PR DESCRIPTION
# Code Review Checklist

## Purpose
All versions of the Github Action `tj-actions/changed-files` are currently compromised with malicious code. This moves the GH action to a pinned commit of v39 to avoid pulling the malicious code (same as used across other matter-labs repos)

See: https://github.com/tj-actions/changed-files/issues/2463

