### PR TITLE
[EVM] Disable tail duplication optimization

### DIFF
--- a/llvm/lib/Target/EVM/EVMTargetMachine.cpp
+++ b/llvm/lib/Target/EVM/EVMTargetMachine.cpp
@@ -164,7 +164,9 @@ namespace {
 class EVMPassConfig final : public TargetPassConfig {
 public:
   EVMPassConfig(EVMTargetMachine &TM, PassManagerBase &PM)
-      : TargetPassConfig(TM, PM) {}
+      : TargetPassConfig(TM, PM) {
+    disablePass(&EarlyTailDuplicateID);
+  }
 
   EVMTargetMachine &getEVMTargetMachine() const {
     return getTM<EVMTargetMachine>();
@@ -232,6 +234,7 @@ void EVMPassConfig::addPostRegAlloc() {
   disablePass(&LiveDebugValuesID);
   disablePass(&PatchableFunctionID);
   disablePass(&ShrinkWrapID);
+  disablePass(&TailDuplicateID);
 
   // TODO: This pass is disabled in WebAssembly, as it hurts code size because
   // it can generate irreducible control flow. Check if this also true for EVM?

--- a/llvm/test/CodeGen/EVM/bps-inifinite-loop-bug.ll
+++ b/llvm/test/CodeGen/EVM/bps-inifinite-loop-bug.ll
@@ -1,0 +1,38 @@
+; RUN: llc -O3 < %s
+
+; This test case is reduced with llvm-reduce.
+; Before the fix, we had an infinite loop in EVMStackSolver::runPropagation,
+; because EarlyTailDuplicate merged header and latch blocks. This caused
+; MachineLoopInfo not to detect the loop correctly, thus running into an
+; infinite loop.
+
+target datalayout = "E-p:256:256-i256:256:256-S256-a:256:256"
+target triple = "evm"
+
+; Function Attrs: nounwind willreturn memory(none)
+declare i256 @llvm.evm.signextend(i256, i256) #0
+
+define void @test(i1 %comparison_result6, i256 %mulmod1446) {
+entry:
+  br i1 %comparison_result6, label %"block_rt_2/0", label %shift_right_non_overflow
+
+"block_rt_2/0":                                   ; preds = %entry
+  unreachable
+
+"block_rt_66/0":                                  ; preds = %division_join1531, %shift_right_non_overflow
+  br i1 %division_is_divider_zero1455, label %division_join1453, label %division_join1531
+
+shift_right_non_overflow:                         ; preds = %entry
+  %division_is_divider_zero1455 = icmp eq i256 %mulmod1446, 0
+  br label %"block_rt_66/0"
+
+division_join1453:                                ; preds = %"block_rt_66/0"
+  %signextend1463 = tail call i256 @llvm.evm.signextend(i256 0, i256 0)
+  br label %division_join1531
+
+division_join1531:                                ; preds = %division_join1453, %"block_rt_66/0"
+  store i256 0, ptr addrspace(1) null, align 4294967296
+  br label %"block_rt_66/0"
+}
+
+attributes #0 = { nounwind willreturn memory(none) }

--- a/llvm/test/CodeGen/EVM/br.ll
+++ b/llvm/test/CodeGen/EVM/br.ll
@@ -19,11 +19,13 @@ define i256 @diamond(i256 %rs1, i256 %rs2) nounwind {
 ; CHECK-NEXT:    SWAP2
 ; CHECK-NEXT:    POP
 ; CHECK-NEXT:    MUL
-; CHECK-NEXT:    SWAP1
+; CHECK-NEXT:    PUSH4 @.BB0_3
 ; CHECK-NEXT:    JUMP
 ; CHECK-NEXT:  .BB0_2: ; %false_bb
 ; CHECK-NEXT:    JUMPDEST
 ; CHECK-NEXT:    ADD
+; CHECK-NEXT:  .BB0_3: ; %end_bb
+; CHECK-NEXT:    JUMPDEST
 ; CHECK-NEXT:    SWAP1
 ; CHECK-NEXT:    JUMP
 

--- a/llvm/test/CodeGen/EVM/machine-sink-cheap-instructions.ll
+++ b/llvm/test/CodeGen/EVM/machine-sink-cheap-instructions.ll
@@ -16,7 +16,7 @@ define i256 @test1(i256 %arg) {
 ; CHECK-NEXT:    JUMPI
 ; CHECK-NEXT:  ; %bb.1:
 ; CHECK-NEXT:    PUSH0
-; CHECK-NEXT:    SWAP1
+; CHECK-NEXT:    PUSH4 @.BB0_3
 ; CHECK-NEXT:    JUMP
 ; CHECK-NEXT:  .BB0_2: ; %bb1
 ; CHECK-NEXT:    JUMPDEST
@@ -24,6 +24,8 @@ define i256 @test1(i256 %arg) {
 ; CHECK-NEXT:    PUSH4 @bar
 ; CHECK-NEXT:    JUMP
 ; CHECK-NEXT:  .FUNC_RET0:
+; CHECK-NEXT:    JUMPDEST
+; CHECK-NEXT:  .BB0_3: ; %bb2
 ; CHECK-NEXT:    JUMPDEST
 ; CHECK-NEXT:    SWAP1
 ; CHECK-NEXT:    JUMP
@@ -50,7 +52,7 @@ define i256 @test2(i256 %arg) {
 ; CHECK-NEXT:    JUMPI
 ; CHECK-NEXT:  ; %bb.1:
 ; CHECK-NEXT:    ADDRESS
-; CHECK-NEXT:    SWAP1
+; CHECK-NEXT:    PUSH4 @.BB1_3
 ; CHECK-NEXT:    JUMP
 ; CHECK-NEXT:  .BB1_2: ; %bb1
 ; CHECK-NEXT:    JUMPDEST
@@ -58,6 +60,8 @@ define i256 @test2(i256 %arg) {
 ; CHECK-NEXT:    PUSH4 @bar
 ; CHECK-NEXT:    JUMP
 ; CHECK-NEXT:  .FUNC_RET1:
+; CHECK-NEXT:    JUMPDEST
+; CHECK-NEXT:  .BB1_3: ; %bb2
 ; CHECK-NEXT:    JUMPDEST
 ; CHECK-NEXT:    SWAP1
 ; CHECK-NEXT:    JUMP


### PR DESCRIPTION
In some cases, tail duplication can combine a loop’s header with its latch. When this happens, MachineLoopInfo may fail to recognize the loop during stackification. This is a problem because, in EVMStackSolver::runPropagation, we add an empty exit stack for loop latches during the first run (if the header hasn’t been visited yet) to prevent infinite loops. If the loop isn’t detected, we will run into an infinite loop situation.