### PR TITLE
ci: run LNT benchmarks only for internal PRs

### DIFF
--- a/.github/workflows/lnt-benchmarks.yml
+++ b/.github/workflows/lnt-benchmarks.yml
@@ -14,6 +14,8 @@ concurrency:
 jobs:
 
   lnt-benchmarks:
+    # Run only for matter-labs pull requests, ignore for forks
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push' }}
     uses: matter-labs/era-compiler-ci/.github/workflows/lnt.yml@v1
     secrets: inherit
     with:


### PR DESCRIPTION
## What?

Run LNT benchmarks only for internal PRs.

## Why?

To protect uploading secret key to improve security.