### PR TITLE
ci: run eravm and evm targets by default in all PRs

### DIFF
--- a/.github/workflows/benchmarks-integration-tests.yml
+++ b/.github/workflows/benchmarks-integration-tests.yml
@@ -75,9 +75,8 @@ jobs:
   target-machine:
     runs-on: ubuntu-latest
     outputs:
-      evm: ${{ steps.evm.outputs.machine }}
-      eravm: ${{ steps.eravm.outputs.machine }}
-      default: ${{ steps.default.outputs.machine }}
+      evm: ${{ steps.evm.outputs.machine || steps.default.outputs.evm }}
+      eravm: ${{ steps.eravm.outputs.machine || steps.default.outputs.eravm }}
     steps:
 
       - name: Check for EraVM target
@@ -95,7 +94,8 @@ jobs:
         shell: bash -ex {0}
         run: |
           if [[ "${{ join(steps.*.outputs.*) }}" == "" ]]; then
-            echo "machine=eravm" | tee -a "${GITHUB_OUTPUT}"
+            echo "eravm=eravm" | tee -a "${GITHUB_OUTPUT}"
+            echo "evm=evm" | tee -a "${GITHUB_OUTPUT}"
           fi
 
   # Benchmarks workflow call from the era-compiler-ci repository


### PR DESCRIPTION
# Code Review Checklist

Fix target selection for integration tests and benchmarks.
If no labels specified, run both `eravm` and `evm` targets as we do in the compiler tester.