### PR TITLE
[EVM][BPS] Make EVMStackSolver to report stack-too-deep errors

### DIFF
--- a/llvm/lib/Target/EVM/EVMStackSolver.h
+++ b/llvm/lib/Target/EVM/EVMStackSolver.h
@@ -45,15 +45,20 @@ private:
   /// minimal.
   /// Side effect: the computed entry stack is stored in StackModel.
   /// \param CompressStack: remove duplicates and rematerializable slots.
-  std::pair<Stack, bool> propagateThroughMI(const Stack &ExitStack,
-                                            const MachineInstr &MI,
-                                            bool CompressStack = false);
+  Stack propagateThroughMI(const Stack &ExitStack, const MachineInstr &MI,
+                           bool CompressStack = false);
 
   /// Given \p ExitStack, compute the stack at the entry of \p MBB.
   /// \param CompressStack: remove duplicates and rematerializable slots.
   Stack propagateThroughMBB(const Stack &ExitStack,
                             const MachineBasicBlock *MBB,
                             bool CompressStack = false);
+
+  // Build the exit stack of the given \p MI.
+  Stack getMIExitStack(const MachineInstr *MI);
+
+  // Check and report for stack-too-deep errors.
+  void checkPropagationErrors();
 
   /// Main algorithm walking the graph from entry to exit and propagating stack
   /// states back to the entries. Iteratively reruns itself along backward jumps

--- a/llvm/test/CodeGen/EVM/stack-too-deep-1.ll
+++ b/llvm/test/CodeGen/EVM/stack-too-deep-1.ll
@@ -1,0 +1,201 @@
+; RUN: not --crash llc < %s -o /dev/null 2>&1 | FileCheck %s
+
+; Test that EVMStackSolver can catch errors when transformation from
+; the BBs entry stack to the entry stack of the first MI is not possible.
+
+; The stack built for the 'bad' BB is
+;
+; 20.block_rt_88/7.outer:
+;  [ %82 %85 %7 %78 %70 %11 %64 %17 %19 %54 %46 %5 %2 %40 %9 %29 %33 ]
+;
+;  [ %82 %85 %7 %78 %70 %11 %64 %17 %19 %54 %46 %5 %2 %40 %9 %82 %85 %29 %33 7 21 ]
+;  EQ
+;  [ %82 %85 %7 %78 %70 %11 %64 %17 %19 %54 %46 %5 %2 %40 %9 %82 %85 %29 %33 %72 ]
+;
+;  [ %82 %85 %7 %78 %70 %11 %64 %17 %19 %54 %46 %5 %2 %40 %9 %82 %85 %29 %33 %72 ]
+
+; CHECK:      EVMStackSolver cannot transform
+; CHECK-SAME: [ %82 %85 %7 %78 %70 %11 %64 %17 %19 %54 %46 %5 %2 %40 %9 %29 %33 ]
+; CHECK-SAME: to
+; CHECK-SAME: [ %82 %85 %7 %78 %70 %11 %64 %17 %19 %54 %46 %5 %2 %40 %9 %82 %85 %29 %33 7 21 ]
+; CHECK-SAME: : stack too deep.
+
+target datalayout = "E-p:256:256-i256:256:256-S256-a:256:256"
+target triple = "evm-unknown-unknown"
+
+define dso_local fastcc void @main() unnamed_addr {
+entry:
+  br label %"block_rt_19/0"
+
+"block_rt_19/0":                                  ; preds = %entry
+  %addition_result2158 = add nuw nsw i256 1, 20
+  %and_result2674 = and i256 %addition_result2158, 255
+  %trunc = trunc i256 %addition_result2158 to i8
+  %comparison_result3799.not = icmp eq i256 %and_result2674, 3
+  %comparison_result6184.not = icmp eq i256 %and_result2674, 24
+  %comparison_result7522.not = icmp eq i256 %and_result2674, 26
+  %comparison_result9235.not = icmp eq i256 %and_result2674, 28
+  br label %"block_rt_44/7"
+
+"block_rt_43/7":                                  ; preds = %remainder_join12933, %"block_rt_54/7.thread", %"block_rt_44/7"
+  unreachable
+
+"block_rt_44/7":                                  ; preds = %"block_rt_19/0"
+  switch i8 %trunc, label %"block_rt_51/7" [
+    i8 1, label %"block_rt_43/7"
+    i8 21, label %conditional_rt_49_join_block2921
+    i8 11, label %"block_rt_46/7"
+  ]
+
+"block_rt_46/7":                                  ; preds = %"block_rt_51/7", %"block_rt_44/7"
+  unreachable
+
+"block_rt_51/7":                                  ; preds = %"block_rt_57/7", %"block_rt_44/7"
+  %stack_var_010.1 = phi i256 [ %multiplication_result1217, %"block_rt_57/7" ], [ 1, %"block_rt_44/7" ]
+  switch i8 %trunc, label %"block_rt_54/7.thread" [
+    i8 22, label %"block_rt_46/7"
+    i8 33, label %"block_rt_54/7"
+  ]
+
+"block_rt_54/7":                                  ; preds = %"block_rt_51/7"
+  %comparison_result3562 = icmp ugt i256 %stack_var_010.1, 1
+  unreachable
+
+"block_rt_56/7.outer":                            ; preds = %"block_rt_56/7.preheader", %"block_rt_70/7"
+  %stack_var_011.8.ph = phi i256 [ 0, %"block_rt_56/7.preheader" ], [ %addition_result2182, %"block_rt_70/7" ]
+  br label %"block_rt_56/7"
+
+"block_rt_56/7":                                  ; preds = %"block_rt_64/7", %"block_rt_56/7.outer"
+  %stack_var_011.8 = phi i256 [ %addition_result2182, %"block_rt_64/7" ], [ %stack_var_011.8.ph, %"block_rt_56/7.outer" ]
+  %and_result2179 = and i256 %stack_var_011.8, 255
+  %addition_result2182 = add nuw nsw i256 %and_result2179, 2
+  br label %"block_rt_64/7"
+
+"block_rt_57/7":                                  ; preds = %"block_rt_64/7"
+  %multiplication_result1217 = shl nuw nsw i256 %stack_var_010.1, 1
+  br label %"block_rt_51/7"
+
+"block_rt_64/7":                                  ; preds = %"block_rt_56/7"
+  switch i8 %trunc, label %conditional_rt_68_join_block5874 [
+    i8 12, label %"block_rt_56/7"
+    i8 23, label %"block_rt_57/7"
+  ]
+
+"block_rt_70/7":                                  ; preds = %conditional_rt_68_join_block5874
+  %comparison_result6061 = icmp ugt i256 %and_result5861, 2
+  %or.cond = or i1 %comparison_result6184.not, %comparison_result6061
+  br i1 %or.cond, label %"block_rt_56/7.outer", label %"block_rt_73/7"
+
+"block_rt_73/7":                                  ; preds = %"block_rt_80/7", %"block_rt_70/7"
+  %stack_var_013.2 = phi i256 [ %addition_result6585, %"block_rt_80/7" ], [ 10, %"block_rt_70/7" ]
+  %and_result6465 = and i256 %stack_var_013.2, 255
+  br i1 false, label %"block_rt_123/8", label %conditional_rt_74_join_block6475
+
+"block_rt_80/7":                                  ; preds = %"block_rt_86/7"
+  %addition_result6585 = add nuw nsw i256 %stack_var_013.2, 1
+  br label %"block_rt_73/7"
+
+"block_rt_86/7":                                  ; preds = %remainder_join12901
+  br i1 %comparison_result7522.not, label %"block_rt_80/7", label %"block_rt_88/7.outer"
+
+"block_rt_88/7.outer":                            ; preds = %"block_rt_101/7", %"block_rt_86/7"
+  %stack_var_008.19.ph = phi i256 [ poison, %"block_rt_86/7" ], [ %stack_var_008.20, %"block_rt_101/7" ]
+  %stack_var_015.1.ph = phi i256 [ 10, %"block_rt_86/7" ], [ %addition_result2206, %"block_rt_101/7" ]
+  %and_result7774 = and i256 %stack_var_015.1.ph, 255
+  switch i8 %trunc, label %"block_rt_92/7" [
+    i8 7, label %conditional_rt_90_join_block7798
+    i8 27, label %"block_rt_131/7.backedge"
+  ]
+
+"block_rt_89/7":                                  ; preds = %"block_rt_95/7"
+  unreachable
+
+"block_rt_131/7.outer":                           ; preds = %conditional_rt_74_join_block6475
+  br label %"block_rt_131/7"
+
+"block_rt_92/7":                                  ; preds = %"block_rt_88/7.outer"
+  %addition_result2206 = add nuw nsw i256 %and_result7774, 1
+  br label %"block_rt_95/7"
+
+"block_rt_95/7":                                  ; preds = %"block_rt_92/7"
+  %comparison_result8476.not = icmp eq i256 %addition_result2206, 16
+  br i1 %comparison_result8476.not, label %"block_rt_89/7", label %"block_rt_96/7"
+
+"block_rt_96/7":                                  ; preds = %"block_rt_95/7"
+  switch i8 %trunc, label %"block_rt_101/7.preheader" [
+    i8 31, label %"block_rt_97/7"
+    i8 32, label %"block_rt_99/7"
+  ]
+
+"block_rt_97/7":                                  ; preds = %"block_rt_96/7"
+  unreachable
+
+"block_rt_99/7":                                  ; preds = %"block_rt_96/7"
+  unreachable
+
+"block_rt_101/7.preheader":                       ; preds = %"block_rt_96/7"
+  br label %"block_rt_101/7"
+
+"block_rt_101/7":                                 ; preds = %"block_rt_103/7", %"block_rt_101/7.preheader"
+  %stack_var_008.20 = phi i256 [ %stack_var_008.21, %"block_rt_103/7" ], [ %stack_var_008.19.ph, %"block_rt_101/7.preheader" ]
+  %or.cond20853 = or i1 %comparison_result9235.not, false
+  br i1 %or.cond20853, label %"block_rt_88/7.outer", label %remainder_join12933
+
+"block_rt_103/7":                                 ; preds = %remainder_join12933, %"block_rt_108/7"
+  %stack_var_008.21 = phi i256 [ %addition_result10002, %"block_rt_108/7" ], [ %stack_var_008.20, %remainder_join12933 ]
+  br label %"block_rt_101/7"
+
+"block_rt_108/7":                                 ; preds = %remainder_join12933
+  %and_result9999 = and i256 %stack_var_008.20, 18446744073709551615
+  %addition_result10002 = add nuw nsw i256 %and_result9999, 1
+  br label %"block_rt_103/7"
+
+"block_rt_123/8":                                 ; preds = %conditional_rt_74_join_block6475, %"block_rt_73/7"
+  %addition_result12201 = add nuw nsw i256 %and_result5861, 1
+  br label %conditional_rt_68_join_block5874
+
+"block_rt_131/7":                                 ; preds = %"block_rt_131/7.backedge", %"block_rt_131/7.outer"
+  %stack_var_014.1 = phi i256 [ 7, %"block_rt_131/7.outer" ], [ %subtraction_result7209, %"block_rt_131/7.backedge" ]
+  %and_result7206 = and i256 %stack_var_014.1, 255
+  %subtraction_result7209 = add nsw i256 %and_result7206, -1
+  br label %remainder_join12901
+
+conditional_rt_49_join_block2921:                 ; preds = %"block_rt_44/7"
+  unreachable
+
+"block_rt_54/7.thread":                           ; preds = %"block_rt_51/7"
+  br i1 %comparison_result3799.not, label %"block_rt_43/7", label %"block_rt_56/7.preheader"
+
+"block_rt_56/7.preheader":                        ; preds = %"block_rt_54/7.thread"
+  br label %"block_rt_56/7.outer"
+
+conditional_rt_68_join_block5874:                 ; preds = %"block_rt_123/8", %"block_rt_64/7"
+  %stack_var_012.2 = phi i256 [ %addition_result12201, %"block_rt_123/8" ], [ 1, %"block_rt_64/7" ]
+  %and_result5861 = and i256 %stack_var_012.2, 255
+  br label %"block_rt_70/7"
+
+conditional_rt_74_join_block6475:                 ; preds = %"block_rt_73/7"
+  switch i8 %trunc, label %"block_rt_131/7.outer" [
+    i8 5, label %conditional_rt_76_join_block6491
+    i8 25, label %"block_rt_123/8"
+  ]
+
+conditional_rt_76_join_block6491:                 ; preds = %conditional_rt_74_join_block6475
+  unreachable
+
+conditional_rt_90_join_block7798:                 ; preds = %"block_rt_88/7.outer"
+  unreachable
+
+remainder_join12901:                              ; preds = %"block_rt_131/7"
+  %remainder_result_non_zero12904 = and i256 %subtraction_result7209, 1
+  br i1 poison, label %"block_rt_131/7.backedge", label %"block_rt_86/7"
+
+"block_rt_131/7.backedge":                        ; preds = %remainder_join12901, %"block_rt_88/7.outer"
+  br label %"block_rt_131/7"
+
+remainder_join12933:                              ; preds = %"block_rt_101/7"
+  switch i8 %trunc, label %"block_rt_108/7" [
+    i8 8, label %"block_rt_43/7"
+    i8 13, label %"block_rt_103/7"
+  ]
+}

--- a/llvm/test/CodeGen/EVM/stack-too-deep-2.ll
+++ b/llvm/test/CodeGen/EVM/stack-too-deep-2.ll
@@ -1,0 +1,244 @@
+; RUN: not --crash llc < %s -o /dev/null 2>&1 | FileCheck %s
+
+; Test that EVMStackSolver can catch errors when transformation from
+; the BBs entry stack to the BBs exit stack (empty BB) is not possible.
+
+; The stack built for the 'bad' BB is
+;
+; 69.:
+; 	[ RET %137 %8 %0 %105 %131 %154 %126 %18 %26 %28 %20 %81 %7 %19 %85 %3 %137 %16 %58 %63 ]
+;
+; 	[ RET %137 %20 %16 %0 %105 %131 %154 %126 %18 %26 %58 %137 %7 %19 %85 %81 %63 %3 %8 1 255 %28 ]
+
+; CHECK:      EVMStackSolver cannot transform
+; CHECK-SAME: [ RET %137 %8 %0 %105 %131 %154 %126 %18 %26 %28 %20 %81 %7 %19 %85 %3 %137 %16 %58 %63 ]
+; CHECK-SAME: to
+; CHECK-SAME: [ RET %137 %20 %16 %0 %105 %131 %154 %126 %18 %26 %58 %137 %7 %19 %85 %81 %63 %3 %8 1 255 %28 ]
+; CHECK-SAME: : stack too deep.
+
+target datalayout = "E-p:256:256-i256:256:256-S256-a:256:256"
+target triple = "evm-unknown-unknown"
+
+declare i256 @checked_mul_uint8(i256)
+
+define private fastcc i256 @fun_test_462(i256 %0) unnamed_addr {
+entry:
+  %and_result3 = and i256 %0, 255
+  %trunc = trunc i256 %0 to i8
+  %comparison_result38 = icmp eq i256 %and_result3, 22
+  %comparison_result45 = icmp eq i256 %and_result3, 33
+  %comparison_result68 = icmp eq i256 %and_result3, 3
+  %comparison_result113 = icmp eq i256 %and_result3, 4
+  %comparison_result126 = icmp eq i256 %and_result3, 24
+  %comparison_result187 = icmp eq i256 %and_result3, 26
+  %comparison_result237 = icmp eq i256 %and_result3, 31
+  %comparison_result255 = icmp eq i256 %and_result3, 32
+  %comparison_result282 = icmp eq i256 %and_result3, 28
+  %comparison_result330 = icmp eq i256 %and_result3, 6
+  br label %for_condition
+
+return.loopexit572.split.loop.exit599:            ; preds = %if_join42
+  %var_cnt.2.mux.le = select i1 %spec.select, i256 %var_cnt.2, i256 30
+  br label %return
+
+return:                                           ; preds = %if_join295, %for_join195, %for_body193, %for_body132, %if_join110, %checked_mul_uint8_1420.exit, %for_body, %for_condition, %return.loopexit572.split.loop.exit599
+  %return_pointer.0 = phi i256 [ 10, %checked_mul_uint8_1420.exit ], [ %var_cnt.2.mux.le, %return.loopexit572.split.loop.exit599 ], [ 80, %if_join295 ], [ 70, %for_body193 ], [ 60, %for_join195 ], [ 50, %for_body132 ], [ 40, %if_join110 ], [ 0, %for_body ], [ %var_cnt.0, %for_condition ]
+  ret i256 %return_pointer.0
+
+for_condition:                                    ; preds = %for_increment, %entry
+  %var_i.0 = phi i256 [ 0, %entry ], [ %addition_result348, %for_increment ]
+  %var_cnt.0 = phi i256 [ 0, %entry ], [ %var_cnt.1, %for_increment ]
+  %comparison_result = icmp ult i256 %var_i.0, 2
+  br i1 %comparison_result, label %for_body, label %return
+
+for_body:                                         ; preds = %for_condition
+  switch i8 %trunc, label %for_condition22 [
+    i8 1, label %checked_mul_uint8_1420.exit
+    i8 21, label %return
+    i8 11, label %for_increment
+  ]
+
+for_increment:                                    ; preds = %for_condition22, %for_body
+  %var_cnt.1 = phi i256 [ %var_cnt.0, %for_body ], [ %var_cnt.2, %for_condition22 ]
+  %addition_result348 = add nuw nsw i256 %var_i.0, 1
+  br label %for_condition
+
+checked_mul_uint8_1420.exit:                      ; preds = %for_body
+  br label %return
+
+for_condition22:                                  ; preds = %for_join65, %for_body
+  %var_j.0 = phi i256 [ %checked_mul_uint8_call, %for_join65 ], [ 1, %for_body ]
+  %var_cnt.2 = phi i256 [ %var_cnt.3.lcssa541, %for_join65 ], [ %var_cnt.0, %for_body ]
+  %comparison_result29 = icmp ugt i256 %var_j.0, 3
+  %or.cond = or i1 %comparison_result38, %comparison_result29
+  br i1 %or.cond, label %for_increment, label %if_join42
+
+if_join42:                                        ; preds = %for_condition22
+  %comparison_result55 = icmp ugt i256 %var_j.0, 1
+  %spec.select = and i1 %comparison_result45, %comparison_result55
+  %brmerge = or i1 %spec.select, %comparison_result68
+  br i1 %brmerge, label %return.loopexit572.split.loop.exit599, label %for_condition62.outer
+
+for_condition62.outer:                            ; preds = %if_join117, %if_join42
+  %var_p.0.ph = phi i256 [ 0, %if_join42 ], [ %addition_result.i, %if_join117 ]
+  %var_cnt.3.ph = phi i256 [ %var_cnt.2, %if_join42 ], [ %var_cnt.5, %if_join117 ]
+  br label %for_condition62
+
+for_condition62:                                  ; preds = %if_join84, %for_condition62.outer
+  %var_p.0 = phi i256 [ %addition_result.i, %if_join84 ], [ %var_p.0.ph, %for_condition62.outer ]
+  %and_result.i410 = and i256 %var_p.0, 255
+  %comparison_result.i = icmp ugt i256 %and_result.i410, 253
+  br i1 %comparison_result.i, label %shift_left_non_overflow.i411, label %checked_add_uint8.exit
+
+for_join65:                                       ; preds = %if_join84, %checked_add_uint8.exit
+  %var_cnt.3.lcssa541 = phi i256 [ %var_cnt.2, %if_join84 ], [ %var_cnt.3.ph, %checked_add_uint8.exit ]
+  %checked_mul_uint8_call = tail call fastcc i256 @checked_mul_uint8(i256 %var_j.0)
+  br label %for_condition22
+
+shift_left_non_overflow.i411:                     ; preds = %if_join309, %for_condition62
+  unreachable
+
+checked_add_uint8.exit:                           ; preds = %for_condition62
+  %addition_result.i = add nuw nsw i256 %and_result.i410, 2
+  %and_result78 = and i256 %addition_result.i, 7
+  %comparison_result80 = icmp eq i256 %and_result78, 0
+  br i1 %comparison_result80, label %for_join65, label %if_join84
+
+if_join84:                                        ; preds = %checked_add_uint8.exit
+  %trunc2 = trunc i256 %and_result78 to i8
+  switch i8 %trunc2, label %if_join110 [
+    i8 12, label %for_condition62
+    i8 23, label %for_join65
+  ]
+
+if_join110:                                       ; preds = %increment_uint8.exit, %if_join84
+  %var_h.0 = phi i256 [ %addition_result.i414, %increment_uint8.exit ], [ 1, %if_join84 ]
+  %var_cnt.5 = phi i256 [ %var_cnt.6.lcssa, %increment_uint8.exit ], [ %var_cnt.3.ph, %if_join84 ]
+  br i1 %comparison_result113, label %return, label %if_join117
+
+if_join117:                                       ; preds = %if_join110
+  %comparison_result119 = icmp ugt i256 %var_h.0, 2
+  %or.cond401 = or i1 %comparison_result126, %comparison_result119
+  br i1 %or.cond401, label %for_condition62.outer, label %for_condition131
+
+for_condition131:                                 ; preds = %for_join159, %if_join117
+  %var_k.0 = phi i256 [ %addition_result336, %for_join159 ], [ 10, %if_join117 ]
+  %var_cnt.6 = phi i256 [ %var_cnt.7.ph645, %for_join159 ], [ %var_cnt.5, %if_join117 ]
+  %comparison_result137 = icmp ult i256 %var_k.0, 12
+  br i1 %comparison_result137, label %for_body132, label %increment_uint8.exit
+
+for_body132:                                      ; preds = %for_condition131
+  %trunc3 = trunc i256 %var_cnt.6 to i8
+  switch i8 %trunc3, label %if_join167.outer [
+    i8 5, label %return
+    i8 25, label %increment_uint8.exit
+  ]
+
+increment_uint8.exit:                             ; preds = %for_body132, %for_condition131
+  %var_cnt.6.lcssa = phi i256 [ %var_cnt.6, %for_condition131 ], [ %var_cnt.5, %for_body132 ]
+  %addition_result.i414 = add nuw nsw i256 %var_h.0, 1
+  br label %if_join110
+
+for_join159:                                      ; preds = %if_join184, %if_join167
+  %addition_result336 = add nuw nsw i256 %var_k.0, 1
+  br label %for_condition131
+
+if_join167.outer:                                 ; preds = %if_join167.outer.backedge, %for_body132
+  %var_x.0.ph = phi i256 [ %addition_result, %if_join167.outer.backedge ], [ 7, %for_body132 ]
+  %var_cnt.7.ph645 = phi i256 [ %var_cnt.7.ph645.be, %if_join167.outer.backedge ], [ %var_cnt.6, %for_body132 ]
+  br label %if_join167
+
+if_join167:                                       ; preds = %if_join175, %if_join167.outer
+  %var_x.0 = phi i256 [ %addition_result, %if_join175 ], [ %var_x.0.ph, %if_join167.outer ]
+  %and_result161 = and i256 %var_x.0, 255
+  %addition_result = add nsw i256 %and_result161, -1
+  %comparison_result171 = icmp eq i256 %addition_result, 0
+  br i1 %comparison_result171, label %for_join159, label %if_join175
+
+if_join175:                                       ; preds = %if_join167
+  %and_result177 = and i256 %addition_result, 1
+  %comparison_result180 = icmp eq i256 %and_result177, 0
+  br i1 %comparison_result180, label %if_join167, label %if_join184
+
+if_join184:                                       ; preds = %if_join175
+  br i1 %comparison_result187, label %for_join159, label %for_condition192.outer
+
+for_condition192.outer:                           ; preds = %for_condition271, %if_join184
+  %var_y.0.ph = phi i256 [ 10, %if_join184 ], [ %addition_result.i427, %for_condition271 ]
+  %var_cnt.9.ph = phi i256 [ %var_cnt.7.ph645, %if_join184 ], [ %var_cnt.11, %for_condition271 ]
+  br label %for_condition192
+
+for_condition192:                                 ; preds = %for_condition192.backedge, %for_condition192.outer
+  %var_y.0 = phi i256 [ %var_y.0.ph, %for_condition192.outer ], [ %addition_result.i427, %for_condition192.backedge ]
+  %comparison_result198 = icmp ult i256 %var_y.0, 17
+  br i1 %comparison_result198, label %for_body193, label %for_join195
+
+for_body193:                                      ; preds = %for_condition192
+  switch i8 %trunc, label %checked_add_t_uint8.exit [
+    i8 7, label %return
+    i8 27, label %if_join167.outer.backedge
+  ]
+
+for_join195:                                      ; preds = %if_join228, %for_condition192
+  br i1 %comparison_result330, label %return, label %if_join167.outer.backedge
+
+if_join167.outer.backedge:                        ; preds = %if_join252, %for_join195, %for_body193
+  %var_cnt.7.ph645.be = phi i256 [ %var_cnt.9.ph, %for_join195 ], [ %var_cnt.7.ph645, %for_body193 ], [ %var_cnt.9.ph, %if_join252 ]
+  br label %if_join167.outer
+
+checked_add_t_uint8.exit:                         ; preds = %for_body193
+  %addition_result.i427 = add nuw nsw i256 %var_y.0, 1
+  %remainder_result_non_zero.lhs.trunc = trunc nuw i256 %addition_result.i427 to i8
+  %remainder_result_non_zero429 = urem i8 %remainder_result_non_zero.lhs.trunc, 3
+  %comparison_result224 = icmp eq i8 %remainder_result_non_zero429, 0
+  br i1 %comparison_result224, label %for_condition192.backedge, label %if_join228
+
+if_join228:                                       ; preds = %checked_add_t_uint8.exit
+  %comparison_result230 = icmp eq i256 %addition_result.i427, 16
+  br i1 %comparison_result230, label %for_join195, label %if_join234
+
+if_join234:                                       ; preds = %if_join228
+  %comparison_result247 = icmp ugt i256 %var_y.0, 10
+  %spec.select402 = and i1 %comparison_result237, %comparison_result247
+  br i1 %spec.select402, label %for_condition192.backedge, label %if_join252
+
+for_condition192.backedge:                        ; preds = %if_join234, %checked_add_t_uint8.exit
+  br label %for_condition192
+
+if_join252:                                       ; preds = %if_join234
+  %comparison_result265 = icmp ugt i256 %var_y.0, 12
+  %spec.select403 = and i1 %comparison_result255, %comparison_result265
+  br i1 %spec.select403, label %if_join167.outer.backedge, label %for_condition271
+
+for_condition271:                                 ; preds = %for_increment273, %if_join252
+  %var_l.0 = phi i256 [ %addition_result326, %for_increment273 ], [ 0, %if_join252 ]
+  %var_cnt.11 = phi i256 [ %var_cnt.12, %for_increment273 ], [ %var_cnt.9.ph, %if_join252 ]
+  %comparison_result277 = icmp ugt i256 %var_l.0, 3
+  %or.cond404 = or i1 %comparison_result282, %comparison_result277
+  br i1 %or.cond404, label %for_condition192.outer, label %if_join286
+
+for_increment273:                                 ; preds = %if_join318, %if_join295, %if_join286
+  %var_cnt.12 = phi i256 [ %var_cnt.11, %if_join286 ], [ %addition_result312, %if_join318 ], [ %var_cnt.11, %if_join295 ]
+  %addition_result326 = add nuw nsw i256 %var_l.0, 1
+  br label %for_condition271
+
+if_join286:                                       ; preds = %for_condition271
+  %and_result288 = and i256 %var_l.0, 1
+  %comparison_result291 = icmp eq i256 %and_result288, 0
+  br i1 %comparison_result291, label %for_increment273, label %if_join295
+
+if_join295:                                       ; preds = %if_join286
+  switch i8 %trunc, label %if_join309 [
+    i8 8, label %return
+    i8 13, label %for_increment273
+  ]
+
+if_join309:                                       ; preds = %if_join295
+  %and_result311 = and i256 %var_cnt.11, 18446744073709551615
+  %comparison_result314 = icmp eq i256 %and_result311, 18446744073709551615
+  br i1 %comparison_result314, label %shift_left_non_overflow.i411, label %if_join318
+
+if_join318:                                       ; preds = %if_join309
+  %addition_result312 = add nuw nsw i256 %and_result311, 1
+  br label %for_increment273
+}

--- a/llvm/test/CodeGen/EVM/stack-too-deep-3.ll
+++ b/llvm/test/CodeGen/EVM/stack-too-deep-3.ll
@@ -1,0 +1,125 @@
+; RUN: not --crash llc < %s -o /dev/null 2>&1 | FileCheck %s
+
+; Test that EVMStackSolver can catch errors when transformation from
+; an MIs exit stack to an entry stack of the next MI is not possible.
+
+; The stack built for the 'bad' BB is
+;
+; 2.block_rt_158/3:
+; 	[ %19 %64 %0 %20 %3 %21 %35 %22 %63 %41 %62 %23 %61 %65 ]
+;
+; 	[ %19 %19 %0 %20 %3 %21 %35 %22 %63 %41 %62 %23 %61 %65 %64 %19 ]
+; 	CALLDATALOAD
+; 	[ %19 %19 %0 %20 %3 %21 %35 %22 %63 %41 %62 %23 %61 %65 %64 %4 ]
+;
+; 	[ %19 %19 %0 %20 %3 %21 %35 %22 %63 %41 %62 %23 %61 %65 %4 %64 %4 5 ]
+; 	SHL
+; 	[ %19 %19 %0 %20 %3 %21 %35 %22 %63 %41 %62 %23 %61 %65 %4 %64 %5 ]
+;
+; 	[ %5 %19 %0 %20 %3 %21 %35 %22 %63 %41 %62 %23 %61 %65 %4 %64 %19 %5 0 ]
+; 	SUB
+; 	[ %5 %19 %0 %20 %3 %21 %35 %22 %63 %41 %62 %23 %61 %65 %4 %64 %19 %46 ]
+;
+; 	[ %5 %19 %0 %20 %3 %21 %35 %22 %63 %41 %62 %23 %61 %65 %4 %64 %46 32 %19 ]
+; 	ADD
+; 	[ %5 %19 %0 %20 %3 %21 %35 %22 %63 %41 %62 %23 %61 %65 %4 %64 %46 %71 ]
+;
+; 	[ %5 %19 %0 %20 %3 %21 %35 %22 %63 %41 %62 %23 %61 %65 %4 %64 %46 %71 ]
+; 	GT
+; 	[ %5 %19 %0 %20 %3 %21 %35 %22 %63 %41 %62 %23 %61 %65 %4 %64 %47 ]
+;
+; 	[ %5 %19 %0 %20 %3 %21 %35 %22 %63 %41 %62 %23 %61 %65 %4 %64 %47 ]
+
+; CHECK:      EVMStackSolver cannot transform
+; CHECK-SAME: [ %19 %19 %0 %20 %3 %21 %35 %22 %63 %41 %62 %23 %61 %65 %4 %64 %5 ]
+; CHECK-SAME: to
+; CHECK-SAME: [ %5 %19 %0 %20 %3 %21 %35 %22 %63 %41 %62 %23 %61 %65 %4 %64 %19 %5 0 ]
+; CHECK-SAME: : stack too deep.
+
+target datalayout = "E-p:256:256-i256:256:256-S256-a:256:256"
+target triple = "evm-unknown-unknown"
+
+declare void @llvm.memmove.p1.p1.i256(ptr addrspace(1) nocapture writeonly, ptr addrspace(1) nocapture readonly, i256, i1 immarg) #0
+
+define dso_local fastcc void @main() unnamed_addr {
+entry:
+  br i1 poison, label %"block_rt_7/0", label %"block_rt_2/0"
+
+"block_rt_2/0":                                   ; preds = %conditional_rt_187_join_block, %conditional_rt_181_join_block, %"block_rt_158/3", %entry
+  unreachable
+
+"block_rt_7/0":                                   ; preds = %entry
+  %calldata_load_result2781 = load i256, ptr addrspace(2) inttoptr (i256 4 to ptr addrspace(2)), align 4
+  %addition_result2798 = add nuw nsw i256 %calldata_load_result2781, 4
+  %calldataload_pointer2604 = inttoptr i256 %addition_result2798 to ptr addrspace(2)
+  %calldata_load_result2605 = load i256, ptr addrspace(2) %calldataload_pointer2604, align 1
+  %addition_result2659 = add nuw nsw i256 %calldata_load_result2781, 36
+  %addition_result1186 = add nsw i256 0, -99
+  %subtraction_result1906 = add nsw i256 0, -31
+  br label %conditional_rt_187_join_block
+
+"block_rt_158/3":                                 ; preds = %conditional_rt_181_join_block
+  %addition_result3239 = add i256 0, %addition_result3756
+  %calldataload_pointer3244 = inttoptr i256 %addition_result3239 to ptr addrspace(2)
+  %calldata_load_result3245 = load i256, ptr addrspace(2) %calldataload_pointer3244, align 1
+  %addition_result3251 = add i256 %addition_result3239, 32
+  %shift_left_non_overflow_result3390 = shl nuw nsw i256 %calldata_load_result3245, 5
+  %subtraction_result3395 = sub i256 0, %shift_left_non_overflow_result3390
+  %comparison_result3399.not = icmp sgt i256 %addition_result3251, %subtraction_result3395
+  br i1 %comparison_result3399.not, label %"block_rt_2/0", label %"block_rt_160/3"
+
+"block_rt_160/3":                                 ; preds = %"block_rt_158/3"
+  %memory_store_pointer3530 = inttoptr i256 %stack_var_021.06950 to ptr addrspace(1)
+  %addition_result3535 = add i256 %stack_var_021.0.in6947, 96
+  %memory_store_pointer3538 = inttoptr i256 %addition_result3535 to ptr addrspace(1)
+  store i256 %calldata_load_result3245, ptr addrspace(1) %memory_store_pointer3538, align 1
+  %addition_result3694 = add i256 %shift_left_non_overflow_result3390, %stack_var_021.06950
+  %addition_result3972 = add i256 %stack_var_022.06948, 32
+  %addition_result3978 = add i256 %stack_var_017.26946, 32
+  %stack_var_021.0 = add i256 %addition_result3694, 64
+  br i1 %comparison_result3909.not, label %conditional_rt_181_join_block, label %"block_rt_181/0"
+
+"block_rt_181/0":                                 ; preds = %"block_rt_160/3"
+  %addition_result4058 = add i256 %stack_var_012.36954, 32
+  %addition_result4064 = add i256 %stack_var_011.36953, 32
+  %addition_result4044 = add nuw i256 %stack_var_013.36955, 1
+  %comparison_result4003.not = icmp ult i256 %addition_result4044, %calldata_load_result2605
+  br i1 %comparison_result4003.not, label %conditional_rt_187_join_block, label %"block_rt_187/0.loopexit"
+
+"block_rt_187/0.loopexit":                        ; preds = %"block_rt_181/0"
+  %addition_result451 = add i256 %stack_var_021.0, 64
+  %mcopy_destination455 = inttoptr i256 %addition_result451 to ptr addrspace(1)
+  tail call void @llvm.memmove.p1.p1.i256(ptr addrspace(1) align 1 %mcopy_destination455, ptr addrspace(1) align 1 poison, i256 poison, i1 false)
+  unreachable
+
+"block_rt_188/0":                                 ; preds = %conditional_rt_187_join_block
+  %addition_result4054 = add i256 0, %addition_result2659
+  br label %conditional_rt_181_join_block
+
+conditional_rt_181_join_block:                    ; preds = %"block_rt_188/0", %"block_rt_160/3"
+  %stack_var_021.06950 = phi i256 [ poison, %"block_rt_188/0" ], [ %stack_var_021.0, %"block_rt_160/3" ]
+  %comparison_result3909.not = phi i1 [ true, %"block_rt_188/0" ], [ false, %"block_rt_160/3" ]
+  %stack_var_022.06948 = phi i256 [ %addition_result4054, %"block_rt_188/0" ], [ %addition_result3972, %"block_rt_160/3" ]
+  %stack_var_021.0.in6947 = phi i256 [ %stack_var_010.26952, %"block_rt_188/0" ], [ %addition_result3694, %"block_rt_160/3" ]
+  %stack_var_017.26946 = phi i256 [ %stack_var_010.26952, %"block_rt_188/0" ], [ %addition_result3978, %"block_rt_160/3" ]
+  %subtraction_result3918 = sub i256 %stack_var_021.06950, %stack_var_010.26952
+  %memory_store_pointer3922 = inttoptr i256 %stack_var_017.26946 to ptr addrspace(1)
+  store i256 %subtraction_result3918, ptr addrspace(1) %memory_store_pointer3922, align 1
+  %calldataload_pointer1898 = inttoptr i256 %stack_var_022.06948 to ptr addrspace(2)
+  %addition_result3756 = add i256 0, %addition_result4054
+  %addition_result1811 = sub i256 %subtraction_result1906, %addition_result3756
+  %comparison_result1815.not = icmp slt i256 0, %addition_result1811
+  br i1 %comparison_result1815.not, label %"block_rt_158/3", label %"block_rt_2/0"
+
+conditional_rt_187_join_block:                    ; preds = %"block_rt_181/0", %"block_rt_7/0"
+  %stack_var_013.36955 = phi i256 [ 0, %"block_rt_7/0" ], [ %addition_result4044, %"block_rt_181/0" ]
+  %stack_var_012.36954 = phi i256 [ %addition_result2659, %"block_rt_7/0" ], [ %addition_result4058, %"block_rt_181/0" ]
+  %stack_var_011.36953 = phi i256 [ 224, %"block_rt_7/0" ], [ %addition_result4064, %"block_rt_181/0" ]
+  %stack_var_010.26952 = phi i256 [ poison, %"block_rt_7/0" ], [ %stack_var_021.0, %"block_rt_181/0" ]
+  %memory_store_pointer4021 = inttoptr i256 %stack_var_011.36953 to ptr addrspace(1)
+  %calldataload_pointer4024 = inttoptr i256 %stack_var_012.36954 to ptr addrspace(2)
+  %comparison_result4030.not = icmp slt i256 0, %addition_result1186
+  br i1 %comparison_result4030.not, label %"block_rt_188/0", label %"block_rt_2/0"
+}
+
+attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }


### PR DESCRIPTION
After EVMStackSolver finished stack propagation, it now checks all
the stacks built for stack-too-deep and report them as fatal errors.

The following transformations are checked and reported:
* the MBB's entry stack to the entry stack of the first MI,
* an exit stack of an MI to an entry stack of the next one,
* the exit stack of the last MI to the MBB exit stack,
* the MBB's entry stack to the MBB's exit if the BB is empty.