### PR TITLE
ci: add proper forge benchmarks for ToT using LLVM PR target branch

### DIFF
--- a/.github/workflows/forge-benchmarks.yaml
+++ b/.github/workflows/forge-benchmarks.yaml
@@ -15,6 +15,10 @@ on:
         description: 'LLVM candidate branch to use. If empty, the current branch will be used.'
         required: false
         default: ''
+      compiler_llvm_reference_branch:
+        description: 'LLVM reference branch to use. If empty, the default repository branch will be used.'
+        required: false
+        default: 'main'
   pull_request:
 
 permissions:
@@ -35,4 +39,5 @@ jobs:
       solx_candidate_branch: ${{ inputs.solx_candidate_branch || 'main' }}
       solx_reference_branch: ${{ inputs.solx_reference_branch || 'main' }}
       compiler_llvm_candidate_branch: ${{ inputs.compiler_llvm_candidate_branch || github.head_ref }}
+      compiler_llvm_reference_branch: ${{ inputs.compiler_llvm_reference_branch || github.base_ref || github.event.repository.default_branch }}
       compiler-llvm-repo: ${{ github.event.pull_request.head.repo.full_name || 'matter-labs/era-compiler-llvm' }} # required to properly test forks


### PR DESCRIPTION
# Code Review Checklist

## Purpose

Add proper forge benchmarks for ToT using LLVM PR target branch.

This allows getting ToT results for LLVM repo with ToT of LLVM, and not fixed submodule of `solx`.

