### PR TITLE
chore: add check-lld-unit into CI regression and coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -87,6 +87,7 @@ jobs:
           ninja -C './target-llvm/build-final' check-llvm-codegen-generic -v || true
           ninja -C './target-llvm/build-final' check-llvm-mc-evm -v || true
           ninja -C './target-llvm/build-final' check-llvm-unit -v || true
+          ninja -C './target-llvm/build-final' check-lld-unit -v || true
 
       - name: Generate coverage reports
         run: |
@@ -191,6 +192,7 @@ jobs:
           ninja -C './target-llvm/build-final' check-llvm-codegen-generic -v || true
           ninja -C './target-llvm/build-final' check-llvm-mc-evm -v || true
           ninja -C './target-llvm/build-final' check-llvm-unit -v || true
+          ninja -C './target-llvm/build-final' check-lld-unit -v || true
           llvm-profdata merge -sparse -o ${PROFDATA_FILE} ./target-llvm/build-final/profiles/*.profraw
 
       - name: Run integration tests with coverage

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -181,7 +181,9 @@ jobs:
       # it includes `check-llvm` and special codegen tests
       # called via `verify-llvm-codegen-opt` and `verify-llvm-codegen-llc` targets
       - name: Running Lit tests
-        run: ninja -C './target-llvm/build-final' verify-llvm -v
+        run: |
+          ninja -C './target-llvm/build-final' verify-llvm -v
+          ninja -C './target-llvm/build-final' check-lld-unit -v
 
       - name: clang-tidy
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
# Code Review Checklist

* [x] Add check-lld-unit into verify-llvm testing target

## Purpose

To add `lld` tests to coverage and regression.