### PR TITLE
[EVM] Set that staticcall can't change storage

### DIFF
--- a/llvm/include/llvm/IR/IntrinsicsEVM.td
+++ b/llvm/include/llvm/IR/IntrinsicsEVM.td
@@ -108,6 +108,10 @@ def int_evm_msize : Intrinsic<[llvm_i256_ty], [], [IntrWillReturn]>;
 
 def int_evm_pc : Intrinsic<[llvm_i256_ty], [], [IntrWillReturn]>;
 
+// TODO: #904: Set IntrInaccessibleMemOnly attribute to gas intrinsic.
+// Currently, it is not set because benchmark numbers showed that it is not
+// profitable to do that for heap address space. Revisit this decision once
+// optimization for free ptr updates is implemented.
 def int_evm_gas : Intrinsic<[llvm_i256_ty], [], [IntrWillReturn]>;
 
 // Getting values from the context.

--- a/llvm/lib/Target/EVM/EVMAliasAnalysis.cpp
+++ b/llvm/lib/Target/EVM/EVMAliasAnalysis.cpp
@@ -109,6 +109,7 @@ ModRefInfo EVMAAResult::getModRefInfo(const CallBase *Call,
   unsigned AS = Loc.Ptr->getType()->getPointerAddressSpace();
   switch (II->getIntrinsicID()) {
   case Intrinsic::evm_return:
+  case Intrinsic::evm_staticcall:
     if (AS == EVMAS::AS_STORAGE || AS == EVMAS::AS_TSTORAGE)
       return ModRefInfo::Ref;
     break;
@@ -117,7 +118,6 @@ ModRefInfo EVMAAResult::getModRefInfo(const CallBase *Call,
   case Intrinsic::evm_call:
   case Intrinsic::evm_callcode:
   case Intrinsic::evm_delegatecall:
-  case Intrinsic::evm_staticcall:
     if (AS == EVMAS::AS_STORAGE || AS == EVMAS::AS_TSTORAGE)
       return ModRefInfo::ModRef;
     break;

--- a/llvm/lib/Target/EVM/EVMAliasAnalysis.cpp
+++ b/llvm/lib/Target/EVM/EVMAliasAnalysis.cpp
@@ -108,6 +108,13 @@ ModRefInfo EVMAAResult::getModRefInfo(const CallBase *Call,
 
   unsigned AS = Loc.Ptr->getType()->getPointerAddressSpace();
   switch (II->getIntrinsicID()) {
+  case Intrinsic::evm_gas:
+    // TODO: #904: Ideally, we would add IntrInaccessibleMemOnly attribute to
+    // gas intrinsic, but benchmark numbers showed that it is not profitable
+    // to do that for heap address space.
+    if (AS == EVMAS::AS_STORAGE || AS == EVMAS::AS_TSTORAGE)
+      return ModRefInfo::NoModRef;
+    return ModRefInfo::ModRef;
   case Intrinsic::evm_return:
   case Intrinsic::evm_staticcall:
     if (AS == EVMAS::AS_STORAGE || AS == EVMAS::AS_TSTORAGE)

--- a/llvm/test/CodeGen/EVM/aa-eval.ll
+++ b/llvm/test/CodeGen/EVM/aa-eval.ll
@@ -343,8 +343,8 @@ define i256 @test_as1_alias_call(ptr addrspace(1) %ptr1) {
 }
 
 ; CHECK-LABEL: Function: test_as6_as5_alias_staticcall
-; CHECK: Both ModRef: Ptr: i256* %ptr1	<->  %ret = call i256 @llvm.evm.staticcall
-; CHECK: Both ModRef: Ptr: i256* %ptr2	<->  %ret = call i256 @llvm.evm.staticcall
+; CHECK: Just Ref: Ptr: i256* %ptr1	<->  %ret = call i256 @llvm.evm.staticcall
+; CHECK: Just Ref: Ptr: i256* %ptr2	<->  %ret = call i256 @llvm.evm.staticcall
 define i256 @test_as6_as5_alias_staticcall(ptr addrspace(5) %ptr1) {
   store i256 1, ptr addrspace(5) %ptr1, align 32
   %ptr2 = inttoptr i256 32 to ptr addrspace(6)

--- a/llvm/test/CodeGen/EVM/aa-memory-opt.ll
+++ b/llvm/test/CodeGen/EVM/aa-memory-opt.ll
@@ -285,6 +285,23 @@ define i256 @test_as6_large() {
   ret i256 %ret
 }
 
+define i256 @test_opt_staticcall(ptr addrspace(5) %ptr1, ptr addrspace(6) %ptr2) {
+; CHECK-LABEL: define noundef i256 @test_opt_staticcall
+; CHECK-SAME: (ptr addrspace(5) nocapture writeonly [[PTR1:%.*]], ptr addrspace(6) nocapture writeonly [[PTR2:%.*]]) local_unnamed_addr #[[ATTR3]] {
+; CHECK-NEXT:    store i256 1, ptr addrspace(5) [[PTR1]], align 32
+; CHECK-NEXT:    store i256 2, ptr addrspace(6) [[PTR2]], align 32
+; CHECK-NEXT:    [[TMP1:%.*]] = tail call i256 @llvm.evm.staticcall(i256 1, i256 1, ptr addrspace(1) null, i256 1, ptr addrspace(1) null, i256 1)
+; CHECK-NEXT:    ret i256 3
+;
+  store i256 1, ptr addrspace(5) %ptr1, align 32
+  store i256 2, ptr addrspace(6) %ptr2, align 32
+  call i256 @llvm.evm.staticcall(i256 1, i256 1, ptr addrspace(1) null, i256 1, ptr addrspace(1) null, i256 1)
+  %ret1 = load i256, ptr addrspace(5) %ptr1
+  %ret2 = load i256, ptr addrspace(6) %ptr2
+  %ret = add i256 %ret1, %ret2
+  ret i256 %ret
+}
+
 ; Verify that in the following tests all load operations are preserved.
 
 define i256 @test_noopt_create(ptr addrspace(5) %ptr1, ptr addrspace(6) %ptr2) {
@@ -341,26 +358,6 @@ define i256 @test_noopt_call(ptr addrspace(5) %ptr1, ptr addrspace(6) %ptr2) {
   store i256 1, ptr addrspace(5) %ptr1, align 32
   store i256 2, ptr addrspace(6) %ptr2, align 32
   call i256 @llvm.evm.call(i256 1, i256 1, i256 1, ptr addrspace(1) null, i256 1, ptr addrspace(1) null, i256 1)
-  %ret1 = load i256, ptr addrspace(5) %ptr1
-  %ret2 = load i256, ptr addrspace(6) %ptr2
-  %ret = add i256 %ret1, %ret2
-  ret i256 %ret
-}
-
-define i256 @test_noopt_staticcall(ptr addrspace(5) %ptr1, ptr addrspace(6) %ptr2) {
-; CHECK-LABEL: define i256 @test_noopt_staticcall
-; CHECK-SAME: (ptr addrspace(5) nocapture [[PTR1:%.*]], ptr addrspace(6) nocapture [[PTR2:%.*]]) local_unnamed_addr #[[ATTR3]] {
-; CHECK-NEXT:    store i256 1, ptr addrspace(5) [[PTR1]], align 32
-; CHECK-NEXT:    store i256 2, ptr addrspace(6) [[PTR2]], align 32
-; CHECK-NEXT:    [[TMP1:%.*]] = tail call i256 @llvm.evm.staticcall(i256 1, i256 1, ptr addrspace(1) null, i256 1, ptr addrspace(1) null, i256 1)
-; CHECK-NEXT:    [[RET1:%.*]] = load i256, ptr addrspace(5) [[PTR1]], align 32
-; CHECK-NEXT:    [[RET2:%.*]] = load i256, ptr addrspace(6) [[PTR2]], align 32
-; CHECK-NEXT:    [[RET:%.*]] = add i256 [[RET2]], [[RET1]]
-; CHECK-NEXT:    ret i256 [[RET]]
-;
-  store i256 1, ptr addrspace(5) %ptr1, align 32
-  store i256 2, ptr addrspace(6) %ptr2, align 32
-  call i256 @llvm.evm.staticcall(i256 1, i256 1, ptr addrspace(1) null, i256 1, ptr addrspace(1) null, i256 1)
   %ret1 = load i256, ptr addrspace(5) %ptr1
   %ret2 = load i256, ptr addrspace(6) %ptr2
   %ret = add i256 %ret1, %ret2

--- a/llvm/test/CodeGen/EVM/aa-memory-opt.ll
+++ b/llvm/test/CodeGen/EVM/aa-memory-opt.ll
@@ -53,19 +53,51 @@ define i256 @test_different_locsizes() {
   ret i256 %ret
 }
 
-define i256 @test_gas() {
-; CHECK-LABEL: define i256 @test_gas
+define i256 @test_gas_as1() {
+; CHECK-LABEL: define i256 @test_gas_as1
 ; CHECK-SAME: () local_unnamed_addr #[[ATTR2:[0-9]+]] {
+; CHECK-NEXT:    store i256 2, ptr addrspace(1) inttoptr (i256 2 to ptr addrspace(1)), align 64
+; CHECK-NEXT:    [[GAS:%.*]] = tail call i256 @llvm.evm.gas()
+; CHECK-NEXT:    [[LOAD:%.*]] = load i256, ptr addrspace(1) inttoptr (i256 2 to ptr addrspace(1)), align 64
+; CHECK-NEXT:    [[RET:%.*]] = add i256 [[LOAD]], [[GAS]]
+; CHECK-NEXT:    ret i256 [[RET]]
+;
+  store i256 2, ptr addrspace(1) inttoptr (i256 2 to ptr addrspace(1)), align 64
+  %gas = call i256 @llvm.evm.gas()
+  %load = load i256, ptr addrspace(1) inttoptr (i256 2 to ptr addrspace(1)), align 64
+  %ret = add i256 %load, %gas
+  ret i256 %ret
+}
+
+define i256 @test_gas_as5() {
+; CHECK-LABEL: define i256 @test_gas_as5
+; CHECK-SAME: () local_unnamed_addr #[[ATTR2]] {
 ; CHECK-NEXT:    store i256 2, ptr addrspace(5) inttoptr (i256 2 to ptr addrspace(5)), align 64
 ; CHECK-NEXT:    [[GAS:%.*]] = tail call i256 @llvm.evm.gas()
-; CHECK-NEXT:    store i256 [[GAS]], ptr addrspace(1) inttoptr (i256 1 to ptr addrspace(1)), align 64
-; CHECK-NEXT:    [[RET:%.*]] = load i256, ptr addrspace(5) inttoptr (i256 2 to ptr addrspace(5)), align 64
+; CHECK-NEXT:    [[LOAD:%.*]] = load i256, ptr addrspace(5) inttoptr (i256 2 to ptr addrspace(5)), align 64
+; CHECK-NEXT:    [[RET:%.*]] = add i256 [[LOAD]], [[GAS]]
 ; CHECK-NEXT:    ret i256 [[RET]]
 ;
   store i256 2, ptr addrspace(5) inttoptr (i256 2 to ptr addrspace(5)), align 64
   %gas = call i256 @llvm.evm.gas()
-  store i256 %gas, ptr addrspace(1) inttoptr (i256 1 to ptr addrspace(1)), align 64
-  %ret = load i256, ptr addrspace(5) inttoptr (i256 2 to ptr addrspace(5)), align 64
+  %load = load i256, ptr addrspace(5) inttoptr (i256 2 to ptr addrspace(5)), align 64
+  %ret = add i256 %load, %gas
+  ret i256 %ret
+}
+
+define i256 @test_gas_as6() {
+; CHECK-LABEL: define i256 @test_gas_as6
+; CHECK-SAME: () local_unnamed_addr #[[ATTR2]] {
+; CHECK-NEXT:    store i256 2, ptr addrspace(6) inttoptr (i256 2 to ptr addrspace(6)), align 64
+; CHECK-NEXT:    [[GAS:%.*]] = tail call i256 @llvm.evm.gas()
+; CHECK-NEXT:    [[LOAD:%.*]] = load i256, ptr addrspace(6) inttoptr (i256 2 to ptr addrspace(6)), align 64
+; CHECK-NEXT:    [[RET:%.*]] = add i256 [[LOAD]], [[GAS]]
+; CHECK-NEXT:    ret i256 [[RET]]
+;
+  store i256 2, ptr addrspace(6) inttoptr (i256 2 to ptr addrspace(6)), align 64
+  %gas = call i256 @llvm.evm.gas()
+  %load = load i256, ptr addrspace(6) inttoptr (i256 2 to ptr addrspace(6)), align 64
+  %ret = add i256 %load, %gas
   ret i256 %ret
 }
 

--- a/llvm/test/CodeGen/EVM/aa-memory-opt.ll
+++ b/llvm/test/CodeGen/EVM/aa-memory-opt.ll
@@ -53,6 +53,8 @@ define i256 @test_different_locsizes() {
   ret i256 %ret
 }
 
+; TODO: #904: It is safe to remove load in this test, but it is not done since benchmark
+; numbers showed that it is not profitable to do that for heap address space.
 define i256 @test_gas_as1() {
 ; CHECK-LABEL: define i256 @test_gas_as1
 ; CHECK-SAME: () local_unnamed_addr #[[ATTR2:[0-9]+]] {
@@ -74,8 +76,7 @@ define i256 @test_gas_as5() {
 ; CHECK-SAME: () local_unnamed_addr #[[ATTR2]] {
 ; CHECK-NEXT:    store i256 2, ptr addrspace(5) inttoptr (i256 2 to ptr addrspace(5)), align 64
 ; CHECK-NEXT:    [[GAS:%.*]] = tail call i256 @llvm.evm.gas()
-; CHECK-NEXT:    [[LOAD:%.*]] = load i256, ptr addrspace(5) inttoptr (i256 2 to ptr addrspace(5)), align 64
-; CHECK-NEXT:    [[RET:%.*]] = add i256 [[LOAD]], [[GAS]]
+; CHECK-NEXT:    [[RET:%.*]] = add i256 [[GAS]], 2
 ; CHECK-NEXT:    ret i256 [[RET]]
 ;
   store i256 2, ptr addrspace(5) inttoptr (i256 2 to ptr addrspace(5)), align 64
@@ -90,8 +91,7 @@ define i256 @test_gas_as6() {
 ; CHECK-SAME: () local_unnamed_addr #[[ATTR2]] {
 ; CHECK-NEXT:    store i256 2, ptr addrspace(6) inttoptr (i256 2 to ptr addrspace(6)), align 64
 ; CHECK-NEXT:    [[GAS:%.*]] = tail call i256 @llvm.evm.gas()
-; CHECK-NEXT:    [[LOAD:%.*]] = load i256, ptr addrspace(6) inttoptr (i256 2 to ptr addrspace(6)), align 64
-; CHECK-NEXT:    [[RET:%.*]] = add i256 [[LOAD]], [[GAS]]
+; CHECK-NEXT:    [[RET:%.*]] = add i256 [[GAS]], 2
 ; CHECK-NEXT:    ret i256 [[RET]]
 ;
   store i256 2, ptr addrspace(6) inttoptr (i256 2 to ptr addrspace(6)), align 64


### PR DESCRIPTION
From the description, staticcall can't change storage, so update the code to ensure no storage modifications occur during staticcall.
