### PR TITLE
[EVM][CVP] Disable narrowing of div and rem instructions

### DIFF
--- a/llvm/lib/Transforms/Scalar/CorrelatedValuePropagation.cpp
+++ b/llvm/lib/Transforms/Scalar/CorrelatedValuePropagation.cpp
@@ -752,6 +752,12 @@ static bool narrowSDivOrSRem(BinaryOperator *Instr, const ConstantRange &LCR,
   assert(Instr->getOpcode() == Instruction::SDiv ||
          Instr->getOpcode() == Instruction::SRem);
 
+  // EVM local begin
+  Triple TT(Instr->getFunction()->getParent()->getTargetTriple());
+  if (TT.isEVM())
+    return false;
+  // EVM local end
+
   // Find the smallest power of two bitwidth that's sufficient to hold Instr's
   // operands.
   unsigned OrigWidth = Instr->getType()->getScalarSizeInBits();
@@ -884,6 +890,12 @@ static bool narrowUDivOrURem(BinaryOperator *Instr, const ConstantRange &XCR,
                              const ConstantRange &YCR) {
   assert(Instr->getOpcode() == Instruction::UDiv ||
          Instr->getOpcode() == Instruction::URem);
+
+  // EVM local begin
+  Triple TT(Instr->getFunction()->getParent()->getTargetTriple());
+  if (TT.isEVM())
+    return false;
+  // EVM local end
 
   // Find the smallest power of two bitwidth that's sufficient to hold Instr's
   // operands.


### PR DESCRIPTION
This is not profitable for us, since it will introduce more instructions.