### PR TITLE
[EVM] Fix handling of imprecise memory locations in EVMAliasAnalysis

### DIFF
--- a/llvm/lib/Target/EVM/EVMAliasAnalysis.cpp
+++ b/llvm/lib/Target/EVM/EVMAliasAnalysis.cpp
@@ -140,6 +140,11 @@ ModRefInfo EVMAAResult::getModRefInfo(const CallBase *Call,
     unsigned ArgIdx = I.index();
     MemoryLocation ArgLoc = getMemLocForArgument(Call, ArgIdx);
     AliasResult ArgAlias = VMAAResult::alias(ArgLoc, Loc, AAQI, Call);
+    LLVM_DEBUG({
+      // NOLINTNEXTLINE(clang-analyzer-core.NonNullParamChecker)
+      dbgs() << "  " << ArgAlias << ":\t" << *ArgLoc.Ptr << ", " << *Loc.Ptr
+             << "\n";
+    });
     if (ArgAlias != AliasResult::NoAlias)
       Result |= getArgModRefInfo(Call, ArgIdx);
   }

--- a/llvm/test/CodeGen/EVM/aa-imprecise.ll
+++ b/llvm/test/CodeGen/EVM/aa-imprecise.ll
@@ -1,0 +1,48 @@
+; RUN: opt -passes=aa-eval -aa-pipeline=evm-aa,basic-aa -print-all-alias-modref-info --debug-only=evm-aa -disable-output < %s 2>&1 | FileCheck %s
+; REQUIRES: asserts
+
+target datalayout = "E-p:256:256-i256:256:256-S256-a:256:256"
+target triple = "evm"
+
+declare void @llvm.evm.return(ptr addrspace(1), i256)
+declare void @llvm.memcpy.p1.p1.i256(ptr addrspace(1), ptr addrspace(1), i256, i1 immarg)
+
+; CHECK-LABEL: Function: test_both_imprecise
+; CHECK: PartialAlias: ptr addrspace(1) inttoptr (i256 128 to ptr addrspace(1)), ptr addrspace(1) inttoptr (i256 256 to ptr addrspace(1))
+define void @test_both_imprecise(i256 %size) noreturn {
+  tail call void @llvm.memcpy.p1.p1.i256(ptr addrspace(1) inttoptr (i256 256 to ptr addrspace(1)), ptr addrspace(1) inttoptr (i256 512 to ptr addrspace(1)), i256 %size, i1 false)
+  call void @llvm.evm.return(ptr addrspace(1) inttoptr (i256 128 to ptr addrspace(1)), i256 %size)
+  unreachable
+}
+
+; CHECK-LABEL: Function: test_mayalias1
+; CHECK: PartialAlias: ptr addrspace(1) inttoptr (i256 32 to ptr addrspace(1)), ptr addrspace(1) inttoptr (i256 128 to ptr addrspace(1))
+define void @test_mayalias1(i256 %size) noreturn {
+  tail call void @llvm.memcpy.p1.p1.i256(ptr addrspace(1) inttoptr (i256 128 to ptr addrspace(1)), ptr addrspace(1) inttoptr (i256 512 to ptr addrspace(1)), i256 32, i1 false)
+  call void @llvm.evm.return(ptr addrspace(1) inttoptr (i256 32 to ptr addrspace(1)), i256 %size)
+  unreachable
+}
+
+; CHECK-LABEL: Function: test_mayalias2
+; CHECK: PartialAlias: ptr addrspace(1) inttoptr (i256 128 to ptr addrspace(1)), ptr addrspace(1) inttoptr (i256 128 to ptr addrspace(1))
+define void @test_mayalias2(i256 %size) noreturn {
+  tail call void @llvm.memcpy.p1.p1.i256(ptr addrspace(1) inttoptr (i256 128 to ptr addrspace(1)), ptr addrspace(1) inttoptr (i256 512 to ptr addrspace(1)), i256 32, i1 false)
+  call void @llvm.evm.return(ptr addrspace(1) inttoptr (i256 128 to ptr addrspace(1)), i256 %size)
+  unreachable
+}
+
+; CHECK-LABEL: Function: test_partialalias
+; CHECK: PartialAlias: ptr addrspace(1) inttoptr (i256 130 to ptr addrspace(1)), ptr addrspace(1) inttoptr (i256 128 to ptr addrspace(1))
+define void @test_partialalias(i256 %size) noreturn {
+  tail call void @llvm.memcpy.p1.p1.i256(ptr addrspace(1) inttoptr (i256 128 to ptr addrspace(1)), ptr addrspace(1) inttoptr (i256 512 to ptr addrspace(1)), i256 32, i1 false)
+  call void @llvm.evm.return(ptr addrspace(1) inttoptr (i256 130 to ptr addrspace(1)), i256 %size)
+  unreachable
+}
+
+; CHECK-LABEL: Function: test_noalias
+; CHECK: NoAlias: ptr addrspace(1) inttoptr (i256 128 to ptr addrspace(1)), ptr addrspace(1) inttoptr (i256 96 to ptr addrspace(1))
+define void @test_noalias(i256 %size) noreturn {
+  tail call void @llvm.memcpy.p1.p1.i256(ptr addrspace(1) inttoptr (i256 96 to ptr addrspace(1)), ptr addrspace(1) inttoptr (i256 512 to ptr addrspace(1)), i256 32, i1 false)
+  call void @llvm.evm.return(ptr addrspace(1) inttoptr (i256 128 to ptr addrspace(1)), i256 %size)
+  unreachable
+}

--- a/llvm/test/CodeGen/EVM/aa-imprecise.ll
+++ b/llvm/test/CodeGen/EVM/aa-imprecise.ll
@@ -8,7 +8,7 @@ declare void @llvm.evm.return(ptr addrspace(1), i256)
 declare void @llvm.memcpy.p1.p1.i256(ptr addrspace(1), ptr addrspace(1), i256, i1 immarg)
 
 ; CHECK-LABEL: Function: test_both_imprecise
-; CHECK: PartialAlias: ptr addrspace(1) inttoptr (i256 128 to ptr addrspace(1)), ptr addrspace(1) inttoptr (i256 256 to ptr addrspace(1))
+; CHECK: MayAlias: ptr addrspace(1) inttoptr (i256 128 to ptr addrspace(1)), ptr addrspace(1) inttoptr (i256 256 to ptr addrspace(1))
 define void @test_both_imprecise(i256 %size) noreturn {
   tail call void @llvm.memcpy.p1.p1.i256(ptr addrspace(1) inttoptr (i256 256 to ptr addrspace(1)), ptr addrspace(1) inttoptr (i256 512 to ptr addrspace(1)), i256 %size, i1 false)
   call void @llvm.evm.return(ptr addrspace(1) inttoptr (i256 128 to ptr addrspace(1)), i256 %size)
@@ -16,7 +16,7 @@ define void @test_both_imprecise(i256 %size) noreturn {
 }
 
 ; CHECK-LABEL: Function: test_mayalias1
-; CHECK: PartialAlias: ptr addrspace(1) inttoptr (i256 32 to ptr addrspace(1)), ptr addrspace(1) inttoptr (i256 128 to ptr addrspace(1))
+; CHECK: MayAlias: ptr addrspace(1) inttoptr (i256 32 to ptr addrspace(1)), ptr addrspace(1) inttoptr (i256 128 to ptr addrspace(1))
 define void @test_mayalias1(i256 %size) noreturn {
   tail call void @llvm.memcpy.p1.p1.i256(ptr addrspace(1) inttoptr (i256 128 to ptr addrspace(1)), ptr addrspace(1) inttoptr (i256 512 to ptr addrspace(1)), i256 32, i1 false)
   call void @llvm.evm.return(ptr addrspace(1) inttoptr (i256 32 to ptr addrspace(1)), i256 %size)
@@ -24,7 +24,7 @@ define void @test_mayalias1(i256 %size) noreturn {
 }
 
 ; CHECK-LABEL: Function: test_mayalias2
-; CHECK: PartialAlias: ptr addrspace(1) inttoptr (i256 128 to ptr addrspace(1)), ptr addrspace(1) inttoptr (i256 128 to ptr addrspace(1))
+; CHECK: MayAlias: ptr addrspace(1) inttoptr (i256 128 to ptr addrspace(1)), ptr addrspace(1) inttoptr (i256 128 to ptr addrspace(1))
 define void @test_mayalias2(i256 %size) noreturn {
   tail call void @llvm.memcpy.p1.p1.i256(ptr addrspace(1) inttoptr (i256 128 to ptr addrspace(1)), ptr addrspace(1) inttoptr (i256 512 to ptr addrspace(1)), i256 32, i1 false)
   call void @llvm.evm.return(ptr addrspace(1) inttoptr (i256 128 to ptr addrspace(1)), i256 %size)
@@ -32,7 +32,7 @@ define void @test_mayalias2(i256 %size) noreturn {
 }
 
 ; CHECK-LABEL: Function: test_partialalias
-; CHECK: PartialAlias: ptr addrspace(1) inttoptr (i256 130 to ptr addrspace(1)), ptr addrspace(1) inttoptr (i256 128 to ptr addrspace(1))
+; CHECK: MayAlias: ptr addrspace(1) inttoptr (i256 130 to ptr addrspace(1)), ptr addrspace(1) inttoptr (i256 128 to ptr addrspace(1))
 define void @test_partialalias(i256 %size) noreturn {
   tail call void @llvm.memcpy.p1.p1.i256(ptr addrspace(1) inttoptr (i256 128 to ptr addrspace(1)), ptr addrspace(1) inttoptr (i256 512 to ptr addrspace(1)), i256 32, i1 false)
   call void @llvm.evm.return(ptr addrspace(1) inttoptr (i256 130 to ptr addrspace(1)), i256 %size)


### PR DESCRIPTION
This patch fixes following issues:
1. If both sizes are imprecise, return MayAlias instead of PartialAlias.
2. If both pointers have the same starting address and one of them has
   imprecise size, return MayAlias instead of PartialAlias. In this case
   we can't deduce between MustAlias or PartialAlias, so be conservative
   and return MayAlias.
3. If imprecise is lower than precise memory location, return MayAlias
   instead of PartialAlias. Imprecise memory location can be NoAlias or
   PartialAlias, but we don't know that in the compile time.

The only case where we can return PartialAlias is when imprecise memory
location is in the middle of precise location. This is not done since
there shouldn't be any optimization that could benefit from this, and
to keep the implementation simple.