### PR TITLE
[EVM] Fix nondeterminism in constant unfolding

### DIFF
--- a/llvm/lib/Target/EVM/EVMConstantUnfolding.cpp
+++ b/llvm/lib/Target/EVM/EVMConstantUnfolding.cpp
@@ -635,7 +635,8 @@ static bool runImpl(Module &M, MachineModuleInfo &MMI) {
       EVM::calculateModuleCodeSize(M, MMI) + MetadataSize;
 
   // Collect PUSH instructions to process.
-  DenseMap<MachineFunction *, std::unique_ptr<LoopDepthInstrCache>>
+  SmallVector<
+      std::pair<MachineFunction *, std::unique_ptr<LoopDepthInstrCache>>, 16>
       InstrCacheMap;
 
   for (Function &F : M) {
@@ -653,9 +654,8 @@ static bool runImpl(Module &M, MachineModuleInfo &MMI) {
     OwnedMLI->analyze(MDT->getBase());
     const MachineLoopInfo *MLI = OwnedMLI.get();
 
-    [[maybe_unused]] auto It = InstrCacheMap.try_emplace(
+    InstrCacheMap.emplace_back(
         MF, std::make_unique<LoopDepthInstrCache>(*MF, *MLI));
-    assert(It.second);
   }
 
   LLVM_DEBUG({


### PR DESCRIPTION
Previously, the code that collected PUSH instructions to process used a DenseMap with MachineFunction* as the key. This could lead to nondeterministic iteration order, causing inconsistent behavior across different runs. Fix this by changing DenseMap to SmallVector, since we are using lookups for asserts that can't fail, because we are iterating over all MachineFunctions only once.