### PR TITLE
[EVM] Print large immediates in hex in disassembly

### DIFF
--- a/llvm/lib/Target/EVM/Disassembler/EVMDisassembler.cpp
+++ b/llvm/lib/Target/EVM/Disassembler/EVMDisassembler.cpp
@@ -58,7 +58,7 @@ static DecodeStatus decodePUSH(MCInst &Inst, APInt &Insn, uint64_t Address,
   assert(alignTo(Insn.getActiveBits(), 8) == (ImmByteWidth + 1) * 8);
   MCContext &Ctx = Decoder->getContext();
   auto *Str = new (Ctx) SmallString<80>();
-  Insn.extractBits(ImmByteWidth * 8, 0).toStringUnsigned(*Str);
+  Insn.extractBits(ImmByteWidth * 8, 0).toStringUnsigned(*Str, 16);
   Inst.addOperand(MCOperand::createExpr(EVMCImmMCExpr::create(*Str, Ctx)));
   return MCDisassembler::Success;
 }

--- a/llvm/test/MC/EVM/imm-hex-disassemble.ll
+++ b/llvm/test/MC/EVM/imm-hex-disassemble.ll
@@ -1,0 +1,10 @@
+; RUN: llc -filetype=obj %s -o - | llvm-objdump --no-leading-addr --disassemble - | FileCheck %s
+
+target datalayout = "E-p:256:256-i256:256:256-S256-a:256:256"
+target triple = "evm"
+
+define i256 @test() {
+; CHECK-LABEL:  <test>:
+; CHECK:  69 11 22 33 44 55 66 77 88 99 ff     	PUSH10          0x80911113678783024503295
+  ret i256 80911113678783024503295
+}

--- a/llvm/test/MC/EVM/imm-hex-disassemble.ll
+++ b/llvm/test/MC/EVM/imm-hex-disassemble.ll
@@ -5,6 +5,6 @@ target triple = "evm"
 
 define i256 @test() {
 ; CHECK-LABEL:  <test>:
-; CHECK:  69 11 22 33 44 55 66 77 88 99 ff     	PUSH10          0x80911113678783024503295
+; CHECK:  69 11 22 33 44 55 66 77 88 99 ff     	PUSH10          0x112233445566778899FF
   ret i256 80911113678783024503295
 }


### PR DESCRIPTION
Large immediates were previously printed in decimal. Print them in hex instead.